### PR TITLE
Improved binary support: allow base64 or files to be used for binary/string input

### DIFF
--- a/thrift/types.go
+++ b/thrift/types.go
@@ -119,10 +119,7 @@ func parseBinaryList(vl []interface{}) ([]byte, error) {
 			}
 			bs = append(bs, byte(vInt))
 		case string:
-			if len(v) != 1 {
-				return nil, fmt.Errorf("not a valid character in list of characters: %q", v)
-			}
-			bs = append(bs, v[0])
+			bs = append(bs, v...)
 		default:
 			return nil, fmt.Errorf("can only parse list of bytes or characters, invalid element: %q", v)
 		}

--- a/thrift/types.go
+++ b/thrift/types.go
@@ -25,11 +25,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"strconv"
 	"strings"
 )
 
-var errBinaryObjectOptions = errors.New("object input for binary/string must have one of the following keys: base64")
+var errBinaryObjectOptions = errors.New(
+	"object input for binary/string must have one of the following keys: base64, file")
 
 func parseBoolNumber(v json.Number) (bool, error) {
 	i64, err := v.Int64()
@@ -140,6 +142,15 @@ func parseBinaryMap(v map[string]interface{}) ([]byte, error) {
 		// all "=" characters out, and use RawStdEncoding (which does not need padding).
 		str = strings.TrimRight(str, "=")
 		return base64.RawStdEncoding.DecodeString(str)
+	}
+
+	if v, ok := v["file"]; ok {
+		str, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("file requires filename as string, got %T", v)
+		}
+
+		return ioutil.ReadFile(str)
 	}
 
 	return nil, errBinaryObjectOptions

--- a/thrift/types_test.go
+++ b/thrift/types_test.go
@@ -261,6 +261,14 @@ func TestParseBinary(t *testing.T) {
 			want:  []byte("AB"),
 		},
 		{
+			value: map[string]interface{}{"base64": "YWI="},
+			want:  []byte("ab"),
+		},
+		{
+			value: map[string]interface{}{"base64": "YWI"},
+			want:  []byte("ab"),
+		},
+		{
 			value:  []interface{}{""},
 			errMsg: "not a valid character",
 		},
@@ -277,16 +285,28 @@ func TestParseBinary(t *testing.T) {
 			errMsg: "failed to parse list of bytes",
 		},
 		{
+			value:  map[string]interface{}{"base64": true},
+			errMsg: "base64 must be specified as string",
+		},
+		{
+			value:  map[string]interface{}{"base64": "a_b"},
+			errMsg: "illegal base64 data",
+		},
+		{
+			value:  map[string]interface{}{"unsupported": "ab"},
+			errMsg: errBinaryObjectOptions.Error(),
+		},
+		{
 			value:  json.Number("3.14159"),
-			errMsg: "cannot parse string",
+			errMsg: "cannot parse binary/string",
 		},
 		{
 			value:  true,
-			errMsg: "cannot parse string",
+			errMsg: "cannot parse binary/string",
 		},
 		{
 			value:  1,
-			errMsg: "cannot parse string",
+			errMsg: "cannot parse binary/string",
 		},
 		{
 			value:  []interface{}{0, 0, 0},

--- a/thrift/types_test.go
+++ b/thrift/types_test.go
@@ -269,6 +269,10 @@ func TestParseBinary(t *testing.T) {
 			want:  []byte("ab"),
 		},
 		{
+			value: map[string]interface{}{"file": "../testdata/valid.json"},
+			want:  []byte(`{"k1": "v1", "k2": 5}` + "\n"),
+		},
+		{
 			value:  []interface{}{""},
 			errMsg: "not a valid character",
 		},
@@ -295,6 +299,14 @@ func TestParseBinary(t *testing.T) {
 		{
 			value:  map[string]interface{}{"unsupported": "ab"},
 			errMsg: errBinaryObjectOptions.Error(),
+		},
+		{
+			value:  map[string]interface{}{"file": true},
+			errMsg: "file requires filename as string",
+		},
+		{
+			value:  map[string]interface{}{"file": "not-found.json"},
+			errMsg: "no such file or directory",
 		},
 		{
 			value:  json.Number("3.14159"),

--- a/thrift/types_test.go
+++ b/thrift/types_test.go
@@ -261,6 +261,10 @@ func TestParseBinary(t *testing.T) {
 			want:  []byte("AB"),
 		},
 		{
+			value: []interface{}{json.Number("104"), "ello", "", " ", "world"},
+			want:  []byte("hello world"),
+		},
+		{
 			value: map[string]interface{}{"base64": "YWI="},
 			want:  []byte("ab"),
 		},
@@ -271,14 +275,6 @@ func TestParseBinary(t *testing.T) {
 		{
 			value: map[string]interface{}{"file": "../testdata/valid.json"},
 			want:  []byte(`{"k1": "v1", "k2": 5}` + "\n"),
-		},
-		{
-			value:  []interface{}{""},
-			errMsg: "not a valid character",
-		},
-		{
-			value:  []interface{}{"a", "too long"},
-			errMsg: "not a valid character",
 		},
 		{
 			value:  []interface{}{json.Number("256")},

--- a/thrift/types_test.go
+++ b/thrift/types_test.go
@@ -240,9 +240,9 @@ func TestParseDouble(t *testing.T) {
 
 func TestParseBinary(t *testing.T) {
 	tests := []struct {
-		value   interface{}
-		want    []byte
-		wantErr bool
+		value  interface{}
+		want   []byte
+		errMsg string
 	}{
 		{
 			value: "",
@@ -253,27 +253,53 @@ func TestParseBinary(t *testing.T) {
 			want:  []byte("asd"),
 		},
 		{
-			value:   json.Number("3.14159"),
-			wantErr: true,
+			value: []interface{}{"a", "s", "d"},
+			want:  []byte("asd"),
 		},
 		{
-			value:   true,
-			wantErr: true,
+			value: []interface{}{json.Number("65"), json.Number("66")},
+			want:  []byte("AB"),
 		},
 		{
-			value:   1,
-			wantErr: true,
+			value:  []interface{}{""},
+			errMsg: "not a valid character",
 		},
 		{
-			value:   []interface{}{0, 0, 0},
-			wantErr: true,
+			value:  []interface{}{"a", "too long"},
+			errMsg: "not a valid character",
+		},
+		{
+			value:  []interface{}{json.Number("256")},
+			errMsg: "failed to parse list of bytes",
+		},
+		{
+			value:  []interface{}{json.Number("1.5")},
+			errMsg: "failed to parse list of bytes",
+		},
+		{
+			value:  json.Number("3.14159"),
+			errMsg: "cannot parse string",
+		},
+		{
+			value:  true,
+			errMsg: "cannot parse string",
+		},
+		{
+			value:  1,
+			errMsg: "cannot parse string",
+		},
+		{
+			value:  []interface{}{0, 0, 0},
+			errMsg: "can only parse list of bytes or characters",
 		},
 	}
 
 	for _, tt := range tests {
 		got, err := parseBinary(tt.value)
-		if tt.wantErr {
-			assert.Error(t, err, "parseBinary(%v) should fail", tt.value)
+		if tt.errMsg != "" {
+			if assert.Error(t, err, "parseBinary(%v) should fail", tt.value) {
+				assert.Contains(t, err.Error(), tt.errMsg, "parseBinary(%v) unexpected error", tt.value)
+			}
 			continue
 		}
 		if assert.NoError(t, err, "parseBinary(%v) should not fail", tt.value) {


### PR DESCRIPTION
Previously, binary only supported strings,
```json
"binaryField": "value"
```

Now, we allow for the object to be specifies as a list of numbers or characters:
```json
"binaryField": [1,2,3]
```
```json
"binaryField": ["a", "b", "c"]
```

We also allow using objects to specify custom binary deserialization, such as base64 or reading a file:
```json
"binaryField": {
  "base64": "YWI="
}
```
```json
"binaryField": {
  "file": "/my/file"
}
```

@abhinav @akshayjshah 