### PR TITLE
Set trace sample rate to 0 in tchannel

### DIFF
--- a/transport/tchannel.go
+++ b/transport/tchannel.go
@@ -54,8 +54,11 @@ func TChannel(opts TChannelOptions) (Transport, error) {
 		level = *opts.LogLevel
 	}
 
+	// TODO: set trace sample rate to 1 for the initial request.
+	zero := float64(0)
 	ch, err := tchannel.NewChannel(opts.SourceService, &tchannel.ChannelOptions{
-		Logger: tchannel.NewLevelLogger(tchannel.SimpleLogger, level),
+		Logger:          tchannel.NewLevelLogger(tchannel.SimpleLogger, level),
+		TraceSampleRate: &zero,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TChannel: %v", err)

--- a/transport/tchannel_test.go
+++ b/transport/tchannel_test.go
@@ -85,6 +85,7 @@ func TestTChannelCallSuccess(t *testing.T) {
 	defer svr.Close()
 
 	testutils.RegisterFunc(svr, "echo", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
+		assert.False(t, tchannel.CurrentSpan(ctx).TracingEnabled(), "Tracing should be disabled")
 		return &raw.Res{
 			Arg2: args.Arg2,
 			Arg3: args.Arg3,


### PR DESCRIPTION
Benchmark runs should not be sending traces
