### PR TITLE
Fix flaky parse test, didn't account for map iteration order

### DIFF
--- a/thrift/parse_test.go
+++ b/thrift/parse_test.go
@@ -384,8 +384,9 @@ func TestParseRequest(t *testing.T) {
 			continue
 		}
 		if assert.NoError(t, err, "Expected no error for %v", req) {
-			want := wire.Struct{Fields: tt.want}
-			assert.Equal(t, want, got, "Fields mismatch for %v", req)
+			want := wire.NewValueStruct(wire.Struct{Fields: tt.want})
+			assert.True(t, wire.ValuesAreEqual(want, wire.NewValueStruct(got)),
+				"Parsed mismatch for %v:\n want %v\n  got %v\n", req, want, got)
 		}
 	}
 }


### PR DESCRIPTION
Use wire.ValuesAreEqual instead of using assert.Equal which
takes into account ordering for map values.

@abhinav 
