### PR TITLE
Fix compatibility with latest thriftrw-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,18 @@
-hash: 9c5ae201877c264f697dbe3f6609ede8f1a8c371507ad520889f8f6bbfc67054
-updated: 2016-03-10T23:02:10.899434856-08:00
+hash: 58a3f270f53fafeaef50923b802499db02ea83060fbe6c65f295811147386e3b
+updated: 2016-04-01T16:25:55.216235387-07:00
 imports:
 - name: github.com/apache/thrift
   version: 23d6746079d7b5fdb38214387c63f987e68a6d8f
   subpackages:
   - lib/go/thrift
+- name: github.com/cactus/go-statsd-client
+  version: 725f76bd0300c1f9562e76fd94c27aa17e41243e
+  subpackages:
+  - statsd
 - name: github.com/jessevdk/go-flags
   version: 6b9493b3cb60367edd942144879646604089e3f7
 - name: github.com/thriftrw/thriftrw-go
-  version: fa2079dcd5e7f71ecd4a1af10a428b1e21f5bf75
+  version: 331b3b5e410ef32ec0513048dc7bb85b65234767
   subpackages:
   - ast
   - compile
@@ -18,9 +22,10 @@ imports:
   - protocol/binary
   - idl/internal
 - name: github.com/uber/tchannel-go
-  version: 5c2734fb6946fdb9b2486e794bcb8f9bdf5b67b9
+  version: 08671e7060a917eaafa2e6fac0a01b0b247eb60b
   subpackages:
   - thrift
+  - atomic
   - tnet
   - typed
   - thrift/gen-go/meta

--- a/thrift/fields.go
+++ b/thrift/fields.go
@@ -29,8 +29,18 @@ import (
 	"github.com/thriftrw/thriftrw-go/wire"
 )
 
-func fieldGroupToValue(fields compile.FieldGroup, request map[string]interface{}) ([]wire.Field, error) {
+func fieldMap(fields compile.FieldGroup) map[string]*compile.FieldSpec {
+	m := make(map[string]*compile.FieldSpec)
+	for _, f := range fields {
+		m[f.ThriftName()] = f
+	}
+	return m
+}
+
+func fieldGroupToValue(fieldsList compile.FieldGroup, request map[string]interface{}) ([]wire.Field, error) {
 	var (
+		fields = fieldMap(fieldsList)
+
 		err = fieldGroupError{available: sorted.MapKeys(fields)}
 
 		// userFields is the user-specified values by field name.
@@ -73,7 +83,7 @@ func fieldGroupToValue(fields compile.FieldGroup, request map[string]interface{}
 
 // fieldMapToValue converts the userFields to a list of wire.Field.
 // It does not do any error checking.
-func fieldsMapToValue(fields compile.FieldGroup, userFields map[string]interface{}) ([]wire.Field, error) {
+func fieldsMapToValue(fields map[string]*compile.FieldSpec, userFields map[string]interface{}) ([]wire.Field, error) {
 	wireFields := make([]wire.Field, 0, len(userFields))
 	for k, userValue := range userFields {
 		spec := fields[k]

--- a/thrift/from_wire_test.go
+++ b/thrift/from_wire_test.go
@@ -187,13 +187,11 @@ func TestValueFromWireSuccess(t *testing.T) {
 			spec: &compile.StructSpec{
 				Name: "S",
 				Type: ast.StructType,
-				Fields: compile.FieldGroup{
-					"s": &compile.FieldSpec{
-						ID:   1,
-						Name: "s",
-						Type: compile.StringSpec,
-					},
-				},
+				Fields: compile.FieldGroup{{
+					ID:   1,
+					Name: "s",
+					Type: compile.StringSpec,
+				}},
 			},
 			v: map[string]interface{}{
 				"s": "foo",
@@ -221,14 +219,12 @@ func TestValueFromWireSuccess(t *testing.T) {
 			spec: &compile.StructSpec{
 				Name: "S",
 				Type: ast.StructType,
-				Fields: compile.FieldGroup{
-					"s": &compile.FieldSpec{
-						ID:      1,
-						Name:    "s",
-						Type:    compile.StringSpec,
-						Default: compile.ConstantString("foo"),
-					},
-				},
+				Fields: compile.FieldGroup{{
+					ID:      1,
+					Name:    "s",
+					Type:    compile.StringSpec,
+					Default: compile.ConstantString("foo"),
+				}},
 			},
 			v: map[string]interface{}{
 				"s": "foo",
@@ -312,13 +308,11 @@ func TestValueFromWireError(t *testing.T) {
 			spec: &compile.StructSpec{
 				Name: "S",
 				Type: ast.StructType,
-				Fields: compile.FieldGroup{
-					"s": &compile.FieldSpec{
-						ID:   1,
-						Name: "s",
-						Type: compile.StringSpec,
-					},
-				},
+				Fields: compile.FieldGroup{{
+					ID:   1,
+					Name: "s",
+					Type: compile.StringSpec,
+				}},
 			},
 			err: specValueMismatch{"S",
 				specStructFieldMismatch{"s", specTypeMismatch{specified: wire.TBinary, got: wire.TI32}},


### PR DESCRIPTION
Latest thriftrw-go uses a list for compile.FieldGroup instead of a map