### PR TITLE
Allow meta endpoints to be targeted without writing out a temporary meta.thrift

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 58a3f270f53fafeaef50923b802499db02ea83060fbe6c65f295811147386e3b
-updated: 2016-04-01T16:25:55.216235387-07:00
+updated: 2016-04-05T12:56:58.494783949-07:00
 imports:
 - name: github.com/apache/thrift
   version: 23d6746079d7b5fdb38214387c63f987e68a6d8f
@@ -12,7 +12,7 @@ imports:
 - name: github.com/jessevdk/go-flags
   version: 6b9493b3cb60367edd942144879646604089e3f7
 - name: github.com/thriftrw/thriftrw-go
-  version: 331b3b5e410ef32ec0513048dc7bb85b65234767
+  version: 653f1295612da68d9ce57e01ee1ff94fbb38a835
   subpackages:
   - ast
   - compile
@@ -22,7 +22,7 @@ imports:
   - protocol/binary
   - idl/internal
 - name: github.com/uber/tchannel-go
-  version: 08671e7060a917eaafa2e6fac0a01b0b247eb60b
+  version: 3e3e53962cc103863e644ac84dcda5169ead0467
   subpackages:
   - thrift
   - atomic

--- a/main.go
+++ b/main.go
@@ -171,14 +171,9 @@ func getMethodSpec(opts *RequestOptions) (*compile.FunctionSpec, error) {
 			return nil, errHealthAndMethod
 		}
 
-		file, err := getMetaFile()
-		if err != nil {
-			return nil, err
-		}
-		defer os.Remove(file)
-
-		opts.ThriftFile = file
-		opts.MethodName = "Meta::health"
+		methodName, spec := getHealthSpec()
+		opts.MethodName = methodName
+		return spec, nil
 	}
 
 	if opts.ThriftFile == "" {

--- a/main_test.go
+++ b/main_test.go
@@ -73,11 +73,12 @@ func TestGetRequest(t *testing.T) {
 
 func TestGetMethodSpec(t *testing.T) {
 	tests := []struct {
-		desc      string
-		opts      RequestOptions
-		checkSpec func(*compile.FunctionSpec)
-		errMsg    string
-		errMsgs   []string
+		desc           string
+		opts           RequestOptions
+		overrideMethod string
+		checkSpec      func(*compile.FunctionSpec)
+		errMsg         string
+		errMsgs        []string
 	}{
 		{
 			desc:   "No thrift file specified",
@@ -115,8 +116,9 @@ func TestGetMethodSpec(t *testing.T) {
 			errMsg: errHealthAndMethod.Error(),
 		},
 		{
-			desc: "Health method",
-			opts: RequestOptions{Health: true},
+			desc:           "Health method",
+			opts:           RequestOptions{Health: true},
+			overrideMethod: "Meta::health",
 			checkSpec: func(spec *compile.FunctionSpec) {
 				assert.Equal(t, 0, len(spec.ArgsSpec), "health method should not have arguments")
 				assert.NotNil(t, spec.ResultSpec.ReturnType, "health method should have a return")
@@ -142,6 +144,11 @@ func TestGetMethodSpec(t *testing.T) {
 			if tt.checkSpec != nil {
 				tt.checkSpec(got)
 			}
+			checkMethod := opts.MethodName
+			if tt.overrideMethod != "" {
+				checkMethod = tt.overrideMethod
+			}
+			assert.Equal(t, checkMethod, opts.MethodName, "invalid MethodName")
 			continue
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/testutils"
+	"github.com/uber/tchannel-go/thrift"
 )
 
 func TestGetRequest(t *testing.T) {
@@ -282,6 +283,25 @@ func TestMain(t *testing.T) {
 		"-t", validThrift,
 		"foo", fooMethod,
 		"-p", echoAddr,
+	}
+
+	main()
+}
+
+func TestHealthIntegration(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	// Create a server with the Meta::health endpoint.
+	server := newServer(t)
+	thrift.NewServer(server.ch)
+	defer server.shutdown()
+
+	os.Args = []string{
+		"yab",
+		"foo",
+		"-p", server.hostPort(),
+		"--health",
 	}
 
 	main()

--- a/meta_test.go
+++ b/meta_test.go
@@ -21,20 +21,22 @@
 package main
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetMetaFile(t *testing.T) {
-	f, err := getMetaFile()
-	require.NoError(t, err, "getMetaFile failed")
-	defer os.Remove(f)
+func TestMetaSpec(t *testing.T) {
+	assert.NotPanics(t, func() {
+		spec := getMetaService()
+		assert.NotNil(t, spec, "Meta service spec is nil")
+	}, "Failed to get Meta service")
 
-	contents, err := ioutil.ReadFile(f)
-	require.NoError(t, err, "Failed to read resulting meta file")
-	assert.Equal(t, _metaThrift, string(contents), "Meta file contents wrong")
+	assert.NotPanics(t, func() {
+		name, spec := getHealthSpec()
+		assert.Equal(t, "Meta::health", name, "Method name mismatch")
+		require.NotNil(t, spec, "Got nil health spec")
+		assert.Equal(t, 0, len(spec.ArgsSpec), "Health method")
+	}, "Failed to get health spec")
 }


### PR DESCRIPTION
Use `Compile` option added in https://github.com/thriftrw/thriftrw-go/pull/108 to avoid creating a temporary `meta.thrift` when making requests to the health endpoint.