### PR TITLE
Setting timeout causes data races in benchmarks

### DIFF
--- a/bench_method_test.go
+++ b/bench_method_test.go
@@ -32,7 +32,7 @@ import (
 
 func benchmarkMethodForTest(t *testing.T, methodString string) benchmarkMethod {
 	rOpts := RequestOptions{
-		Encoding: Thrift,
+		Encoding:   Thrift,
 		ThriftFile: validThrift,
 		MethodName: methodString,
 	}
@@ -45,6 +45,7 @@ func benchmarkMethodForTest(t *testing.T, methodString string) benchmarkMethod {
 	req, err := serializer.Request(input)
 	require.NoError(t, err, "Failed to serialize Thrift body")
 
+	req.Timeout = time.Second
 	return benchmarkMethod{serializer, req}
 }
 

--- a/main.go
+++ b/main.go
@@ -140,10 +140,6 @@ func runWithOptions(opts Options, out output) {
 
 // makeRequest makes a request using the given transport.
 func makeRequest(t transport.Transport, request *transport.Request) (*transport.Response, error) {
-	if request.Timeout == 0 {
-		request.Timeout = time.Second
-	}
-
 	ctx, cancel := tchannel.NewContext(request.Timeout)
 	defer cancel()
 


### PR DESCRIPTION
Multiple goroutines may call makeRequest on the same Request object
as it's supposed to be immutable. Have all callers ensure the Request
has a timeout before passing it in to makeRequest.

@abhinav 