### PR TITLE
Allow struct fields to be specified by field ID

### DIFF
--- a/thrift/parse_test.go
+++ b/thrift/parse_test.go
@@ -398,6 +398,26 @@ func TestParseRequest(t *testing.T) {
 			},
 			errMsg: fieldGroupError{notFound: []string{"NS"}}.Error(),
 		},
+		{
+			// allow specifying fields by field ID
+			request: map[string]interface{}{
+				"1":  json.Number("1"),
+				"9":  json.Number("3"),
+				"11": true,
+			},
+			want: []wire.Field{
+				{ID: 1, Value: wire.NewValueI8(1)},
+				{ID: 9, Value: wire.NewValueI16(3)},
+				{ID: 11, Value: wire.NewValueBool(true)},
+			},
+		},
+		{
+			// invalid field IDs should report an error though.
+			request: map[string]interface{}{
+				"999": json.Number("1"),
+			},
+			errMsg: fieldGroupError{notFound: []string{"999"}}.Error(),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This makes consuming output from tools such as tcap.

tcap output looks like:
```
arg3 as thrift
{ '1':
   { '1': 'string',
     '2': 'go' } }
```

Unfortunately json doesn't allow `'` to be used, but once you replace the single quotes with double quotes, it can be passed to `yab` and makes a successful request.

@abhinav 