### PR TITLE
Use in-memory filesystem for parsing test thrift files

### DIFF
--- a/encoding/thrift_request_test.go
+++ b/encoding/thrift_request_test.go
@@ -21,14 +21,12 @@
 package encoding
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
+
+	"github.com/yarpc/yab/internal/thrifttest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/thriftrw/thriftrw-go/compile"
-	"github.com/yarpc/yab/thrift"
 )
 
 const (
@@ -140,7 +138,7 @@ func TestRequest(t *testing.T) {
 }
 
 func TestFindServiceFound(t *testing.T) {
-	parsed := mustParse(t, `
+	parsed := thrifttest.Parse(t, `
     service Foo {}
     service Bar {}
   `)
@@ -176,7 +174,7 @@ func TestFindServiceFound(t *testing.T) {
 }
 
 func TestFindMethod(t *testing.T) {
-	parsed := mustParse(t, `
+	parsed := thrifttest.Parse(t, `
     service Foo {
       void f1()
       i32 f2(1: i32 i)
@@ -244,28 +242,4 @@ func TestFindMethod(t *testing.T) {
 			assert.Equal(t, tt.f, got.Name, "Method name mismatch")
 		}
 	}
-}
-
-func writeFile(t *testing.T, prefix, contents string) string {
-	f, err := ioutil.TempFile("", prefix)
-	require.NoError(t, err, "TempFile failed")
-	_, err = f.WriteString(contents)
-	require.NoError(t, err, "Write to temp file failed")
-	require.NoError(t, f.Close(), "Close temp file failed")
-	return f.Name()
-}
-
-// TODO use fake filesystem for compile.Compile
-
-func mustParse(t *testing.T, contents string) *compile.Module {
-	f := writeFile(t, "thrift", contents)
-	defer os.Remove(f)
-
-	return mustParseFile(t, f)
-}
-
-func mustParseFile(t *testing.T, filename string) *compile.Module {
-	parsed, err := thrift.Parse(filename)
-	require.NoError(t, err, "thrift.Parse failed")
-	return parsed
 }

--- a/internal/thrifttest/thrifttest.go
+++ b/internal/thrifttest/thrifttest.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package thrifttest contains utilities to help test THrift serialization.
+package thrifttest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/thriftrw/thriftrw-go/compile"
+)
+
+// DummyFS is an in-memory implementation of the Filesystem interface.
+type DummyFS map[string][]byte
+
+// Read returns the contents for the specified file.
+func (fs DummyFS) Read(filename string) ([]byte, error) {
+	if contents, ok := fs[filename]; ok {
+		return contents, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+// Abs returns the absolute path for the specified file.
+// The dummy implementation always returns the original path.
+func (DummyFS) Abs(filename string) (string, error) {
+	return filename, nil
+}
+
+// Parse parses the given file contents as a Thrift file with no dependencies.
+func Parse(t *testing.T, contents string) *compile.Module {
+	fs := DummyFS{
+		"file.thrift": []byte(contents),
+	}
+	compiled, err := compile.Compile("file.thrift", compile.Filesystem(fs))
+	require.NoError(t, err, "Failed to compile thrift file:\n%s", contents)
+	return compiled
+}

--- a/thrift/parse_test.go
+++ b/thrift/parse_test.go
@@ -22,8 +22,9 @@ package thrift
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
+
+	"github.com/yarpc/yab/internal/thrifttest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,18 +34,7 @@ import (
 
 // getFuncSpecs returns the spec for a service named "Test".
 func getFuncSpecs(t *testing.T, contents string) map[string]*compile.FunctionSpec {
-	file, err := ioutil.TempFile("", "func.thrift")
-	require.NoError(t, err, "TempFile failed")
-	defer os.Remove(file.Name())
-
-	_, err = file.Write([]byte(contents))
-	require.NoError(t, err, "Write failed")
-	require.NoError(t, file.Close(), "Close failed")
-
-	// Parse the Thrift file
-	module, err := compile.Compile(file.Name())
-	require.NoError(t, err, "Compile failed")
-
+	module := thrifttest.Parse(t, contents)
 	svc, err := module.LookupService("Test")
 	require.NoError(t, err, "Thrift contents missing service Test")
 	return svc.Functions


### PR DESCRIPTION
Test refactoring with no functional changes.

cc @abhinav 