### PR TITLE
Refactor encoding code into separate package

### DIFF
--- a/bench_method.go
+++ b/bench_method.go
@@ -24,13 +24,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/yarpc/yab/encoding"
 	"github.com/yarpc/yab/transport"
 )
 
 const warmupRequests = 10
 
 type benchmarkMethod struct {
-	serializer Serializer
+	serializer encoding.Serializer
 	req        *transport.Request
 }
 

--- a/bench_method_test.go
+++ b/bench_method_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/yarpc/yab/encoding"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/testutils"
@@ -32,7 +34,7 @@ import (
 
 func benchmarkMethodForTest(t *testing.T, methodString string) benchmarkMethod {
 	rOpts := RequestOptions{
-		Encoding:   Thrift,
+		Encoding:   encoding.Thrift,
 		ThriftFile: validThrift,
 		MethodName: methodString,
 	}
@@ -140,7 +142,7 @@ func TestBenchmarkMethodCall(t *testing.T) {
 		ServiceName: "foo",
 		HostPorts:   []string{s.hostPort()},
 	}
-	transport, err := getTransport(tOpts, Thrift)
+	transport, err := getTransport(tOpts, encoding.Thrift)
 	require.NoError(t, err, "Failed to get transport")
 
 	for _, tt := range tests {

--- a/encoding/meta.go
+++ b/encoding/meta.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package encoding
 
 import (
 	"fmt"

--- a/encoding/meta_test.go
+++ b/encoding/meta_test.go
@@ -18,52 +18,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package encoding
 
 import (
-	"bytes"
-	"fmt"
-	"io/ioutil"
-	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// Constants useful for tests
-const (
-	validThrift = "testdata/simple.thrift"
-	fooMethod   = "Simple::foo"
-)
+func TestMetaSpec(t *testing.T) {
+	assert.NotPanics(t, func() {
+		spec := getMetaService()
+		assert.NotNil(t, spec, "Meta service spec is nil")
+	}, "Failed to get Meta service")
 
-type testOutput struct {
-	*bytes.Buffer
-	fatalf func(string, ...interface{})
-}
-
-func (t testOutput) Fatalf(format string, args ...interface{}) {
-	t.fatalf(format, args...)
-	runtime.Goexit()
-}
-
-func (t testOutput) Printf(format string, args ...interface{}) {
-	t.WriteString(fmt.Sprintf(format, args...))
-}
-
-func getOutput(t *testing.T) (*bytes.Buffer, output) {
-	buf := &bytes.Buffer{}
-	out := testOutput{
-		Buffer: buf,
-		fatalf: t.Errorf,
-	}
-	return buf, out
-}
-
-func writeFile(t *testing.T, prefix, contents string) string {
-	f, err := ioutil.TempFile("", prefix)
-	require.NoError(t, err, "TempFile failed")
-	_, err = f.WriteString(contents)
-	require.NoError(t, err, "Write to temp file failed")
-	require.NoError(t, f.Close(), "Close temp file failed")
-	return f.Name()
+	assert.NotPanics(t, func() {
+		name, spec := getHealthSpec()
+		assert.Equal(t, "Meta::health", name, "Method name mismatch")
+		require.NotNil(t, spec, "Got nil health spec")
+		assert.Equal(t, 0, len(spec.ArgsSpec), "Health method")
+	}, "Failed to get health spec")
 }

--- a/encoding/not_found.go
+++ b/encoding/not_found.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package encoding
 
 import (
 	"fmt"

--- a/encoding/thrift_request.go
+++ b/encoding/thrift_request.go
@@ -18,15 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package encoding
 
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/yarpc/yab/sorted"
 	"github.com/yarpc/yab/thrift"
 	"github.com/yarpc/yab/transport"
+	"github.com/yarpc/yab/unmarshal"
 
 	"github.com/thriftrw/thriftrw-go/compile"
 )
@@ -36,7 +38,8 @@ type thriftSerializer struct {
 	spec       *compile.FunctionSpec
 }
 
-func newThriftSerializer(thriftFile, methodName string) (Serializer, error) {
+// NewThrift returns a Thrift serializer.
+func NewThrift(thriftFile, methodName string) (Serializer, error) {
 	if thriftFile == "" {
 		return nil, errors.New("specify a Thrift file using --thrift")
 	}
@@ -72,7 +75,7 @@ func (e thriftSerializer) Encoding() Encoding {
 }
 
 func (e thriftSerializer) Request(input []byte) (*transport.Request, error) {
-	reqMap, err := unmarshalYAMLInput(input)
+	reqMap, err := unmarshal.YAML(input)
 	if err != nil {
 		return nil, err
 	}
@@ -132,4 +135,9 @@ func findMethod(service *compile.ServiceSpec, methodName string) (*compile.Funct
 		errMsg = fmt.Sprintf("could not find method %q in %q", methodName, service.Name)
 	}
 	return nil, notFoundError{errMsg + ", available methods:", available}
+}
+
+func isFileMissing(f string) bool {
+	_, err := os.Stat(f)
+	return os.IsNotExist(err)
 }

--- a/encoding/yaml_to_thrift_test.go
+++ b/encoding/yaml_to_thrift_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package encoding
 
 import (
 	"io/ioutil"
@@ -66,7 +66,7 @@ func getSerializer(typeSpec compile.TypeSpec) thriftSerializer {
 }
 
 func TestYAMLToThrift(t *testing.T) {
-	const testDir = "testdata/yamltothrift/"
+	const testDir = "../testdata/yamltothrift/"
 
 	files, err := ioutil.ReadDir(testDir)
 	require.NoError(t, err, "Failed to read test directory %v: %v", testDir, err)

--- a/main.go
+++ b/main.go
@@ -181,8 +181,3 @@ func makeRequest(t transport.Transport, request *transport.Request) (*transport.
 
 	return t.Call(ctx, request)
 }
-
-func isFileMissing(f string) bool {
-	_, err := os.Stat(f)
-	return os.IsNotExist(err)
-}

--- a/options.go
+++ b/options.go
@@ -23,6 +23,8 @@ package main
 import (
 	"strconv"
 	"time"
+
+	"github.com/yarpc/yab/encoding"
 )
 
 // Options are parsed from flags using go-flags.
@@ -35,15 +37,15 @@ type Options struct {
 
 // RequestOptions are request related options
 type RequestOptions struct {
-	Encoding    Encoding       `short:"e" long:"encoding" description:"The encoding of the data, options are: Thrift, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified"`
-	ThriftFile  string         `short:"t" long:"thrift" description:"Path of the .thrift file"`
-	MethodName  string         `short:"m" long:"method" description:"The full Thrift method name (Svc::Method) to invoke"`
-	RequestJSON string         `short:"r" long:"request" description:"The request body, in JSON or YAML format"`
-	RequestFile string         `short:"f" long:"file" description:"Path of a file containing the request body in JSON or YAML"`
-	HeadersJSON string         `long:"headers" description:"The headers in JSON or YAML format"`
-	HeadersFile string         `long:"headers-file" description:"Path of a file containing the headers in JSON or YAML"`
-	Health      bool           `long:"health" description:"Hit the health endpoint, Meta::health"`
-	Timeout     timeMillisFlag `long:"timeout" default:"1s" description:"The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
+	Encoding    encoding.Encoding `short:"e" long:"encoding" description:"The encoding of the data, options are: Thrift, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified"`
+	ThriftFile  string            `short:"t" long:"thrift" description:"Path of the .thrift file"`
+	MethodName  string            `short:"m" long:"method" description:"The full Thrift method name (Svc::Method) to invoke"`
+	RequestJSON string            `short:"r" long:"request" description:"The request body, in JSON or YAML format"`
+	RequestFile string            `short:"f" long:"file" description:"Path of a file containing the request body in JSON or YAML"`
+	HeadersJSON string            `long:"headers" description:"The headers in JSON or YAML format"`
+	HeadersFile string            `long:"headers-file" description:"Path of a file containing the headers in JSON or YAML"`
+	Health      bool              `long:"health" description:"Hit the health endpoint, Meta::health"`
+	Timeout     timeMillisFlag    `long:"timeout" default:"1s" description:"The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
 }
 
 // TransportOptions are transport related options.

--- a/testdata/yamltothrift/binary_data.json
+++ b/testdata/yamltothrift/binary_data.json
@@ -1,7 +1,7 @@
 {
   "arg": {
     "b": {
-      "file": "testdata/yamltothrift/binary_data.file"
+      "file": "../testdata/yamltothrift/binary_data.file"
     }
   }
 }

--- a/transport.go
+++ b/transport.go
@@ -34,6 +34,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/yarpc/yab/encoding"
 	"github.com/yarpc/yab/transport"
 
 	"github.com/uber/tchannel-go"
@@ -85,7 +86,7 @@ func ensureSameProtocol(hostPorts []string) (string, error) {
 	return lastProtocol, nil
 }
 
-func getTransport(opts TransportOptions, encoding Encoding) (transport.Transport, error) {
+func getTransport(opts TransportOptions, encoding encoding.Encoding) (transport.Transport, error) {
 	if opts.ServiceName == "" {
 		return nil, errServiceRequired
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -25,13 +25,14 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"github.com/yarpc/yab/encoding"
+	"github.com/yarpc/yab/transport"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/raw"
-	"github.com/yarpc/yab/transport"
+	"golang.org/x/net/context"
 )
 
 func TestProtocolFor(t *testing.T) {
@@ -140,7 +141,7 @@ func TestGetTransport(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		transport, err := getTransport(tt.opts, Thrift)
+		transport, err := getTransport(tt.opts, encoding.Thrift)
 		if tt.errMsg != "" {
 			if assert.Error(t, err, "getTransport(%v) should fail", tt.opts) {
 				assert.Contains(t, err.Error(), tt.errMsg, "Unexpected error for getTransport(%v)", tt.opts)
@@ -196,7 +197,7 @@ func TestGetTransportCallerName(t *testing.T) {
 			CallerOverride: tt.callerOverride,
 			benchmarking:   tt.benchmark,
 		}
-		tchan, err := getTransport(opts, Raw)
+		tchan, err := getTransport(opts, encoding.Raw)
 		if tt.wantErr {
 			assert.Error(t, err, "Expect fail: %+v", tt)
 			continue
@@ -239,7 +240,7 @@ func TestGetTransportTraceEnabled(t *testing.T) {
 		ctx, cancel := tchannel.NewContext(time.Second)
 		defer cancel()
 
-		tchan, err := getTransport(opts, Raw)
+		tchan, err := getTransport(opts, encoding.Raw)
 		require.NoError(t, err, "getTransport failed")
 		res, err := tchan.Call(ctx, &transport.Request{Method: "test"})
 		require.NoError(t, err, "transport.Call failed")

--- a/unmarshal/unmarshal.go
+++ b/unmarshal/unmarshal.go
@@ -18,25 +18,40 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package unmarshal
 
 import (
-	"testing"
+	"bytes"
+	"encoding/json"
+	"fmt"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
-func TestMetaSpec(t *testing.T) {
-	assert.NotPanics(t, func() {
-		spec := getMetaService()
-		assert.NotNil(t, spec, "Meta service spec is nil")
-	}, "Failed to get Meta service")
+// YAML unmarshals the given YAML input to a map.
+func YAML(bs []byte) (map[string]interface{}, error) {
+	var m map[string]interface{}
+	if err := yaml.Unmarshal(bs, &m); err != nil {
+		return nil, err
+	}
 
-	assert.NotPanics(t, func() {
-		name, spec := getHealthSpec()
-		assert.Equal(t, "Meta::health", name, "Method name mismatch")
-		require.NotNil(t, spec, "Got nil health spec")
-		assert.Equal(t, 0, len(spec.ArgsSpec), "Health method")
-	}, "Failed to get health spec")
+	return m, nil
+}
+
+// JSON unmarshals the given JSON input to a map.
+func JSON(bs []byte) (map[string]interface{}, error) {
+	// An empty body should produce an empty input map.
+	if len(bs) == 0 {
+		return make(map[string]interface{}), nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(bs))
+	decoder.UseNumber()
+
+	var data map[string]interface{}
+	if err := decoder.Decode(&data); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %v", err)
+	}
+
+	return data, nil
 }

--- a/unmarshal/unmarshal_test.go
+++ b/unmarshal/unmarshal_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package unmarshal
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mustRead(fname string) []byte {
+	bs, err := ioutil.ReadFile(fname)
+	if err != nil {
+		panic(err)
+	}
+	return bs
+}
+
+func TestJSON(t *testing.T) {
+	tests := []struct {
+		input   []byte
+		want    map[string]interface{}
+		wantErr bool
+	}{
+		{
+			input: nil,
+			want:  map[string]interface{}{},
+		},
+		{
+			input: []byte("{}"),
+			want:  map[string]interface{}{},
+		},
+		{
+			input: mustRead("../testdata/valid.json"),
+			want: map[string]interface{}{
+				"k1": "v1",
+				"k2": json.Number("5"),
+			},
+		},
+		{
+			input:   []byte("{"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		got, err := JSON(tt.input)
+		if tt.wantErr {
+			assert.Error(t, err, "unmarshalJSON(%s) should fail", tt.input)
+			continue
+		}
+
+		if assert.NoError(t, err, "unmarshalJSON(%s) should not fail", tt.input) {
+			assert.Equal(t, tt.want, got, "unmarshalJSON(%s) unexpected result", tt.input)
+		}
+	}
+}
+
+func TestYAML(t *testing.T) {
+	tests := []struct {
+		msg       string
+		input     string
+		jsonInput string
+		want      map[string]interface{}
+		wantErr   bool
+	}{
+		{
+			msg: "basic types",
+			input: `
+str: v1
+int: 5
+bool: true
+int64: 9223372036854775807
+uint64: 18446744073709551615
+float: 6.5`,
+			want: map[string]interface{}{
+				"str":    "v1",
+				"int":    5,
+				"bool":   true,
+				"int64":  9223372036854775807,
+				"uint64": uint64(18446744073709551615),
+				"float":  6.5,
+			},
+		},
+		{
+			msg: "inline objects",
+			input: `
+obj:
+  1: 2
+  3: 5.6`,
+			want: map[string]interface{}{
+				"obj": map[interface{}]interface{}{
+					1: 2,
+					3: 5.6,
+				},
+			},
+		},
+		{
+			msg: "json is yaml",
+			input: `{
+				"str": "v1",
+				"int": 5,
+				"bool": true,
+				"int64": 9223372036854775807,
+				"uint64": 18446744073709551615,
+				"float": 6.5,
+				"obj": {"k1": "v1"}
+			}`,
+			want: map[string]interface{}{
+				"str":    "v1",
+				"int":    5,
+				"bool":   true,
+				"int64":  9223372036854775807,
+				"uint64": uint64(18446744073709551615),
+				"float":  6.5,
+				"obj": map[interface{}]interface{}{
+					"k1": "v1",
+				},
+			},
+		},
+		{
+			msg: "json with trailing comma",
+			input: `{
+				"str": "v1",
+			}`,
+			want: map[string]interface{}{
+				"str": "v1",
+			},
+		},
+		{
+			msg: "json with map[int]int",
+			input: `{
+				"obj": {
+					1: 2,
+					3: 4,
+				}
+			}`,
+			want: map[string]interface{}{
+				"obj": map[interface{}]interface{}{
+					1: 2,
+					3: 4,
+				},
+			},
+		},
+		{
+			msg:     "invalid yaml",
+			input:   `{"str" "asd"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		got, err := YAML([]byte(tt.input))
+		if tt.wantErr {
+			assert.Error(t, err, "%v: should fail", tt.msg)
+			continue
+		}
+		if !assert.NoError(t, err, "%v: should succeed", tt.msg) {
+			continue
+		}
+		assert.Equal(t, tt.want, got, "%v: mismatch", tt.msg)
+	}
+}


### PR DESCRIPTION
The main package is huge -- refactoring all encoding related code into a separate `encoding` package.

There are no changes to the logic, only refactoring + more unit tests.

@abhinav 