### PR TITLE
benchmark: Round robin peer selection to balance connections

### DIFF
--- a/benchmark.go
+++ b/benchmark.go
@@ -82,7 +82,6 @@ func runBenchmark(out output, allOpts Options, m benchmarkMethod) {
 	out.Printf("  Max RPS:         %v\n", opts.RPS)
 
 	// Warm up number of connections.
-	// TODO: If we're making N connections, we should try to select N unique peers
 	connections, err := m.WarmTransports(numConns, allOpts.TOpts, opts.WarmupRequests)
 	if err != nil {
 		out.Fatalf("Failed to warmup connections for benchmark: %v", err)

--- a/server_util_test.go
+++ b/server_util_test.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/uber/tchannel-go"
@@ -108,6 +109,14 @@ func (methodsT) errorIf(f func() bool) handler {
 			Arg3: args.Arg3,
 		}, nil
 	}
+}
+
+func (methodsT) counter() (*int32, handler) {
+	var count int32
+	return &count, methods.errorIf(func() bool {
+		atomic.AddInt32(&count, 1)
+		return false
+	})
 }
 
 func echoServer(t *testing.T, method string, overrideResp []byte) string {


### PR DESCRIPTION
Previously, we relied on randomly picking a peer for each connection
which could lead to an imbalance. E.g., if there are 3 peers and 3
connections, there was no guarantee that all 3 peers would receive
a single connection.

Instead of picking randomly, round-robin the peers that can be used
for each connection (starting at a random offset) for better load
balancing.