### PR TITLE
Improve man pages + flags documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,14 @@ install_ci: install
 		go get golang.org/x/tools/cmd/cover
 
 
+.PHONY: update_man
+update_man:
+	go install .
+	yab --man-page > man/yab.1
+	nroff -man man/yab.1 | man2html -title yab > man/yab.html
+	[[ -d ../yab_ghpages ]] && cp man/yab.html ../yab_ghpages/man.html
+	@echo "Please update gh-pages"
+
 .PHONY: test_ci
 test_ci: install_ci build
 	./scripts/cover.sh $(shell go list $(PACKAGES))

--- a/benchmark.go
+++ b/benchmark.go
@@ -112,6 +112,7 @@ func runBenchmark(out output, allOpts Options, m benchmarkMethod) {
 	out.Printf("  Max RPS:         %v\n", opts.RPS)
 
 	// Warm up number of connections.
+	// TODO: If we're making N connections, we should try to select N unique peers
 	connections, err := m.WarmTransports(numConns, allOpts.TOpts)
 	if err != nil {
 		out.Fatalf("Failed to create connections: %v", err)

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// yab is a benchmarking tool for TChannel and HTTP applications.
+// It's primarily intended for Thrift applications but supports other encodings like JSON and binary (raw).
+//
+// It can be used in a curl-like fashion when benchmarking features are disabled.
+//
+// For usage information, check out the man page:
+// http://yarpc.github.io/yab/man.html
+package main
+
+const _reqOptsDesc = `Configures the request data and the encoding.
+
+To make Thrift requests, specify a Thrift file and pass the Thrift
+service and procedure to the method argument (-m or --method) as
+Service::Method.
+  $ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
+
+You can also use positional arguments to specify the method and body:
+  $ yab -p localhost:9787  -t kv.thrift kv KeyValue::Count '{}'
+
+The TChannel health endpoint can be hit without specifying a Thrift file
+by passing --health.
+
+Thrift requests can be specified as JSON or YAML. For example, for a method
+defined as:
+  void addUser(1: string name, 2: i32 age)
+
+You can pass the request as JSON: {"name": "Prashant", age: 100}
+or as YAML:
+  name: Prashant
+  age: 100
+
+The request body can be specified on the command line using -r or --request:
+  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get -r '{"key": "hello"}'
+
+Or it can be loaded from a file using -f or --file:
+  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
+
+Binary data can be specified in one of many ways:
+  - As a string or an array of bytes: "data" or [100, 97, 116, 97]
+  - As base64: {"base64": "ZGF0YQ=="}
+  - Loaded from a file: {"file": "data.bin"}
+
+Examples:
+  $ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set -3 '{"key": "hello", "value": [100, 97, 116, 97]}'
+  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set -3 '{"key": "hello", "value": {"file": "data.bin"}}'
+`
+
+const _transportOptsDesc = `Configures the network transport used to make requests.
+
+yab can target both TChannel and HTTP endpoints. To specify a TChannel endpoint,
+specify the peer's host and port:
+  $ yab -p localhost:9787 [options]
+or
+  $ yab -p tchannel://localhost:9787 [options]
+
+For HTTP endpoints, specify the URL as the peer,
+  $ yab -p http://localhost:8080/thrift [options]
+
+The Thrift encoded body will be POSTed to the specified URL.
+
+Multiple peers can be specified using a peer list using -P or --peer-list.
+When making a single request, a single peer from this list is selected randomly.
+When benchmarking, each connection will randomly select a peer.
+  $ yab --peer-list hosts.json [options]
+`
+
+const _benchmarkOptsDesc = `Configures benchmarking, which is disabled by default.
+
+By default, yab will only make a single request. To enable benchmarking, you
+must specify the maximum duration for the benchmark by passing -d or --max-duration.
+
+yab will make requests till either the maximum requests (-n or --max-requests)
+or the maximum duration is reached.
+
+You can control the rate at which yab makes requests using the --rps flag.
+
+An example benchmark command might be:
+  yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
+
+This would make requests at 1000 RPS until either the maximum number of
+requests (100,000) or the maximum duration (10 seconds) is reached.
+
+By default, yab will create multiple connections (defaulting to the number of
+CPUs on the machine), but will only have one concurrent call per connection.
+The number of connections and concurrent calls per connection can be controlled
+using --connections and --concurrency.
+`

--- a/main.go
+++ b/main.go
@@ -44,6 +44,12 @@ func findGroup(parser *flags.Parser, group string) *flags.Group {
 	panic("no group called " + group + " found.")
 }
 
+func setGroupDesc(parser *flags.Parser, groupName, newName, desc string) {
+	g := findGroup(parser, groupName)
+	g.ShortDescription = newName
+	g.LongDescription = desc
+}
+
 func fromPositional(args []string, index int, s *string) bool {
 	if len(args) <= index {
 		return false
@@ -74,9 +80,9 @@ yab is a benchmarking tool for TChannel and HTTP applications. It's primarily in
 It can be used in a curl-like fashion when benchmarking features are disabled.
 `
 
-	findGroup(parser, "transport").ShortDescription = "Transport Options"
-	findGroup(parser, "request").ShortDescription = "Request Options"
-	findGroup(parser, "benchmark").ShortDescription = "Benchmark Options"
+	setGroupDesc(parser, "request", "Request Options", _reqOptsDesc)
+	setGroupDesc(parser, "transport", "Transport Options", _transportOptsDesc)
+	setGroupDesc(parser, "benchmark", "Benchmark Options", _benchmarkOptsDesc)
 
 	// If there are no arguments specified, write the help.
 	if len(args) == 0 {

--- a/man/yab.1
+++ b/man/yab.1
@@ -1,0 +1,162 @@
+.TH yab 1 "3 June 2016"
+.SH NAME
+yab \- yet another benchmarker
+.SH SYNOPSIS
+\fByab\fP [<service> <method> <body>] [OPTIONS]
+.SH DESCRIPTION
+
+yab is a benchmarking tool for TChannel and HTTP applications. It's primarily intended for Thrift applications but supports other encodings like JSON and binary (raw).
+
+It can be used in a curl-like fashion when benchmarking features are disabled.
+
+.SH OPTIONS
+.SS Application Options
+.TP
+\fB\fB\-\-version\fR\fP
+Displays the application version
+.SS Request Options
+Configures the request data and the encoding.
+
+To make Thrift requests, specify a Thrift file and pass the Thrift
+service and procedure to the method argument (-m or --method) as
+Service::Method.
+  $ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
+
+You can also use positional arguments to specify the method and body:
+  $ yab -p localhost:9787  -t kv.thrift kv KeyValue::Count '{}'
+
+The TChannel health endpoint can be hit without specifying a Thrift file
+by passing --health.
+
+Thrift requests can be specified as JSON or YAML. For example, for a method
+defined as:
+  void addUser(1: string name, 2: i32 age)
+
+You can pass the request as JSON: {"name": "Prashant", age: 100}
+or as YAML:
+  name: Prashant
+  age: 100
+
+The request body can be specified on the command line using -r or --request:
+  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get -r '{"key": "hello"}'
+
+Or it can be loaded from a file using -f or --file:
+  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
+
+Binary data can be specified in one of many ways:
+  - As a string or an array of bytes: "data" or [100, 97, 116, 97]
+  - As base64: {"base64": "ZGF0YQ=="}
+  - Loaded from a file: {"file": "data.bin"}
+
+Examples:
+  $ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set -3 '{"key": "hello", "value": [100, 97, 116, 97]}'
+  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set -3 '{"key": "hello", "value": {"file": "data.bin"}}'
+
+.TP
+\fB\fB\-e\fR, \fB\-\-encoding\fR\fP
+The encoding of the data, options are: Thrift, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified
+.TP
+\fB\fB\-t\fR, \fB\-\-thrift\fR\fP
+Path of the .thrift file
+.TP
+\fB\fB\-m\fR, \fB\-\-method\fR\fP
+The full Thrift method name (Svc::Method) to invoke
+.TP
+\fB\fB\-r\fR, \fB\-\-request\fR\fP
+The request body, in JSON or YAML format
+.TP
+\fB\fB\-f\fR, \fB\-\-file\fR\fP
+Path of a file containing the request body in JSON or YAML
+.TP
+\fB\fB\-\-headers\fR\fP
+The headers in JSON or YAML format
+.TP
+\fB\fB\-\-headers-file\fR\fP
+Path of a file containing the headers in JSON or YAML
+.TP
+\fB\fB\-\-health\fR\fP
+Hit the health endpoint, Meta::health
+.TP
+\fB\fB\-\-timeout\fR <default: \fI"1s"\fR>\fP
+The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed.
+.SS Transport Options
+Configures the network transport used to make requests.
+
+yab can target both TChannel and HTTP endpoints. To specify a TChannel endpoint,
+specify the peer's host and port:
+  $ yab -p localhost:9787 [options]
+or
+  $ yab -p tchannel://localhost:9787 [options]
+
+For HTTP endpoints, specify the URL as the peer,
+  $ yab -p http://localhost:8080/thrift [options]
+
+The Thrift encoded body will be POSTed to the specified URL.
+
+Multiple peers can be specified using a peer list using -P or --peer-list.
+When making a single request, a single peer from this list is selected randomly.
+When benchmarking, each connection will randomly select a peer.
+  $ yab --peer-list hosts.json [options]
+
+.TP
+\fB\fB\-s\fR, \fB\-\-service\fR\fP
+The TChannel/Hyperbahn service name
+.TP
+\fB\fB\-p\fR, \fB\-\-peer\fR\fP
+The host:port of the service to call
+.TP
+\fB\fB\-P\fR, \fB\-\-peer-list\fR\fP
+Path of a JSON or YAML file containing a list of host:ports
+.TP
+\fB\fB\-\-caller\fR\fP
+Caller will override the default caller name (which is yab-$USER).
+.TP
+\fB\fB\-\-topt\fR\fP
+Custom options for the specific transport being used
+.SS Benchmark Options
+Configures benchmarking, which is disabled by default.
+
+By default, yab will only make a single request. To enable benchmarking, you
+must specify the maximum duration for the benchmark by passing -d or --max-duration.
+
+yab will make requests till either the maximum requests (-n or --max-requests)
+or the maximum duration is reached.
+
+You can control the rate at which yab makes requests using the --rps flag.
+
+An example benchmark command might be:
+  yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
+
+This would make requests at 1000 RPS until either the maximum number of
+requests (100,000) or the maximum duration (10 seconds) is reached.
+
+By default, yab will create multiple connections (defaulting to the number of
+CPUs on the machine), but will only have one concurrent call per connection.
+The number of connections and concurrent calls per connection can be controlled
+using --connections and --concurrency.
+
+.TP
+\fB\fB\-n\fR, \fB\-\-max-requests\fR <default: \fI"1000000"\fR>\fP
+The maximum number of requests to make
+.TP
+\fB\fB\-d\fR, \fB\-\-max-duration\fR <default: \fI"0s"\fR>\fP
+The maximum amount of time to run the benchmark for
+.TP
+\fB\fB\-\-cpus\fR\fP
+The number of OS threads
+.TP
+\fB\fB\-\-connections\fR\fP
+The number of TCP connections to use
+.TP
+\fB\fB\-\-concurrency\fR <default: \fI"1"\fR>\fP
+The number of concurrent calls per connection
+.TP
+\fB\fB\-\-rps\fR <default: \fI"0"\fR>\fP
+Limit on the number of requests per second. The default (0) is no limit.
+.TP
+\fB\fB\-\-statsd\fR\fP
+Optional host:port of a StatsD server to report metrics
+.SS Help Options
+.TP
+\fB\fB\-h\fR, \fB\-\-help\fR\fP
+Show this help message

--- a/man/yab.html
+++ b/man/yab.html
@@ -1,0 +1,175 @@
+<HTML>
+<HEAD>
+<TITLE>yab</TITLE>
+<meta charset="utf-8">
+</HEAD>
+<BODY>
+<H1>yab</H1>
+<HR>
+<PRE>
+<!-- Manpage converted by man2html 3.0.1 -->
+
+</PRE>
+<H2>SYNOPSIS</H2><PRE>
+       <B>yab</B> [&lt;service&gt; &lt;method&gt; &lt;body&gt;] [OPTIONS]
+
+
+</PRE>
+<H2>DESCRIPTION</H2><PRE>
+       yab  is  a  benchmarking  tool for TChannel and HTTP applications. It’s
+       primarily intended for Thrift applications but supports other encodings
+       like JSON and binary (raw).
+
+       It  can  be  used in a curl‐like fashion when benchmarking features are
+       disabled.
+
+
+
+</PRE>
+<H2>OPTIONS</H2><PRE>
+   <B>Application</B> <B>Options</B>
+       --<B>version</B>
+              Displays the application version
+
+   <B>Request</B> <B>Options</B>
+       Configures the request data and the encoding.
+
+       To make Thrift requests, specify a Thrift file and pass the Thrift ser‐
+       vice  and  procedure  to  the  method argument (‐m or ‐‐method) as Ser‐
+       vice::Method.
+         $ yab ‐p localhost:9787 kv ‐t kv.thrift ‐m KeyValue::Count ‐r ’{}’
+
+       You can also use positional arguments to specify the method and body:
+         $ yab ‐p localhost:9787  ‐t kv.thrift kv KeyValue::Count ’{}’
+
+       The TChannel health endpoint can be hit  without  specifying  a  Thrift
+       file by passing ‐‐health.
+
+       Thrift  requests  can  be specified as JSON or YAML. For example, for a
+       method defined as:
+         void addUser(1: string name, 2: i32 age)
+
+       You can pass the request as JSON: {"name": "Prashant", age: 100} or  as
+       YAML:
+         name: Prashant
+         age: 100
+
+       The  request  body  can  be  specified  on the command line using ‐r or
+       ‐‐request:
+         $ yab ‐p localhost:9787 ‐t kv.thrift  kv  KeyValue::Get  ‐r  ’{"key":
+       "hello"}’
+
+       Or it can be loaded from a file using ‐f or ‐‐file:
+         $ yab ‐p localhost:9787 ‐t kv.thrift kv KeyValue::Get ‐‐file req.yaml
+
+       Binary data can be specified in one of many ways:
+         ‐ As a string or an array of bytes: "data" or [100, 97, 116, 97]
+         ‐ As base64: {"base64": "ZGF0YQ=="}
+         ‐ Loaded from a file: {"file": "data.bin"}
+              Path of the .thrift file
+
+       -<B>m</B>, --<B>method</B>
+              The full Thrift method name (Svc::Method) to invoke
+
+       -<B>r</B>, --<B>request</B>
+              The request body, in JSON or YAML format
+
+       -<B>f</B>, --<B>file</B>
+              Path of a file containing the request body in JSON or YAML
+
+       --<B>headers</B>
+              The headers in JSON or YAML format
+
+       --<B>headers</B>-<B>file</B>
+              Path of a file containing the headers in JSON or YAML
+
+       --<B>health</B>
+              Hit the health endpoint, Meta::health
+
+       --<B>timeout</B> &lt;default: <I>"1s"</I>&gt;
+              The timeout for each request. E.g., 100ms, 0.5s, 1s. If no  unit
+              is specified, milliseconds are assumed.
+
+   <B>Transport</B> <B>Options</B>
+       Configures the network transport used to make requests.
+
+       yab  can target both TChannel and HTTP endpoints. To specify a TChannel
+       endpoint, specify the peer’s host and port:
+         $ yab ‐p localhost:9787 [options] or
+         $ yab ‐p tchannel://localhost:9787 [options]
+
+       For HTTP endpoints, specify the URL as the peer,
+         $ yab ‐p http://localhost:8080/thrift [options]
+
+       The Thrift encoded body will be POSTed to the specified URL.
+
+       Multiple peers can be specified using a peer list using ‐P  or  ‐‐peer‐
+       list.   When  making  a single request, a single peer from this list is
+       selected randomly.  When benchmarking, each  connection  will  randomly
+       select a peer.
+         $ yab ‐‐peer‐list hosts.json [options]
+
+
+       -<B>s</B>, --<B>service</B>
+              The TChannel/Hyperbahn service name
+
+       -<B>p</B>, --<B>peer</B>
+              The host:port of the service to call
+
+       -<B>P</B>, --<B>peer</B>-<B>list</B>
+              Path of a JSON or YAML file containing a list of host:ports
+
+       yab will make requests till either the maximum requests (‐n  or  ‐‐max‐
+       requests) or the maximum duration is reached.
+
+       You  can  control  the rate at which yab makes requests using the ‐‐rps
+       flag.
+
+       An example benchmark command might be:
+         yab ‐p localhost:9787 moe ‐‐health ‐n 100000 ‐d 10s ‐‐rps 1000
+
+       This would make requests at 1000 RPS until either the maximum number of
+       requests (100,000) or the maximum duration (10 seconds) is reached.
+
+       By  default,  yab  will  create multiple connections (defaulting to the
+       number of CPUs on the machine), but will only have one concurrent  call
+       per  connection.   The  number  of connections and concurrent calls per
+       connection can be controlled using ‐‐connections and ‐‐concurrency.
+
+
+       -<B>n</B>, --<B>max</B>-<B>requests</B> &lt;default: <I>"1000000"</I>&gt;
+              The maximum number of requests to make
+
+       -<B>d</B>, --<B>max</B>-<B>duration</B> &lt;default: <I>"0s"</I>&gt;
+              The maximum amount of time to run the benchmark for
+
+       --<B>cpus</B> The number of OS threads
+
+       --<B>connections</B>
+              The number of TCP connections to use
+
+       --<B>concurrency</B> &lt;default: <I>"1"</I>&gt;
+              The number of concurrent calls per connection
+
+       --<B>rps</B> &lt;default: <I>"0"</I>&gt;
+              Limit on the number of requests per second. The default  (0)  is
+              no limit.
+
+       --<B>statsd</B>
+              Optional host:port of a StatsD server to report metrics
+
+   <B>Help</B> <B>Options</B>
+       -<B>h</B>, --<B>help</B>
+              Show this help message
+
+
+
+                                  3 June 2016                           <B>yab(1)</B>
+</PRE>
+<HR>
+<ADDRESS>
+Man(1) output converted with
+<a href="http://www.oac.uci.edu/indiv/ehood/man2html.html">man2html</a>
+</ADDRESS>
+</BODY>
+</HTML>

--- a/options.go
+++ b/options.go
@@ -30,7 +30,7 @@ import (
 
 // Options are parsed from flags using go-flags.
 type Options struct {
-	ROpts          RequestOptions   `group:"request" description:"Configures an individual request."`
+	ROpts          RequestOptions   `group:"request"`
 	TOpts          TransportOptions `group:"transport"`
 	BOpts          BenchmarkOptions `group:"benchmark"`
 	DisplayVersion bool             `long:"version" description:"Displays the application version"`
@@ -68,8 +68,8 @@ type TransportOptions struct {
 
 // BenchmarkOptions are benchmark-specific options
 type BenchmarkOptions struct {
-	MaxRequests int           `short:"n" long:"maxRequests" default:"1000000" description:"The maximum number of requests to make"`
-	MaxDuration time.Duration `short:"d" long:"maxDuration" default:"0s" description:"The maximum amount of time to run the benchmark for"`
+	MaxRequests int           `short:"n" long:"max-requests" default:"1000000" description:"The maximum number of requests to make"`
+	MaxDuration time.Duration `short:"d" long:"max-duration" default:"0s" description:"The maximum amount of time to run the benchmark for"`
 
 	// NumCPUs is the value for GOMAXPROCS. The default value of 0 will not update GOMAXPROCS.
 	NumCPUs int `long:"cpus" description:"The number of OS threads"`


### PR DESCRIPTION
Add rules to generate the man page + HTML version, which we will push to a `gh-pages` branch so that the Github page is updated.

Also updated some benchmarking flags to use hyphens instead of camelCase which is the standard for flags.