### PR TITLE
Use NonStrict parsing in yab

### DIFF
--- a/thrift/parse.go
+++ b/thrift/parse.go
@@ -34,11 +34,11 @@ import (
 
 // Parse parses the given Thrift file.
 func Parse(file string) (*compile.Module, error) {
-	module, err := compile.Compile(file)
+	module, err := compile.Compile(file, compile.NonStrict())
 	// thriftrw wraps errors, so we can't use os.IsNotExist here.
 	if err != nil {
 		// The user may have left off the ".thrift", so try appending .thrift
-		if appendedModule, err2 := compile.Compile(file + ".thrift"); err2 == nil {
+		if appendedModule, err2 := compile.Compile(file+".thrift", compile.NonStrict()); err2 == nil {
 			module = appendedModule
 			err = nil
 		}

--- a/thrift/parse_test.go
+++ b/thrift/parse_test.go
@@ -22,6 +22,7 @@ package thrift
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/yarpc/yab/internal/thrifttest"
@@ -510,10 +511,14 @@ func TestParseSuccess(t *testing.T) {
 	filePrefix := tempFile.Name() + "_1"
 	fullFile := filePrefix + ".thrift"
 
-	data := []byte("struct S {}")
+	data := []byte(`
+		struct S {
+			1: string s
+		}
+	`)
 	require.NoError(t, ioutil.WriteFile(fullFile, data, 0666),
 		"Failed to write thrift file to %v", fullFile)
-	//defer os.Remove(fullFile)
+	defer os.Remove(fullFile)
 
 	for _, fname := range []string{fullFile, filePrefix} {
 		module, err := Parse(fname)


### PR DESCRIPTION
In future, we might want to parse in strict mode, and if it fails, do non-strict mode, and then print the errors as warnings.