### PR TITLE
Add aliases -2 and -3 for headers/body to match tcurl

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,35 +60,36 @@ func main() {
 	parseAndRun(consoleOutput{os.Stdout})
 }
 
-// parseAndRun is like main, but uses the given output.
-func parseAndRun(out output) {
-	var opts Options
-	parser := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
+var errExit = errors.New("sentinel error used to exit cleanly")
+
+func getOptions(args []string, out output) (*Options, error) {
+	opts := newOptions()
+	parser := flags.NewParser(opts, flags.HelpFlag|flags.PassDoubleDash)
 	parser.Usage = "[<service> <method> <body>] [OPTIONS]"
 	findGroup(parser, "transport").ShortDescription = "Transport Options"
 	findGroup(parser, "request").ShortDescription = "Request Options"
 	findGroup(parser, "benchmark").ShortDescription = "Benchmark Options"
 
 	// If there are no arguments specified, write the help.
-	if len(os.Args) <= 1 {
+	if len(args) == 0 {
 		parser.WriteHelp(out)
-		return
+		return opts, errExit
 	}
 
-	remaining, err := parser.Parse()
+	remaining, err := parser.ParseArgs(args)
 	if err != nil {
 		if ferr, ok := err.(*flags.Error); ok {
 			if ferr.Type == flags.ErrHelp {
 				parser.WriteHelp(out)
-				return
+				return opts, errExit
 			}
 		}
-		out.Fatalf("Failed to parse flags: %v", err)
+		return opts, err
 	}
 
 	if opts.DisplayVersion {
 		out.Printf("yab version %v\n", versionString)
-		return
+		return opts, errExit
 	}
 
 	fromPositional(remaining, 0, &opts.TOpts.ServiceName)
@@ -103,8 +104,19 @@ func parseAndRun(out output) {
 		fromPositional(remaining, 2, &opts.ROpts.RequestJSON)
 	}
 
-	runWithOptions(opts, out)
-	return
+	return opts, nil
+}
+
+// parseAndRun is like main, but uses the given output.
+func parseAndRun(out output) {
+	opts, err := getOptions(os.Args[1:], out)
+	if err != nil {
+		if err == errExit {
+			return
+		}
+		out.Fatalf("Failed to parse options: %v", err)
+	}
+	runWithOptions(*opts, out)
 }
 
 func runWithOptions(opts Options, out output) {

--- a/main_test.go
+++ b/main_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/testutils"
 	"github.com/uber/tchannel-go/thrift"
 )
@@ -237,4 +238,33 @@ func TestVersion(t *testing.T) {
 	buf, out := getOutput(t)
 	parseAndRun(out)
 	assert.Equal(t, "yab version "+versionString+"\n", buf.String(), "Version output mismatch")
+}
+
+func TestGetOptionsAlias(t *testing.T) {
+	_, out := getOutput(t)
+
+	tests := []struct {
+		flagName  string
+		flagValue string
+	}{
+		{"", ""},
+		{"--request", "1"},
+		{"-r", "2"},
+		{"-3", "3"},
+		{"--arg3", "4"},
+		{"--request", "5"},
+		{"-r", "6"},
+		{"-3", "7"},
+		{"--arg3", "8"},
+	}
+
+	var flags []string
+	for _, tt := range tests {
+		flags = append(flags, tt.flagName, tt.flagValue)
+
+		opts, err := getOptions(flags, out)
+		require.NoError(t, err, "getOptions(%v) failed", flags)
+
+		assert.Equal(t, tt.flagValue, opts.ROpts.RequestJSON, "Unexpected request body for %v", flags)
+	}
 }


### PR DESCRIPTION
Instead of adding another `string` flag, I created a special `stringAlias` type. This ensures that we prefer the last argument specified, rather than preferring `-r` over `-3` or the other way around.

Added test to ensure that the last option specified is preferred, even when the alias is used.