### PR TITLE
thrift: Improve handling of enums

### DIFF
--- a/thrift/from_wire.go
+++ b/thrift/from_wire.go
@@ -123,6 +123,15 @@ func valueFromWireMap(spec *compile.MapSpec, w wire.Map) (map[string]interface{}
 	return result, nil
 }
 
+func mapEnumValueToName(enumSpec *compile.EnumSpec, result int32) interface{} {
+	for _, item := range enumSpec.Items {
+		if item.Value == result {
+			return item.Name
+		}
+	}
+	return fmt.Sprintf("%v(%v)", enumSpec.Name, result)
+}
+
 // valueFromWire converts the wire.Value to the specific type it represents.
 func valueFromWire(spec compile.TypeSpec, w wire.Value) (interface{}, error) {
 	if spec.TypeCode() != w.Type() {
@@ -140,7 +149,11 @@ func valueFromWire(spec compile.TypeSpec, w wire.Value) (interface{}, error) {
 	case wire.TI16:
 		result = w.GetI16()
 	case wire.TI32:
-		result = w.GetI32()
+		if enumSpec, ok := spec.(*compile.EnumSpec); ok {
+			result = mapEnumValueToName(enumSpec, w.GetI32())
+		} else {
+			result = w.GetI32()
+		}
 	case wire.TI64:
 		result = w.GetI64()
 	case wire.TDouble:

--- a/thrift/from_wire_test.go
+++ b/thrift/from_wire_test.go
@@ -230,6 +230,45 @@ func TestValueFromWireSuccess(t *testing.T) {
 				"s": "foo",
 			},
 		},
+		{
+			// Enum with recognized value.
+			w: wire.NewValueI32(1),
+			spec: &compile.EnumSpec{
+				Name: "Op",
+				Items: []compile.EnumItem{{
+					Name:  "Add",
+					Value: 1,
+				}},
+			},
+			v: "Add",
+		},
+		{
+			// Enum with with unrecognized value.
+			w: wire.NewValueI32(1),
+			spec: &compile.EnumSpec{
+				Name:  "Op",
+				Items: nil,
+			},
+			v: "Op(1)",
+		},
+		{
+			// Enum with duplicated value.
+			w: wire.NewValueI32(1),
+			spec: &compile.EnumSpec{
+				Name: "Op",
+				Items: []compile.EnumItem{
+					{
+						Name:  "Add",
+						Value: 1,
+					},
+					{
+						Name:  "Sum",
+						Value: 1,
+					},
+				},
+			},
+			v: "Add",
+		},
 	}
 
 	for _, tt := range tests {

--- a/thrift/parse_test.go
+++ b/thrift/parse_test.go
@@ -67,6 +67,11 @@ func TestParseRequest(t *testing.T) {
 
     typedef i32 Foo
 
+		enum Op {
+			Add = 1,
+			MULTIPLY,
+		}
+
     service Test {
 
       void test(
@@ -87,6 +92,7 @@ func TestParseRequest(t *testing.T) {
 				15: optional map<string, i32> s_i_map;
 				16: optional map<i32, i32> i_i_map;
 				17: optional map<bool, i32> b_i_map;
+				18: optional Op op;
       )
     }
 
@@ -358,6 +364,38 @@ func TestParseRequest(t *testing.T) {
 			}},
 		},
 		{
+			request: map[string]interface{}{
+				"op": 1,
+			},
+			want: []wire.Field{
+				{ID: 18, Value: wire.NewValueI32(1)},
+			},
+		},
+		{
+			request: map[string]interface{}{
+				"op": "Op(999)",
+			},
+			want: []wire.Field{
+				{ID: 18, Value: wire.NewValueI32(999)},
+			},
+		},
+		{
+			request: map[string]interface{}{
+				"op": "Add",
+			},
+			want: []wire.Field{
+				{ID: 18, Value: wire.NewValueI32(1)},
+			},
+		},
+		{
+			request: map[string]interface{}{
+				"op": "Multiply",
+			},
+			want: []wire.Field{
+				{ID: 18, Value: wire.NewValueI32(2)},
+			},
+		},
+		{
 			// map is not the right type.
 			request: map[string]interface{}{
 				"s_i_map": "asd",
@@ -426,6 +464,20 @@ func TestParseRequest(t *testing.T) {
 				"999": 1,
 			},
 			errMsg: fieldGroupError{notFound: []string{"999"}}.Error(),
+		},
+		{
+			// Unknown enum
+			request: map[string]interface{}{
+				"op": "Divide",
+			},
+			errMsg: `unrecognized enum "Divide"`,
+		},
+		{
+			// Unknown enum
+			request: map[string]interface{}{
+				"op": "Op(NaN)",
+			},
+			errMsg: `unrecognized enum "Op(NaN)"`,
 		},
 	}
 


### PR DESCRIPTION
When an enum value is received over the wire, it is formatted using the
name. If a name is not found, it is formatted as EnumType(%d)

Enums can be specified as:
- int32
- Case-insentivie name
- EnumType(%d)

The last format is so that formatted unknown enums on the result path
can be used as input.