### PR TITLE
Ignore case and underscores when look for struct field matches

### DIFF
--- a/thrift/fields_test.go
+++ b/thrift/fields_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFuzz(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"arg", "arg"},
+		{"Arg123", "arg123"},
+		{"_Arg_1_3", "arg13"},
+	}
+
+	for _, tt := range tests {
+		got := fuzz(tt.input)
+		assert.Equal(t, tt.want, got, "Fuzz(%v)", tt.input)
+	}
+}

--- a/thrift/parse_test.go
+++ b/thrift/parse_test.go
@@ -64,6 +64,7 @@ func TestParseRequest(t *testing.T) {
     struct S {
       1: required string f1,
       2: optional NS ns,
+      3: optional NS ns_,
     }
 
 		union U {
@@ -371,6 +372,31 @@ func TestParseRequest(t *testing.T) {
 				},
 			},
 			errMsg: "map value (asd) for key (true) failed",
+		},
+		{
+			// use fuzzy matching to set fields.
+			request: map[string]interface{}{
+				"Arg1":    json.Number("1"),
+				"argi16_": json.Number("3"),
+				"ARGi32":  json.Number("4"),
+				"ArgBool": true,
+			},
+			want: []wire.Field{
+				{ID: 1, Value: wire.NewValueI8(1)},
+				{ID: 9, Value: wire.NewValueI16(3)},
+				{ID: 10, Value: wire.NewValueI32(4)},
+				{ID: 11, Value: wire.NewValueBool(true)},
+			},
+		},
+		{
+			// fuzzy matching is disabled on any name clashes.
+			request: map[string]interface{}{
+				"s": map[string]interface{}{
+					"f1": "foo",
+					"NS": "asd",
+				},
+			},
+			errMsg: fieldGroupError{notFound: []string{"NS"}}.Error(),
 		},
 	}
 


### PR DESCRIPTION
Since we're essentially making Thrift case-insensitive, we can
do fuzzy matching to find the right field. This makes it easier
to do things like copy the request struct from Go and use it in
`yab` even though the Go fields use title case.

@abhinav @akshayjshah 