### PR TITLE
Add support for overriding Caller and setting other TChannel transport options

### DIFF
--- a/bench_method.go
+++ b/bench_method.go
@@ -37,6 +37,7 @@ type benchmarkMethod struct {
 // WarmTransport warms up a transport and returns it. The transport is warmed
 // up by making some number of requests through it.
 func (m benchmarkMethod) WarmTransport(opts TransportOptions) (transport.Transport, error) {
+	opts.benchmarking = true
 	transport, err := getTransport(opts, m.serializer.Encoding())
 	if err != nil {
 		return nil, err

--- a/options.go
+++ b/options.go
@@ -47,9 +47,10 @@ type RequestOptions struct {
 
 // TransportOptions are transport related options.
 type TransportOptions struct {
-	ServiceName  string   `short:"s" long:"service" description:"The TChannel/Hyperbahn service name"`
-	HostPorts    []string `short:"p" long:"peer" description:"The host:port of the service to call"`
-	HostPortFile string   `short:"P" long:"peer-list" description:"Path of a JSON file containing a list of host:ports"`
+	ServiceName      string            `short:"s" long:"service" description:"The TChannel/Hyperbahn service name"`
+	HostPorts        []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
+	HostPortFile     string            `short:"P" long:"peer-list" description:"Path of a JSON file containing a list of host:ports"`
+	TransportOptions map[string]string `long:"topt" description:"Custom options for the specific transport being used"`
 }
 
 // BenchmarkOptions are benchmark-specific options

--- a/options.go
+++ b/options.go
@@ -50,7 +50,11 @@ type TransportOptions struct {
 	ServiceName      string            `short:"s" long:"service" description:"The TChannel/Hyperbahn service name"`
 	HostPorts        []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
 	HostPortFile     string            `short:"P" long:"peer-list" description:"Path of a JSON file containing a list of host:ports"`
+	CallerOverride   string            `long:"caller" description:"Caller will override the default caller name (which is yab-$USER)."`
 	TransportOptions map[string]string `long:"topt" description:"Custom options for the specific transport being used"`
+
+	// benchmarking is a private flag set when a transport is required for benchmarking.
+	benchmarking bool
 }
 
 // BenchmarkOptions are benchmark-specific options

--- a/transport.go
+++ b/transport.go
@@ -122,6 +122,7 @@ func getTransport(opts TransportOptions, encoding Encoding) (transport.Transport
 			TargetService: opts.ServiceName,
 			HostPorts:     hostPorts,
 			Encoding:      encoding.String(),
+			TransportOpts: opts.TransportOptions,
 		}
 		return transport.TChannel(topts)
 	}

--- a/transport.go
+++ b/transport.go
@@ -39,10 +39,11 @@ import (
 )
 
 var (
-	errServiceRequired = errors.New("specify a target service using --service")
-	errPeerRequired    = errors.New("specify at least one peer using --peer or using --hostfile")
-	errPeerOptions     = errors.New("do not specify peers using --peer and --hostfile")
-	errPeerListFile    = errors.New("peer list should be a JSON file with a list of strings")
+	errServiceRequired    = errors.New("specify a target service using --service")
+	errPeerRequired       = errors.New("specify at least one peer using --peer or using --hostfile")
+	errPeerOptions        = errors.New("do not specify peers using --peer and --hostfile")
+	errPeerListFile       = errors.New("peer list should be a JSON file with a list of strings")
+	errCallerForBenchmark = errors.New("cannot override caller name when running benchmarks")
 )
 
 func remapLocalHost(hostPorts []string) {
@@ -113,6 +114,12 @@ func getTransport(opts TransportOptions, encoding Encoding) (transport.Transport
 	}
 
 	sourceService := "yab-" + os.Getenv("USER")
+	if opts.CallerOverride != "" {
+		if opts.benchmarking {
+			return nil, errCallerForBenchmark
+		}
+		sourceService = opts.CallerOverride
+	}
 
 	if protocol == "tchannel" {
 		remapLocalHost(hostPorts)

--- a/transport/tchannel.go
+++ b/transport/tchannel.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/thrift"
@@ -75,10 +76,17 @@ func TChannel(opts TChannelOptions) (Transport, error) {
 		callerName = cn
 	}
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown-host"
+	}
+	processName := fmt.Sprintf("%v@%v:%v[%v]", os.Getenv("USER"), hostname, os.Args[0], os.Getpid())
+
 	// TODO: set trace sample rate to 1 for the initial request.
 	zero := float64(0)
 	ch, err := tchannel.NewChannel(callerName, &tchannel.ChannelOptions{
 		Logger:          tchannel.NewLevelLogger(tchannel.SimpleLogger, level),
+		ProcessName:     processName,
 		TraceSampleRate: &zero,
 	})
 	if err != nil {

--- a/transport/tchannel.go
+++ b/transport/tchannel.go
@@ -57,6 +57,10 @@ type TChannelOptions struct {
 
 	// Encoding is used to set the TChannel format ("as" header).
 	Encoding string
+
+	// TransportOpts are a list of options, mostly used to add or override
+	// TChannel's transport headers.
+	TransportOpts map[string]string
 }
 
 // TChannel returns a Transport that calls a TChannel service.
@@ -66,9 +70,14 @@ func TChannel(opts TChannelOptions) (Transport, error) {
 		level = *opts.LogLevel
 	}
 
+	callerName := opts.SourceService
+	if cn, ok := opts.TransportOpts["cn"]; ok {
+		callerName = cn
+	}
+
 	// TODO: set trace sample rate to 1 for the initial request.
 	zero := float64(0)
-	ch, err := tchannel.NewChannel(opts.SourceService, &tchannel.ChannelOptions{
+	ch, err := tchannel.NewChannel(callerName, &tchannel.ChannelOptions{
 		Logger:          tchannel.NewLevelLogger(tchannel.SimpleLogger, level),
 		TraceSampleRate: &zero,
 	})
@@ -83,6 +92,7 @@ func TChannel(opts TChannelOptions) (Transport, error) {
 	callOpts := &tchannel.CallOptions{
 		Format: tchannel.Format(opts.Encoding),
 	}
+	applyTChanOptions(callOpts, opts.TransportOpts)
 
 	return &tchan{
 		sc:          ch.GetSubChannel(opts.TargetService),
@@ -180,6 +190,18 @@ func (t *tchan) writeArgs(call *tchannel.OutboundCall, r *Request) error {
 	}
 
 	return nil
+}
+
+func applyTChanOptions(callOpts *tchannel.CallOptions, opts map[string]string) {
+	if format, ok := opts["as"]; ok {
+		callOpts.Format = tchannel.Format(format)
+	}
+	if rd, ok := opts["rd"]; ok {
+		callOpts.RoutingDelegate = rd
+	}
+	if sk, ok := opts["sk"]; ok {
+		callOpts.ShardKey = sk
+	}
 }
 
 func readHelper(readerFn func() (tchannel.ArgReader, error), f func(tchannel.ArgReader) error) error {


### PR DESCRIPTION
go-flags allows setting maps via flags, the usage for setting multiple flags would be:
```
yab -P hosts.json moe --health --topt as:raw --topt sk:shard-key --topt rd:router
``` 

We also allow overriding the caller using `--caller`, but this is disabled when making benchmarks (for safety).

For TChannel, we add a more descriptive process name, so even if the user uses a custom caller, we can identify where the request came.

@abhinav 