### PR TITLE
Add customizable timeout when making requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,6 +109,11 @@ func runWithOptions(opts Options, out output) {
 		out.Fatalf("Failed while parsing request input: %v\n", err)
 	}
 
+	req.Timeout = opts.ROpts.Timeout.Duration()
+	if req.Timeout == 0 {
+		req.Timeout = time.Second
+	}
+
 	response, err := makeRequest(transport, req)
 	if err != nil {
 		out.Fatalf("Failed while making call: %v\n", err)
@@ -135,7 +140,11 @@ func runWithOptions(opts Options, out output) {
 
 // makeRequest makes a request using the given transport.
 func makeRequest(t transport.Transport, request *transport.Request) (*transport.Response, error) {
-	ctx, cancel := tchannel.NewContext(time.Second)
+	if request.Timeout == 0 {
+		request.Timeout = time.Second
+	}
+
+	ctx, cancel := tchannel.NewContext(request.Timeout)
 	defer cancel()
 
 	return t.Call(ctx, request)

--- a/main_test.go
+++ b/main_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/testutils"
@@ -91,6 +92,21 @@ func TestRunWithOptions(t *testing.T) {
 				},
 			},
 			errMsg: "Failed while parsing response",
+		},
+		{
+			desc: "Fail due to timeout",
+			opts: Options{
+				ROpts: RequestOptions{
+					ThriftFile: validThrift,
+					MethodName: fooMethod,
+					Timeout:    timeMillisFlag(time.Nanosecond),
+				},
+				TOpts: TransportOptions{
+					ServiceName: "foo",
+					HostPorts:   []string{echoServer(t, fooMethod, nil)},
+				},
+			},
+			errMsg: "timeout",
 		},
 		{
 			desc: "Success",

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeMillisFlag(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			// values without a unit should be treated as milliseconds
+			value: "100",
+			want:  100 * time.Millisecond,
+		},
+		{
+			value: "0.1s",
+			want:  100 * time.Millisecond,
+		},
+		{
+			value:   "0.1",
+			wantErr: true,
+		},
+		{
+			value:   "notanumber",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		var timeMillis timeMillisFlag
+
+		err := timeMillis.UnmarshalFlag(tt.value)
+		if tt.wantErr {
+			assert.Error(t, err, "UnmarshalFlag(%v) should fail", tt.value)
+			continue
+		}
+
+		assert.NoError(t, err, "UnmarshalFlag(%v) should not fail", tt.value)
+		assert.Equal(t, tt.want, timeMillis.Duration(), "UnmarshalFlag(%v) expected %v", tt.value, tt.want)
+	}
+}

--- a/transport/interface.go
+++ b/transport/interface.go
@@ -20,11 +20,16 @@
 
 package transport
 
-import "golang.org/x/net/context"
+import (
+	"time"
+
+	"golang.org/x/net/context"
+)
 
 // Request is the fields used to make an RPC.
 type Request struct {
 	Method  string
+	Timeout time.Duration
 	Headers map[string]string
 	Body    []byte
 }


### PR DESCRIPTION
Allow the user to specify a timeout using the standard duration format (e.g. `1s` or `100ms`) while also allowing units to be specified as a number of milliseconds (for compatibility with `tcurl`)

@abhinav 