### PR TITLE
Add support for request headers and output response headers

### DIFF
--- a/bench_method.go
+++ b/bench_method.go
@@ -37,7 +37,7 @@ type benchmarkMethod struct {
 // WarmTransport warms up a transport and returns it. The transport is warmed
 // up by making some number of requests through it.
 func (m benchmarkMethod) WarmTransport(opts TransportOptions) (transport.Transport, error) {
-	transport, err := getTransport(opts)
+	transport, err := getTransport(opts, m.serializer.Encoding())
 	if err != nil {
 		return nil, err
 	}

--- a/bench_method_test.go
+++ b/bench_method_test.go
@@ -39,10 +39,7 @@ func benchmarkMethodForTest(t *testing.T, methodString string) benchmarkMethod {
 	serializer, err := NewSerializer(rOpts)
 	require.NoError(t, err, "Failed to create Thrift serializer")
 
-	input, err := getRequestInput(rOpts)
-	require.NoError(t, err, "Failed to get request input")
-
-	req, err := serializer.Request(input)
+	req, err := serializer.Request(nil)
 	require.NoError(t, err, "Failed to serialize Thrift body")
 
 	req.Timeout = time.Second
@@ -127,7 +124,7 @@ func TestBenchmarkMethodCall(t *testing.T) {
 		ServiceName: "foo",
 		HostPorts:   []string{s.hostPort()},
 	}
-	transport, err := getTransport(tOpts)
+	transport, err := getTransport(tOpts, Thrift)
 	require.NoError(t, err, "Failed to get transport")
 
 	for _, tt := range tests {

--- a/encoding.go
+++ b/encoding.go
@@ -41,7 +41,7 @@ type Serializer interface {
 
 	// Response converts a transport.Response into something that can be displayed to a user.
 	// For non-raw encodings, this is typically a map[string]interface{}.
-	Response(body *transport.Response) (interface{}, error)
+	Response(body *transport.Response) (response interface{}, err error)
 
 	// CheckSuccess checks whether the response body is a success, and if not, returns an
 	// error with the failure reason.

--- a/main_test.go
+++ b/main_test.go
@@ -157,7 +157,7 @@ func TestRunWithOptions(t *testing.T) {
 	}
 }
 
-func TestMain(t *testing.T) {
+func TestMainNoHeaders(t *testing.T) {
 	origArgs := os.Args
 	defer func() { os.Args = origArgs }()
 
@@ -166,6 +166,23 @@ func TestMain(t *testing.T) {
 		"yab",
 		"-t", validThrift,
 		"foo", fooMethod,
+		"-p", echoAddr,
+	}
+
+	main()
+}
+
+func TestMainWithHeaders(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	echoAddr := echoServer(t, fooMethod, nil)
+	os.Args = []string{
+		"yab",
+		"-t", validThrift,
+		"foo", fooMethod,
+		`{"header": "values"}`,
+		`{}`,
 		"-p", echoAddr,
 	}
 

--- a/options.go
+++ b/options.go
@@ -39,6 +39,8 @@ type RequestOptions struct {
 	MethodName  string         `short:"m" long:"method" description:"The full Thrift method name (Svc::Method) to invoke"`
 	RequestJSON string         `short:"r" long:"request" description:"The request body, in JSON format"`
 	RequestFile string         `short:"f" long:"file" description:"Path of a file containing the request body in JSON"`
+	HeadersJSON string         `long:"headers" description:"The headers in JSON format"`
+	HeadersFile string         `long:"headers-file" description:"Path of a file containing the headers in JSON"`
 	Health      bool           `long:"health" description:"Hit the health endpoint, Meta::health"`
 	Timeout     timeMillisFlag `long:"timeout" default:"1s" description:"The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
 }

--- a/transport.go
+++ b/transport.go
@@ -83,7 +83,7 @@ func ensureSameProtocol(hostPorts []string) (string, error) {
 	return lastProtocol, nil
 }
 
-func getTransport(opts TransportOptions) (transport.Transport, error) {
+func getTransport(opts TransportOptions, encoding Encoding) (transport.Transport, error) {
 	if opts.ServiceName == "" {
 		return nil, errServiceRequired
 	}
@@ -121,6 +121,7 @@ func getTransport(opts TransportOptions) (transport.Transport, error) {
 			SourceService: sourceService,
 			TargetService: opts.ServiceName,
 			HostPorts:     hostPorts,
+			Encoding:      encoding.String(),
 		}
 		return transport.TChannel(topts)
 	}

--- a/transport/http.go
+++ b/transport/http.go
@@ -118,8 +118,13 @@ func (h *httpTransport) Call(ctx context.Context, r *Request) (*Response, error)
 		return nil, err
 	}
 
+	headers := make(map[string]string)
+	for headerKey := range resp.Header {
+		headers[headerKey] = resp.Header.Get(headerKey)
+	}
+
 	return &Response{
-		Headers: nil,
+		Headers: headers,
 		Body:    body,
 	}, nil
 }

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -157,6 +157,7 @@ func TestHTTPCall(t *testing.T) {
 			return
 		}
 
+		w.Header().Set("Custom-Header", "ok")
 		io.WriteString(w, "ok")
 	}))
 	defer svr.Close()
@@ -197,6 +198,7 @@ func TestHTTPCall(t *testing.T) {
 				"Got TTL %v out of range [%v,%v]", gotTTL, tt.ttlMin, tt.ttlMax)
 		}
 
+		assert.Equal(t, "ok", got.Headers["Custom-Header"], "Header mismatch")
 		assert.Equal(t, lastReq.body, tt.r.Body, "Body mismatch")
 	}
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -132,7 +132,7 @@ func TestGetTransport(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		transport, err := getTransport(tt.opts)
+		transport, err := getTransport(tt.opts, Thrift)
 		if tt.errMsg != "" {
 			if assert.Error(t, err, "getTransport(%v) should fail", tt.opts) {
 				assert.Contains(t, err.Error(), tt.errMsg, "Unexpected error for getTransport(%v)", tt.opts)


### PR DESCRIPTION
Note: we have a bit of a hack for raw headers, where we use a `_raw_` key.
This is because I want the internal structure for Headers to be
map[string]string since that is the most common use, but want to support
sending the headers as is for the raw encoding over TChannel.

@abhinav 