### PR TITLE
better man-page support for pre-formatted code and bullet lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install_ci: install
 update_man:
 	go install .
 	yab --man-page > man/yab.1
-	nroff -Tascii -man man/yab.1 | man2html -title yab > man/yab.html
+	groff -man -T html man/yab.1 > man/yab.html
 	[[ -d ../yab_ghpages ]] && cp man/yab.html ../yab_ghpages/man.html
 	@echo "Please update gh-pages"
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install_ci: install
 update_man:
 	go install .
 	yab --man-page > man/yab.1
-	nroff -man man/yab.1 | man2html -title yab > man/yab.html
+	nroff -Tascii -man man/yab.1 | man2html -title yab > man/yab.html
 	[[ -d ../yab_ghpages ]] && cp man/yab.html ../yab_ghpages/man.html
 	@echo "Please update gh-pages"
 

--- a/doc.go
+++ b/doc.go
@@ -32,56 +32,70 @@ const _reqOptsDesc = `Configures the request data and the encoding.
 To make Thrift requests, specify a Thrift file and pass the Thrift
 service and procedure to the method argument (-m or --method) as
 Service::Method.
-  $ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
+
+	$ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
 
 You can also use positional arguments to specify the method and body:
-  $ yab -p localhost:9787  -t kv.thrift kv KeyValue::Count '{}'
+
+	$ yab -p localhost:9787  -t kv.thrift kv KeyValue::Count '{}'
 
 The TChannel health endpoint can be hit without specifying a Thrift file
 by passing --health.
 
 Thrift requests can be specified as JSON or YAML. For example, for a method
 defined as:
-  void addUser(1: string name, 2: i32 age)
+
+	void addUser(1: string name, 2: i32 age)
 
 You can pass the request as JSON: {"name": "Prashant", age: 100}
 or as YAML:
-  name: Prashant
-  age: 100
+
+	name: Prashant
+	age: 100
 
 The request body can be specified on the command line using -r or --request:
-  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get -r '{"key": "hello"}'
+
+	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get -r '{"key": "hello"}'
 
 Or it can be loaded from a file using -f or --file:
-  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
+
+	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
 
 Binary data can be specified in one of many ways:
-  - As a string or an array of bytes: "data" or [100, 97, 116, 97]
-  - As base64: {"base64": "ZGF0YQ=="}
-  - Loaded from a file: {"file": "data.bin"}
+	- As a string or an array of bytes: "data" or [100, 97, 116, 97]
+	- As base64: {"base64": "ZGF0YQ=="}
+	- Loaded from a file: {"file": "data.bin"}
 
 Examples:
-  $ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set -3 '{"key": "hello", "value": [100, 97, 116, 97]}'
-  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set -3 '{"key": "hello", "value": {"file": "data.bin"}}'
+
+	$ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set -3 '{"key": "hello", "value": [100, 97, 116, 97]}'
+
+	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set -3 '{"key": "hello", "value": {"file": "data.bin"}}'
 `
 
 const _transportOptsDesc = `Configures the network transport used to make requests.
 
 yab can target both TChannel and HTTP endpoints. To specify a TChannel endpoint,
 specify the peer's host and port:
-  $ yab -p localhost:9787 [options]
+
+	$ yab -p localhost:9787 [options]
+
 or
-  $ yab -p tchannel://localhost:9787 [options]
+
+	$ yab -p tchannel://localhost:9787 [options]
 
 For HTTP endpoints, specify the URL as the peer,
-  $ yab -p http://localhost:8080/thrift [options]
 
-The Thrift encoded body will be POSTed to the specified URL.
+	$ yab -p http://localhost:8080/thrift [options]
+
+The Thrift-encoded body will be POSTed to the specified URL.
 
 Multiple peers can be specified using a peer list using -P or --peer-list.
 When making a single request, a single peer from this list is selected randomly.
-When benchmarking, each connection will randomly select a peer.
-  $ yab --peer-list hosts.json [options]
+When benchmarking, connections will be established in a round-robin fashion,
+starting with a random peer.
+
+	$ yab --peer-list hosts.json [options]
 `
 
 const _benchmarkOptsDesc = `Configures benchmarking, which is disabled by default.
@@ -89,13 +103,14 @@ const _benchmarkOptsDesc = `Configures benchmarking, which is disabled by defaul
 By default, yab will only make a single request. To enable benchmarking, you
 must specify the maximum duration for the benchmark by passing -d or --max-duration.
 
-yab will make requests till either the maximum requests (-n or --max-requests)
+yab will make requests until either the maximum requests (-n or --max-requests)
 or the maximum duration is reached.
 
 You can control the rate at which yab makes requests using the --rps flag.
 
 An example benchmark command might be:
-  yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
+
+	yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
 
 This would make requests at 1000 RPS until either the maximum number of
 requests (100,000) or the maximum duration (10 seconds) is reached.

--- a/doc.go
+++ b/doc.go
@@ -19,7 +19,8 @@
 // THE SOFTWARE.
 
 // yab is a benchmarking tool for TChannel and HTTP applications.
-// It's primarily intended for Thrift applications but supports other encodings like JSON and binary (raw).
+// It's primarily intended for Thrift applications but supports other encodings
+// like JSON and binary (raw).
 //
 // It can be used in a curl-like fashion when benchmarking features are disabled.
 //
@@ -37,7 +38,7 @@ Service::Method.
 
 You can also use positional arguments to specify the method and body:
 
-	$ yab -p localhost:9787  -t kv.thrift kv KeyValue::Count '{}'
+	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Count '{}'
 
 The TChannel health endpoint can be hit without specifying a Thrift file
 by passing --health.
@@ -55,22 +56,25 @@ or as YAML:
 
 The request body can be specified on the command line using -r or --request:
 
-	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get -r '{"key": "hello"}'
+	$ yab -p localhost:9787 -t kv.thrift kv \
+	    KeyValue::Get -r '{"key": "hello"}'
 
 Or it can be loaded from a file using -f or --file:
 
 	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
 
 Binary data can be specified in one of many ways:
-	- As a string or an array of bytes: "data" or [100, 97, 116, 97]
-	- As base64: {"base64": "ZGF0YQ=="}
-	- Loaded from a file: {"file": "data.bin"}
+	* As a string or an array of bytes: "data" or [100, 97, 116, 97]
+	* As base64: {"base64": "ZGF0YQ=="}
+	* Loaded from a file: {"file": "data.bin"}
 
 Examples:
 
-	$ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set -3 '{"key": "hello", "value": [100, 97, 116, 97]}'
+	$ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set \
+	    -r '{"key": "hello", "value": [100, 97, 116, 97]}'
 
-	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set -3 '{"key": "hello", "value": {"file": "data.bin"}}'
+	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set \
+	    -r '{"key": "hello", "value": {"file": "data.bin"}}'
 `
 
 const _transportOptsDesc = `Configures the network transport used to make requests.
@@ -100,8 +104,8 @@ starting with a random peer.
 
 const _benchmarkOptsDesc = `Configures benchmarking, which is disabled by default.
 
-By default, yab will only make a single request. To enable benchmarking, you
-must specify the maximum duration for the benchmark by passing -d or --max-duration.
+By default, yab will only make a single request. To enable benchmarking,
+specify the maximum duration for the benchmark by passing -d or --max-duration.
 
 yab will make requests until either the maximum requests (-n or --max-requests)
 or the maximum duration is reached.
@@ -110,7 +114,7 @@ You can control the rate at which yab makes requests using the --rps flag.
 
 An example benchmark command might be:
 
-	yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
+	$ yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
 
 This would make requests at 1000 RPS until either the maximum number of
 requests (100,000) or the maximum duration (10 seconds) is reached.
@@ -120,3 +124,5 @@ CPUs on the machine), but will only have one concurrent call per connection.
 The number of connections and concurrent calls per connection can be controlled
 using --connections and --concurrency.
 `
+
+/* vim: set tabstop=8:softtabstop=8:shiftwidth=8:noexpandtab */

--- a/main_test.go
+++ b/main_test.go
@@ -360,3 +360,61 @@ func TestAlises(t *testing.T) {
 		}
 	}
 }
+
+func TestToGroff(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input: `
+not a bullet list
+
+	- bullet
+	- list
+
+not a bullet list`,
+			expected: `
+not a bullet list
+.PP
+.IP \[bu]
+bullet
+.IP \[bu]
+list
+.PP
+not a bullet list`,
+		},
+
+		{
+			input: `
+beginning
+
+	pre-formatted
+
+middle
+
+	pre-formatted
+	still pre-formatted
+
+end`,
+			expected: `
+beginning
+.PP
+.RS 0
+	pre-formatted
+.PP
+middle
+.PP
+.RS 0
+	pre-formatted
+.RS 0
+	still pre-formatted
+.PP
+end`,
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, toGroff(tt.input), tt.expected)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -370,8 +370,8 @@ func TestToGroff(t *testing.T) {
 			input: `
 not a bullet list
 
-	- bullet
-	- list
+	* bullet
+	* list
 
 not a bullet list`,
 			expected: `
@@ -400,15 +400,24 @@ end`,
 			expected: `
 beginning
 .PP
-.RS 0
-	pre-formatted
+.nf
+.RS
+pre-formatted
+.RE
+.fi
 .PP
 middle
 .PP
-.RS 0
-	pre-formatted
-.RS 0
-	still pre-formatted
+.nf
+.RS
+pre-formatted
+.RE
+.fi
+.nf
+.RS
+still pre-formatted
+.RE
+.fi
 .PP
 end`,
 		},

--- a/man/yab.1
+++ b/man/yab.1
@@ -1,4 +1,4 @@
-.TH yab 1 "30 June 2016"
+.TH yab 1 "8 July 2016"
 .SH NAME
 yab \- yet another benchmarker
 .SH SYNOPSIS
@@ -6,7 +6,7 @@ yab \- yet another benchmarker
 .SH DESCRIPTION
 
 yab is a benchmarking tool for TChannel and HTTP applications. It's primarily intended for Thrift applications but supports other encodings like JSON and binary (raw).
-
+.PP
 It can be used in a curl-like fashion when benchmarking features are disabled.
 
 .SH OPTIONS
@@ -16,41 +16,61 @@ It can be used in a curl-like fashion when benchmarking features are disabled.
 Displays the application version
 .SS Request Options
 Configures the request data and the encoding.
-
+.PP
 To make Thrift requests, specify a Thrift file and pass the Thrift
 service and procedure to the method argument (-m or --method) as
 Service::Method.
-  $ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
-
+.PP
+.RS 0
+	$ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
+.PP
 You can also use positional arguments to specify the method and body:
-  $ yab -p localhost:9787  -t kv.thrift kv KeyValue::Count '{}'
-
+.PP
+.RS 0
+	$ yab -p localhost:9787  -t kv.thrift kv KeyValue::Count '{}'
+.PP
 The TChannel health endpoint can be hit without specifying a Thrift file
 by passing --health.
-
+.PP
 Thrift requests can be specified as JSON or YAML. For example, for a method
 defined as:
-  void addUser(1: string name, 2: i32 age)
-
+.PP
+.RS 0
+	void addUser(1: string name, 2: i32 age)
+.PP
 You can pass the request as JSON: {"name": "Prashant", age: 100}
 or as YAML:
-  name: Prashant
-  age: 100
-
+.PP
+.RS 0
+	name: Prashant
+.RS 0
+	age: 100
+.PP
 The request body can be specified on the command line using -r or --request:
-  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get -r '{"key": "hello"}'
-
+.PP
+.RS 0
+	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get -r '{"key": "hello"}'
+.PP
 Or it can be loaded from a file using -f or --file:
-  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
-
+.PP
+.RS 0
+	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
+.PP
 Binary data can be specified in one of many ways:
-  - As a string or an array of bytes: "data" or [100, 97, 116, 97]
-  - As base64: {"base64": "ZGF0YQ=="}
-  - Loaded from a file: {"file": "data.bin"}
-
+.IP \\[bu]
+As a string or an array of bytes: "data" or [100, 97, 116, 97]
+.IP \\[bu]
+As base64: {"base64": "ZGF0YQ=="}
+.IP \\[bu]
+Loaded from a file: {"file": "data.bin"}
+.PP
 Examples:
-  $ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set -3 '{"key": "hello", "value": [100, 97, 116, 97]}'
-  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set -3 '{"key": "hello", "value": {"file": "data.bin"}}'
+.PP
+.RS 0
+	$ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set -3 '{"key": "hello", "value": [100, 97, 116, 97]}'
+.PP
+.RS 0
+	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set -3 '{"key": "hello", "value": {"file": "data.bin"}}'
 
 .TP
 \fB\fB\-e\fR, \fB\-\-encoding\fR\fP
@@ -81,22 +101,32 @@ Hit the health endpoint, Meta::health
 The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed.
 .SS Transport Options
 Configures the network transport used to make requests.
-
+.PP
 yab can target both TChannel and HTTP endpoints. To specify a TChannel endpoint,
 specify the peer's host and port:
-  $ yab -p localhost:9787 [options]
+.PP
+.RS 0
+	$ yab -p localhost:9787 [options]
+.PP
 or
-  $ yab -p tchannel://localhost:9787 [options]
-
+.PP
+.RS 0
+	$ yab -p tchannel://localhost:9787 [options]
+.PP
 For HTTP endpoints, specify the URL as the peer,
-  $ yab -p http://localhost:8080/thrift [options]
-
-The Thrift encoded body will be POSTed to the specified URL.
-
+.PP
+.RS 0
+	$ yab -p http://localhost:8080/thrift [options]
+.PP
+The Thrift-encoded body will be POSTed to the specified URL.
+.PP
 Multiple peers can be specified using a peer list using -P or --peer-list.
 When making a single request, a single peer from this list is selected randomly.
-When benchmarking, each connection will randomly select a peer.
-  $ yab --peer-list hosts.json [options]
+When benchmarking, connections will be established in a round-robin fashion,
+starting with a random peer.
+.PP
+.RS 0
+	$ yab --peer-list hosts.json [options]
 
 .TP
 \fB\fB\-s\fR, \fB\-\-service\fR\fP
@@ -115,21 +145,23 @@ Caller will override the default caller name (which is yab-$USER).
 Custom options for the specific transport being used
 .SS Benchmark Options
 Configures benchmarking, which is disabled by default.
-
+.PP
 By default, yab will only make a single request. To enable benchmarking, you
 must specify the maximum duration for the benchmark by passing -d or --max-duration.
-
-yab will make requests till either the maximum requests (-n or --max-requests)
+.PP
+yab will make requests until either the maximum requests (-n or --max-requests)
 or the maximum duration is reached.
-
+.PP
 You can control the rate at which yab makes requests using the --rps flag.
-
+.PP
 An example benchmark command might be:
-  yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
-
+.PP
+.RS 0
+	yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
+.PP
 This would make requests at 1000 RPS until either the maximum number of
 requests (100,000) or the maximum duration (10 seconds) is reached.
-
+.PP
 By default, yab will create multiple connections (defaulting to the number of
 CPUs on the machine), but will only have one concurrent call per connection.
 The number of connections and concurrent calls per connection can be controlled

--- a/man/yab.1
+++ b/man/yab.1
@@ -1,4 +1,4 @@
-.TH yab 1 "8 July 2016"
+.TH yab 1 "13 July 2016"
 .SH NAME
 yab \- yet another benchmarker
 .SH SYNOPSIS

--- a/man/yab.1
+++ b/man/yab.1
@@ -1,4 +1,4 @@
-.TH yab 1 "13 July 2016"
+.TH yab 1 "15 July 2016"
 .SH NAME
 yab \- yet another benchmarker
 .SH SYNOPSIS
@@ -21,13 +21,19 @@ To make Thrift requests, specify a Thrift file and pass the Thrift
 service and procedure to the method argument (-m or --method) as
 Service::Method.
 .PP
-.RS 0
-	$ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
+.nf
+.RS
+$ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
+.RE
+.fi
 .PP
 You can also use positional arguments to specify the method and body:
 .PP
-.RS 0
-	$ yab -p localhost:9787  -t kv.thrift kv KeyValue::Count '{}'
+.nf
+.RS
+$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Count '{}'
+.RE
+.fi
 .PP
 The TChannel health endpoint can be hit without specifying a Thrift file
 by passing --health.
@@ -35,26 +41,46 @@ by passing --health.
 Thrift requests can be specified as JSON or YAML. For example, for a method
 defined as:
 .PP
-.RS 0
-	void addUser(1: string name, 2: i32 age)
+.nf
+.RS
+void addUser(1: string name, 2: i32 age)
+.RE
+.fi
 .PP
 You can pass the request as JSON: {"name": "Prashant", age: 100}
 or as YAML:
 .PP
-.RS 0
-	name: Prashant
-.RS 0
-	age: 100
+.nf
+.RS
+name: Prashant
+.RE
+.fi
+.nf
+.RS
+age: 100
+.RE
+.fi
 .PP
 The request body can be specified on the command line using -r or --request:
 .PP
-.RS 0
-	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get -r '{"key": "hello"}'
+.nf
+.RS
+$ yab -p localhost:9787 -t kv.thrift kv \\
+.RE
+.fi
+.nf
+.RS
+    KeyValue::Get -r '{"key": "hello"}'
+.RE
+.fi
 .PP
 Or it can be loaded from a file using -f or --file:
 .PP
-.RS 0
-	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
+.nf
+.RS
+$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
+.RE
+.fi
 .PP
 Binary data can be specified in one of many ways:
 .IP \\[bu]
@@ -66,11 +92,27 @@ Loaded from a file: {"file": "data.bin"}
 .PP
 Examples:
 .PP
-.RS 0
-	$ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set -3 '{"key": "hello", "value": [100, 97, 116, 97]}'
+.nf
+.RS
+$ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set \\
+.RE
+.fi
+.nf
+.RS
+    -r '{"key": "hello", "value": [100, 97, 116, 97]}'
+.RE
+.fi
 .PP
-.RS 0
-	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set -3 '{"key": "hello", "value": {"file": "data.bin"}}'
+.nf
+.RS
+$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set \\
+.RE
+.fi
+.nf
+.RS
+    -r '{"key": "hello", "value": {"file": "data.bin"}}'
+.RE
+.fi
 
 .TP
 \fB\fB\-e\fR, \fB\-\-encoding\fR\fP
@@ -105,18 +147,27 @@ Configures the network transport used to make requests.
 yab can target both TChannel and HTTP endpoints. To specify a TChannel endpoint,
 specify the peer's host and port:
 .PP
-.RS 0
-	$ yab -p localhost:9787 [options]
+.nf
+.RS
+$ yab -p localhost:9787 [options]
+.RE
+.fi
 .PP
 or
 .PP
-.RS 0
-	$ yab -p tchannel://localhost:9787 [options]
+.nf
+.RS
+$ yab -p tchannel://localhost:9787 [options]
+.RE
+.fi
 .PP
 For HTTP endpoints, specify the URL as the peer,
 .PP
-.RS 0
-	$ yab -p http://localhost:8080/thrift [options]
+.nf
+.RS
+$ yab -p http://localhost:8080/thrift [options]
+.RE
+.fi
 .PP
 The Thrift-encoded body will be POSTed to the specified URL.
 .PP
@@ -125,8 +176,11 @@ When making a single request, a single peer from this list is selected randomly.
 When benchmarking, connections will be established in a round-robin fashion,
 starting with a random peer.
 .PP
-.RS 0
-	$ yab --peer-list hosts.json [options]
+.nf
+.RS
+$ yab --peer-list hosts.json [options]
+.RE
+.fi
 
 .TP
 \fB\fB\-s\fR, \fB\-\-service\fR\fP
@@ -146,8 +200,8 @@ Custom options for the specific transport being used
 .SS Benchmark Options
 Configures benchmarking, which is disabled by default.
 .PP
-By default, yab will only make a single request. To enable benchmarking, you
-must specify the maximum duration for the benchmark by passing -d or --max-duration.
+By default, yab will only make a single request. To enable benchmarking,
+specify the maximum duration for the benchmark by passing -d or --max-duration.
 .PP
 yab will make requests until either the maximum requests (-n or --max-requests)
 or the maximum duration is reached.
@@ -156,8 +210,11 @@ You can control the rate at which yab makes requests using the --rps flag.
 .PP
 An example benchmark command might be:
 .PP
-.RS 0
-	yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
+.nf
+.RS
+$ yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
+.RE
+.fi
 .PP
 This would make requests at 1000 RPS until either the maximum number of
 requests (100,000) or the maximum duration (10 seconds) is reached.

--- a/man/yab.html
+++ b/man/yab.html
@@ -1,181 +1,415 @@
-<HTML>
-<HEAD>
-<TITLE>yab</TITLE>
-</HEAD>
-<BODY>
-<H1>yab</H1>
-<HR>
-<PRE>
-<!-- Manpage converted by man2html 3.0.1 -->
+<!-- Creator     : groff version 1.19.2 -->
+<!-- CreationDate: Fri Jul 15 07:43:13 2016 -->
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta name="generator" content="groff -Thtml, see www.gnu.org">
+<meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
+<meta name="Content-Style" content="text/css">
+<style type="text/css">
+       p     { margin-top: 0; margin-bottom: 0; }
+       pre   { margin-top: 0; margin-bottom: 0; }
+       table { margin-top: 0; margin-bottom: 0; }
+</style>
+<title>yab</title>
 
-</PRE>
-<H2>SYNOPSIS</H2><PRE>
-       <B>yab</B> [&lt;service&gt; &lt;method&gt; &lt;body&gt;] [OPTIONS]
+</head>
+<body>
 
+<h1 align=center>yab</h1>
 
-</PRE>
-<H2>DESCRIPTION</H2><PRE>
-       yab  is  a  benchmarking  tool for TChannel and HTTP applications. It's
-       primarily intended for Thrift applications but supports other encodings
-       like JSON and binary (raw).
+<a href="#NAME">NAME</a><br>
+<a href="#SYNOPSIS">SYNOPSIS</a><br>
+<a href="#DESCRIPTION">DESCRIPTION</a><br>
+<a href="#OPTIONS">OPTIONS</a><br>
 
-       It  can  be  used in a curl-like fashion when benchmarking features are
-       disabled.
-
-
-
-</PRE>
-<H2>OPTIONS</H2><PRE>
-   <B>Application</B> <B>Options</B>
-       <B>--version</B>
-              Displays the application version
-
-   <B>Request</B> <B>Options</B>
-       Configures the request data and the encoding.
-
-       To make Thrift requests, specify a Thrift file and pass the Thrift ser-
-       vice  and  procedure  to  the  method argument (-m or --method) as Ser-
-       vice::Method.
-
-            $ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
-
-       You can also use positional arguments to specify the method and body:
-
-            $ yab -p localhost:9787  -t kv.thrift kv KeyValue::Count '{}'
-
-       The  TChannel  health  endpoint  can be hit without specifying a Thrift
-       file by passing --health.
-
-       Thrift requests can be specified as JSON or YAML. For  example,  for  a
-       method defined as:
-
-            void addUser(1: string name, 2: i32 age)
-
-       You  can pass the request as JSON: {"name": "Prashant", age: 100} or as
-       YAML:
-
-            name: Prashant
-            age: 100
-
-       The request body can be specified on  the  command  line  using  -r  or
-       --request:
-
-            $  yab -p localhost:9787 -t kv.thrift kv KeyValue::Get -r '{"key":
-       "hello"}'
-
-       Or it can be loaded from a file using -f or --file:
-
-       '{"key": "hello", "value": [100, 97, 116, 97]}'
-
-            $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set -3  '{"key":
-       "hello", "value": {"file": "data.bin"}}'
+<hr>
 
 
-       <B>-e</B>, <B>--encoding</B>
-              The  encoding  of  the  data,  options  are:  Thrift, JSON, raw.
-              Defaults to Thrift if the method contains '::' or a Thrift  file
-              is specified
-
-       <B>-t</B>, <B>--thrift</B>
-              Path of the .thrift file
-
-       <B>-m</B>, <B>--method</B>
-              The full Thrift method name (Svc::Method) to invoke
-
-       <B>-r</B>, <B>--request</B>
-              The request body, in JSON or YAML format
-
-       <B>-f</B>, <B>--file</B>
-              Path of a file containing the request body in JSON or YAML
-
-       <B>--headers</B>
-              The headers in JSON or YAML format
-
-       <B>--headers-file</B>
-              Path of a file containing the headers in JSON or YAML
-
-       <B>--health</B>
-              Hit the health endpoint, Meta::health
-
-       <B>--timeout</B> &lt;default: <I>"1s"</I>&gt;
-              The  timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit
-              is specified, milliseconds are assumed.
-
-   <B>Transport</B> <B>Options</B>
-       Configures the network transport used to make requests.
-
-       yab can target both TChannel and HTTP endpoints. To specify a  TChannel
-       endpoint, specify the peer's host and port:
-
-            $ yab -p localhost:9787 [options]
-
-       or
-
-            $ yab -p tchannel://localhost:9787 [options]
-
-       For HTTP endpoints, specify the URL as the peer,
-
-            $ yab -p http://localhost:8080/thrift [options]
-
-              The host:port of the service to call
-
-       <B>-P</B>, <B>--peer-list</B>
-              Path of a JSON or YAML file containing a list of host:ports
-
-       <B>--caller</B>
-              Caller  will  override  the  default  caller  name   (which   is
-              yab-$USER).
-
-       <B>--topt</B> Custom options for the specific transport being used
-
-   <B>Benchmark</B> <B>Options</B>
-       Configures benchmarking, which is disabled by default.
-
-       By  default,  yab will only make a single request. To enable benchmark-
-       ing, you must specify the maximum duration for the benchmark by passing
-       -d or --max-duration.
-
-       yab  will make requests until either the maximum requests (-n or --max-
-       requests) or the maximum duration is reached.
-
-       You can control the rate at which yab makes requests  using  the  --rps
-       flag.
-
-       An example benchmark command might be:
-
-            yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
-
-       This would make requests at 1000 RPS until either the maximum number of
-       requests (100,000) or the maximum duration (10 seconds) is reached.
-
-       By default, yab will create multiple  connections  (defaulting  to  the
-       number  of CPUs on the machine), but will only have one concurrent call
-       per connection.  The number of connections  and  concurrent  calls  per
-       connection can be controlled using --connections and --concurrency.
+<a name="NAME"></a>
+<h2>NAME</h2>
 
 
-       <B>-n</B>, <B>--max-requests</B> &lt;default: <I>"1000000"</I>&gt;
-              The maximum number of requests to make
+<p style="margin-left:11%; margin-top: 1em">yab &minus; yet
+another benchmarker</p>
 
-       <B>-d</B>, <B>--max-duration</B> &lt;default: <I>"0s"</I>&gt;
-              The maximum amount of time to run the benchmark for
+<a name="SYNOPSIS"></a>
+<h2>SYNOPSIS</h2>
 
-       <B>--cpus</B> The number of OS threads
 
-       <B>--connections</B>
-              The number of TCP connections to use
+<p style="margin-left:11%; margin-top: 1em"><b>yab</b>
+[&lt;service&gt; &lt;method&gt; &lt;body&gt;] [OPTIONS]</p>
 
-       <B>--warmup</B> &lt;default: <I>"10"</I>&gt;
-              The number of requests to make to warmup each connection
+<a name="DESCRIPTION"></a>
+<h2>DESCRIPTION</h2>
 
-       <B>--concurrency</B> &lt;default: <I>"1"</I>&gt;
 
-                                 13 July 2016                           <B>yab(1)</B>
-</PRE>
-<HR>
-<ADDRESS>
-Man(1) output converted with
-<a href="http://www.oac.uci.edu/indiv/ehood/man2html.html">man2html</a>
-</ADDRESS>
-</BODY>
-</HTML>
+<p style="margin-left:11%; margin-top: 1em">yab is a
+benchmarking tool for TChannel and HTTP applications.
+It&rsquo;s primarily intended for Thrift applications but
+supports other encodings like JSON and binary (raw).</p>
+
+<p style="margin-left:11%; margin-top: 1em">It can be used
+in a curl-like fashion when benchmarking features are
+disabled.</p>
+
+<a name="OPTIONS"></a>
+<h2>OPTIONS</h2>
+
+
+<p style="margin-left:11%; margin-top: 1em"><b>Application
+Options <br>
+&minus;&minus;version</b></p>
+
+<p style="margin-left:22%;">Displays the application
+version</p>
+
+<p style="margin-left:11%; margin-top: 1em"><b>Request
+Options</b> <br>
+Configures the request data and the encoding.</p>
+
+<p style="margin-left:11%; margin-top: 1em">To make Thrift
+requests, specify a Thrift file and pass the Thrift service
+and procedure to the method argument (-m or --method) as
+Service::Method.</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 kv -t kv.thrift -m KeyValue::Count -r
+&rsquo;{}&rsquo;</p>
+
+<p style="margin-left:11%; margin-top: 1em">You can also
+use positional arguments to specify the method and body:</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 -t kv.thrift kv KeyValue::Count
+&rsquo;{}&rsquo;</p>
+
+<p style="margin-left:11%; margin-top: 1em">The TChannel
+health endpoint can be hit without specifying a Thrift file
+by passing --health.</p>
+
+<p style="margin-left:11%; margin-top: 1em">Thrift requests
+can be specified as JSON or YAML. For example, for a method
+defined as:</p>
+
+<p style="margin-left:22%; margin-top: 1em">void addUser(1:
+string name, 2: i32 age)</p>
+
+<p style="margin-left:11%; margin-top: 1em">You can pass
+the request as JSON: {&quot;name&quot;:
+&quot;Prashant&quot;, age: 100} or as YAML:</p>
+
+<p style="margin-left:22%; margin-top: 1em">name: Prashant
+<br>
+age: 100</p>
+
+<p style="margin-left:11%; margin-top: 1em">The request
+body can be specified on the command line using -r or
+--request:</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 -t kv.thrift kv \ <br>
+KeyValue::Get -r &rsquo;{&quot;key&quot;:
+&quot;hello&quot;}&rsquo;</p>
+
+<p style="margin-left:11%; margin-top: 1em">Or it can be
+loaded from a file using -f or --file:</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 -t kv.thrift kv KeyValue::Get --file
+req.yaml</p>
+
+<p style="margin-left:11%; margin-top: 1em">Binary data can
+be specified in one of many ways:</p>
+
+<table width="100%" border=0 rules="none" frame="void"
+       cellspacing="0" cellpadding="0">
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="1%">
+
+
+<p style="margin-top: 1em" valign="top">&bull;</p></td>
+<td width="10%"></td>
+<td width="78%">
+
+
+<p style="margin-top: 1em" valign="top">As a string or an
+array of bytes: &quot;data&quot; or [100, 97, 116, 97]</p></td>
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="1%">
+
+
+<p style="margin-top: 1em" valign="top">&bull;</p></td>
+<td width="10%"></td>
+<td width="78%">
+
+
+<p style="margin-top: 1em" valign="top">As base64:
+{&quot;base64&quot;: &quot;ZGF0YQ==&quot;}</p></td>
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="1%">
+
+
+<p style="margin-top: 1em" valign="top">&bull;</p></td>
+<td width="10%"></td>
+<td width="78%">
+
+
+<p style="margin-top: 1em" valign="top">Loaded from a file:
+{&quot;file&quot;: &quot;data.bin&quot;}</p></td>
+</table>
+
+<p style="margin-left:11%; margin-top: 1em">Examples:</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 -t kv.thrift kv -m KeyValue::Set \ <br>
+-r &rsquo;{&quot;key&quot;: &quot;hello&quot;,
+&quot;value&quot;: [100, 97, 116, 97]}&rsquo;</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 -t kv.thrift kv KeyValue::Set \ <br>
+-r &rsquo;{&quot;key&quot;: &quot;hello&quot;,
+&quot;value&quot;: {&quot;file&quot;:
+&quot;data.bin&quot;}}&rsquo;</p>
+
+<p style="margin-left:11%;"><b>&minus;e</b>,
+<b>&minus;&minus;encoding</b></p>
+
+<p style="margin-left:22%;">The encoding of the data,
+options are: Thrift, JSON, raw. Defaults to Thrift if the
+method contains &rsquo;::&rsquo; or a Thrift file is
+specified</p>
+
+<p style="margin-left:11%;"><b>&minus;t</b>,
+<b>&minus;&minus;thrift</b></p>
+
+<p style="margin-left:22%;">Path of the .thrift file</p>
+
+<p style="margin-left:11%;"><b>&minus;m</b>,
+<b>&minus;&minus;method</b></p>
+
+<p style="margin-left:22%;">The full Thrift method name
+(Svc::Method) to invoke</p>
+
+<p style="margin-left:11%;"><b>&minus;r</b>,
+<b>&minus;&minus;request</b></p>
+
+<p style="margin-left:22%;">The request body, in JSON or
+YAML format</p>
+
+<p style="margin-left:11%;"><b>&minus;f</b>,
+<b>&minus;&minus;file</b></p>
+
+<p style="margin-left:22%;">Path of a file containing the
+request body in JSON or YAML</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;headers</b></p>
+
+<p style="margin-left:22%;">The headers in JSON or YAML
+format</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;headers-file</b></p>
+
+<p style="margin-left:22%;">Path of a file containing the
+headers in JSON or YAML</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;health</b></p>
+
+<p style="margin-left:22%;">Hit the health endpoint,
+Meta::health</p>
+
+<p style="margin-left:11%;"><b>&minus;&minus;timeout</b>
+&lt;default: <i>&quot;1s&quot;</i>&gt;</p>
+
+<p style="margin-left:22%;">The timeout for each request.
+E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds
+are assumed.</p>
+
+<p style="margin-left:11%; margin-top: 1em"><b>Transport
+Options</b> <br>
+Configures the network transport used to make requests.</p>
+
+<p style="margin-left:11%; margin-top: 1em">yab can target
+both TChannel and HTTP endpoints. To specify a TChannel
+endpoint, specify the peer&rsquo;s host and port:</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 [options]</p>
+
+<p style="margin-left:11%; margin-top: 1em">or</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+tchannel://localhost:9787 [options]</p>
+
+<p style="margin-left:11%; margin-top: 1em">For HTTP
+endpoints, specify the URL as the peer,</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+http://localhost:8080/thrift [options]</p>
+
+<p style="margin-left:11%; margin-top: 1em">The
+Thrift-encoded body will be POSTed to the specified URL.</p>
+
+<p style="margin-left:11%; margin-top: 1em">Multiple peers
+can be specified using a peer list using -P or --peer-list.
+When making a single request, a single peer from this list
+is selected randomly. When benchmarking, connections will be
+established in a round-robin fashion, starting with a random
+peer.</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab
+--peer-list hosts.json [options]</p>
+
+<p style="margin-left:11%;"><b>&minus;s</b>,
+<b>&minus;&minus;service</b></p>
+
+<p style="margin-left:22%;">The TChannel/Hyperbahn service
+name</p>
+
+<p style="margin-left:11%;"><b>&minus;p</b>,
+<b>&minus;&minus;peer</b></p>
+
+<p style="margin-left:22%;">The host:port of the service to
+call</p>
+
+<p style="margin-left:11%;"><b>&minus;P</b>,
+<b>&minus;&minus;peer-list</b></p>
+
+<p style="margin-left:22%;">Path of a JSON or YAML file
+containing a list of host:ports</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;caller</b></p>
+
+<p style="margin-left:22%;">Caller will override the
+default caller name (which is yab-$USER).</p>
+
+<table width="100%" border=0 rules="none" frame="void"
+       cellspacing="0" cellpadding="0">
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="9%">
+
+
+
+<p style="margin-top: 1em" valign="top"><b>&minus;&minus;topt</b></p> </td>
+<td width="2%"></td>
+<td width="78%">
+
+
+<p style="margin-top: 1em" valign="top">Custom options for
+the specific transport being used</p></td>
+</table>
+
+<p style="margin-left:11%; margin-top: 1em"><b>Benchmark
+Options</b> <br>
+Configures benchmarking, which is disabled by default.</p>
+
+<p style="margin-left:11%; margin-top: 1em">By default, yab
+will only make a single request. To enable benchmarking,
+specify the maximum duration for the benchmark by passing -d
+or --max-duration.</p>
+
+<p style="margin-left:11%; margin-top: 1em">yab will make
+requests until either the maximum requests (-n or
+--max-requests) or the maximum duration is reached.</p>
+
+<p style="margin-left:11%; margin-top: 1em">You can control
+the rate at which yab makes requests using the --rps
+flag.</p>
+
+<p style="margin-left:11%; margin-top: 1em">An example
+benchmark command might be:</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 moe --health -n 100000 -d 10s --rps 1000</p>
+
+<p style="margin-left:11%; margin-top: 1em">This would make
+requests at 1000 RPS until either the maximum number of
+requests (100,000) or the maximum duration (10 seconds) is
+reached.</p>
+
+<p style="margin-left:11%; margin-top: 1em">By default, yab
+will create multiple connections (defaulting to the number
+of CPUs on the machine), but will only have one concurrent
+call per connection. The number of connections and
+concurrent calls per connection can be controlled using
+--connections and --concurrency. <b><br>
+&minus;n</b>, <b>&minus;&minus;max-requests</b> &lt;default:
+<i>&quot;1000000&quot;</i>&gt;</p>
+
+<p style="margin-left:22%;">The maximum number of requests
+to make</p>
+
+<p style="margin-left:11%;"><b>&minus;d</b>,
+<b>&minus;&minus;max-duration</b> &lt;default:
+<i>&quot;0s&quot;</i>&gt;</p>
+
+<p style="margin-left:22%;">The maximum amount of time to
+run the benchmark for</p>
+
+<table width="100%" border=0 rules="none" frame="void"
+       cellspacing="0" cellpadding="0">
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="9%">
+
+
+
+<p style="margin-top: 1em" valign="top"><b>&minus;&minus;cpus</b></p> </td>
+<td width="2%"></td>
+<td width="36%">
+
+
+<p style="margin-top: 1em" valign="top">The number of OS
+threads</p> </td>
+<td width="42%">
+</td>
+</table>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;connections</b></p>
+
+<p style="margin-left:22%;">The number of TCP connections
+to use</p>
+
+<p style="margin-left:11%;"><b>&minus;&minus;warmup</b>
+&lt;default: <i>&quot;10&quot;</i>&gt;</p>
+
+<p style="margin-left:22%;">The number of requests to make
+to warmup each connection</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;concurrency</b>
+&lt;default: <i>&quot;1&quot;</i>&gt;</p>
+
+<p style="margin-left:22%;">The number of concurrent calls
+per connection</p>
+
+<p style="margin-left:11%;"><b>&minus;&minus;rps</b>
+&lt;default: <i>&quot;0&quot;</i>&gt;</p>
+
+<p style="margin-left:22%;">Limit on the number of requests
+per second. The default (0) is no limit.</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;statsd</b></p>
+
+<p style="margin-left:22%;">Optional host:port of a StatsD
+server to report metrics</p>
+
+<p style="margin-left:11%; margin-top: 1em"><b>Help Options
+<br>
+&minus;h</b>, <b>&minus;&minus;help</b></p>
+
+<p style="margin-left:22%;">Show this help message</p>
+<hr>
+</body>
+</html>

--- a/man/yab.html
+++ b/man/yab.html
@@ -1,7 +1,6 @@
 <HTML>
 <HEAD>
 <TITLE>yab</TITLE>
-<meta charset="utf-8">
 </HEAD>
 <BODY>
 <H1>yab</H1>
@@ -28,7 +27,7 @@
 </PRE>
 <H2>OPTIONS</H2><PRE>
    <B>Application</B> <B>Options</B>
-       --<B>version</B>
+       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>version</B>
               Displays the application version
 
    <B>Request</B> <B>Options</B>
@@ -37,137 +36,141 @@
        To make Thrift requests, specify a Thrift file and pass the Thrift serâ€
        vice  and  procedure  to  the  method argument (â€m or â€â€method) as Serâ€
        vice::Method.
-         $ yab â€p localhost:9787 kv â€t kv.thrift â€m KeyValue::Count â€r â€™{}â€™
+
+            $ yab â€p localhost:9787 kv â€t kv.thrift â€m KeyValue::Count â€r â€™{}â€™
 
        You can also use positional arguments to specify the method and body:
-         $ yab â€p localhost:9787  â€t kv.thrift kv KeyValue::Count â€™{}â€™
 
-       The TChannel health endpoint can be hit  without  specifying  a  Thrift
+            $ yab â€p localhost:9787  â€t kv.thrift kv KeyValue::Count â€™{}â€™
+
+       The  TChannel  health  endpoint  can be hit without specifying a Thrift
        file by passing â€â€health.
 
-       Thrift  requests  can  be specified as JSON or YAML. For example, for a
+       Thrift requests can be specified as JSON or YAML. For  example,  for  a
        method defined as:
-         void addUser(1: string name, 2: i32 age)
 
-       You can pass the request as JSON: {"name": "Prashant", age: 100} or  as
+            void addUser(1: string name, 2: i32 age)
+
+       You  can pass the request as JSON: {"name": "Prashant", age: 100} or as
        YAML:
-         name: Prashant
-         age: 100
 
-       The  request  body  can  be  specified  on the command line using â€r or
+            name: Prashant
+            age: 100
+
+       The request body can be specified on  the  command  line  using  â€r  or
        â€â€request:
-         $ yab â€p localhost:9787 â€t kv.thrift  kv  KeyValue::Get  â€r  â€™{"key":
+
+            $  yab â€p localhost:9787 â€t kv.thrift kv KeyValue::Get â€r â€™{"key":
        "hello"}â€™
 
        Or it can be loaded from a file using â€f or â€â€file:
-         $ yab â€p localhost:9787 â€t kv.thrift kv KeyValue::Get â€â€file req.yaml
 
-       Binary data can be specified in one of many ways:
-         â€ As a string or an array of bytes: "data" or [100, 97, 116, 97]
-         â€ As base64: {"base64": "ZGF0YQ=="}
-         â€ Loaded from a file: {"file": "data.bin"}
+       â€™{"key": "hello", "value": [100, 97, 116, 97]}â€™
+
+            $ yab â€p localhost:9787 â€t kv.thrift kv KeyValue::Set â€3  â€™{"key":
+       "hello", "value": {"file": "data.bin"}}â€™
+
+
+       âˆ<B>â</B>ˆ’<B>e</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>encoding</B>
+              The  encoding  of  the  data,  options  are:  Thrift, JSON, raw.
+              Defaults to Thrift if the method contains â€™::â€™ or a Thrift  file
+              is specified
+
+       âˆ<B>â</B>ˆ’<B>t</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>thrift</B>
               Path of the .thrift file
 
-       -<B>m</B>, --<B>method</B>
+       âˆ<B>â</B>ˆ’<B>m</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>method</B>
               The full Thrift method name (Svc::Method) to invoke
 
-       -<B>r</B>, --<B>request</B>
+       âˆ<B>â</B>ˆ’<B>r</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>request</B>
               The request body, in JSON or YAML format
 
-       -<B>f</B>, --<B>file</B>
+       âˆ<B>â</B>ˆ’<B>f</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>file</B>
               Path of a file containing the request body in JSON or YAML
 
-       --<B>headers</B>
+       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>headers</B>
               The headers in JSON or YAML format
 
-       --<B>headers</B>-<B>file</B>
+       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>headers</B>â€<B>â</B>€<B>file</B>
               Path of a file containing the headers in JSON or YAML
 
-       --<B>health</B>
+       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>health</B>
               Hit the health endpoint, Meta::health
 
-       --<B>timeout</B> &lt;default: <I>"1s"</I>&gt;
-              The timeout for each request. E.g., 100ms, 0.5s, 1s. If no  unit
+       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>timeout</B> &lt;default: <I>"1s"</I>&gt;
+              The  timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit
               is specified, milliseconds are assumed.
 
    <B>Transport</B> <B>Options</B>
        Configures the network transport used to make requests.
 
-       yab  can target both TChannel and HTTP endpoints. To specify a TChannel
+       yab can target both TChannel and HTTP endpoints. To specify a  TChannel
        endpoint, specify the peerâ€™s host and port:
-         $ yab â€p localhost:9787 [options] or
-         $ yab â€p tchannel://localhost:9787 [options]
+
+            $ yab â€p localhost:9787 [options]
+
+       or
+
+            $ yab â€p tchannel://localhost:9787 [options]
 
        For HTTP endpoints, specify the URL as the peer,
-         $ yab â€p http://localhost:8080/thrift [options]
 
-       The Thrift encoded body will be POSTed to the specified URL.
+            $ yab â€p http://localhost:8080/thrift [options]
 
-       Multiple peers can be specified using a peer list using â€P  or  â€â€peerâ€
-       list.   When  making  a single request, a single peer from this list is
-       selected randomly.  When benchmarking, each  connection  will  randomly
-       select a peer.
-         $ yab â€â€peerâ€list hosts.json [options]
-
-
-       -<B>s</B>, --<B>service</B>
-              The TChannel/Hyperbahn service name
-
-       -<B>p</B>, --<B>peer</B>
               The host:port of the service to call
 
-       -<B>P</B>, --<B>peer</B>-<B>list</B>
+       âˆ<B>â</B>ˆ’<B>P</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>peer</B>â€<B>â</B>€<B>list</B>
               Path of a JSON or YAML file containing a list of host:ports
 
-       yab will make requests till either the maximum requests (â€n  or  â€â€maxâ€
+       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>caller</B>
+              Caller  will  override  the  default  caller  name   (which   is
+              yabâ€$USER).
+
+       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>topt</B> Custom options for the specific transport being used
+
+   <B>Benchmark</B> <B>Options</B>
+       Configures benchmarking, which is disabled by default.
+
+       By  default,  yab will only make a single request. To enable benchmarkâ€
+       ing, you must specify the maximum duration for the benchmark by passing
+       â€d or â€â€maxâ€duration.
+
+       yab  will make requests until either the maximum requests (â€n or â€â€maxâ€
        requests) or the maximum duration is reached.
 
-       You  can  control  the rate at which yab makes requests using the â€â€rps
+       You can control the rate at which yab makes requests  using  the  â€â€rps
        flag.
 
        An example benchmark command might be:
-         yab â€p localhost:9787 moe â€â€health â€n 100000 â€d 10s â€â€rps 1000
+
+            yab â€p localhost:9787 moe â€â€health â€n 100000 â€d 10s â€â€rps 1000
 
        This would make requests at 1000 RPS until either the maximum number of
        requests (100,000) or the maximum duration (10 seconds) is reached.
 
-       By  default,  yab  will  create multiple connections (defaulting to the
-       number of CPUs on the machine), but will only have one concurrent  call
-       per  connection.   The  number  of connections and concurrent calls per
+       By default, yab will create multiple  connections  (defaulting  to  the
+       number  of CPUs on the machine), but will only have one concurrent call
+       per connection.  The number of connections  and  concurrent  calls  per
        connection can be controlled using â€â€connections and â€â€concurrency.
 
 
-       -<B>n</B>, --<B>max</B>-<B>requests</B> &lt;default: <I>"1000000"</I>&gt;
+       âˆ<B>â</B>ˆ’<B>n</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>max</B>â€<B>â</B>€<B>requests</B> &lt;default: <I>"1000000"</I>&gt;
               The maximum number of requests to make
 
-       -<B>d</B>, --<B>max</B>-<B>duration</B> &lt;default: <I>"0s"</I>&gt;
+       âˆ<B>â</B>ˆ’<B>d</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>max</B>â€<B>â</B>€<B>duration</B> &lt;default: <I>"0s"</I>&gt;
               The maximum amount of time to run the benchmark for
 
-       --<B>cpus</B> The number of OS threads
+       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>cpus</B> The number of OS threads
 
-       --<B>connections</B>
+       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>connections</B>
               The number of TCP connections to use
 
-       --<B>warmup</B> &lt;default: <I>"10"</I>&gt;
+       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>warmup</B> &lt;default: <I>"10"</I>&gt;
               The number of requests to make to warmup each connection
 
-       --<B>concurrency</B> &lt;default: <I>"1"</I>&gt;
-              The number of concurrent calls per connection
+       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>concurrency</B> &lt;default: <I>"1"</I>&gt;
 
-       --<B>rps</B> &lt;default: <I>"0"</I>&gt;
-              Limit on the number of requests per second. The default  (0)  is
-              no limit.
-
-       --<B>statsd</B>
-              Optional host:port of a StatsD server to report metrics
-
-   <B>Help</B> <B>Options</B>
-       -<B>h</B>, --<B>help</B>
-              Show this help message
-
-
-
-                                 30 June 2016                           <B>yab(1)</B>
+                                  8 July 2016                           <B>yab(1)</B>
 </PRE>
 <HR>
 <ADDRESS>

--- a/man/yab.html
+++ b/man/yab.html
@@ -15,11 +15,11 @@
 
 </PRE>
 <H2>DESCRIPTION</H2><PRE>
-       yab  is  a  benchmarking  tool for TChannel and HTTP applications. Itâ€™s
+       yab  is  a  benchmarking  tool for TChannel and HTTP applications. It's
        primarily intended for Thrift applications but supports other encodings
        like JSON and binary (raw).
 
-       It  can  be  used in a curlâ€like fashion when benchmarking features are
+       It  can  be  used in a curl-like fashion when benchmarking features are
        disabled.
 
 
@@ -27,24 +27,24 @@
 </PRE>
 <H2>OPTIONS</H2><PRE>
    <B>Application</B> <B>Options</B>
-       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>version</B>
+       <B>--version</B>
               Displays the application version
 
    <B>Request</B> <B>Options</B>
        Configures the request data and the encoding.
 
-       To make Thrift requests, specify a Thrift file and pass the Thrift serâ€
-       vice  and  procedure  to  the  method argument (â€m or â€â€method) as Serâ€
+       To make Thrift requests, specify a Thrift file and pass the Thrift ser-
+       vice  and  procedure  to  the  method argument (-m or --method) as Ser-
        vice::Method.
 
-            $ yab â€p localhost:9787 kv â€t kv.thrift â€m KeyValue::Count â€r â€™{}â€™
+            $ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
 
        You can also use positional arguments to specify the method and body:
 
-            $ yab â€p localhost:9787  â€t kv.thrift kv KeyValue::Count â€™{}â€™
+            $ yab -p localhost:9787  -t kv.thrift kv KeyValue::Count '{}'
 
        The  TChannel  health  endpoint  can be hit without specifying a Thrift
-       file by passing â€â€health.
+       file by passing --health.
 
        Thrift requests can be specified as JSON or YAML. For  example,  for  a
        method defined as:
@@ -57,47 +57,47 @@
             name: Prashant
             age: 100
 
-       The request body can be specified on  the  command  line  using  â€r  or
-       â€â€request:
+       The request body can be specified on  the  command  line  using  -r  or
+       --request:
 
-            $  yab â€p localhost:9787 â€t kv.thrift kv KeyValue::Get â€r â€™{"key":
-       "hello"}â€™
+            $  yab -p localhost:9787 -t kv.thrift kv KeyValue::Get -r '{"key":
+       "hello"}'
 
-       Or it can be loaded from a file using â€f or â€â€file:
+       Or it can be loaded from a file using -f or --file:
 
-       â€™{"key": "hello", "value": [100, 97, 116, 97]}â€™
+       '{"key": "hello", "value": [100, 97, 116, 97]}'
 
-            $ yab â€p localhost:9787 â€t kv.thrift kv KeyValue::Set â€3  â€™{"key":
-       "hello", "value": {"file": "data.bin"}}â€™
+            $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set -3  '{"key":
+       "hello", "value": {"file": "data.bin"}}'
 
 
-       âˆ<B>â</B>ˆ’<B>e</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>encoding</B>
+       <B>-e</B>, <B>--encoding</B>
               The  encoding  of  the  data,  options  are:  Thrift, JSON, raw.
-              Defaults to Thrift if the method contains â€™::â€™ or a Thrift  file
+              Defaults to Thrift if the method contains '::' or a Thrift  file
               is specified
 
-       âˆ<B>â</B>ˆ’<B>t</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>thrift</B>
+       <B>-t</B>, <B>--thrift</B>
               Path of the .thrift file
 
-       âˆ<B>â</B>ˆ’<B>m</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>method</B>
+       <B>-m</B>, <B>--method</B>
               The full Thrift method name (Svc::Method) to invoke
 
-       âˆ<B>â</B>ˆ’<B>r</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>request</B>
+       <B>-r</B>, <B>--request</B>
               The request body, in JSON or YAML format
 
-       âˆ<B>â</B>ˆ’<B>f</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>file</B>
+       <B>-f</B>, <B>--file</B>
               Path of a file containing the request body in JSON or YAML
 
-       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>headers</B>
+       <B>--headers</B>
               The headers in JSON or YAML format
 
-       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>headers</B>â€<B>â</B>€<B>file</B>
+       <B>--headers-file</B>
               Path of a file containing the headers in JSON or YAML
 
-       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>health</B>
+       <B>--health</B>
               Hit the health endpoint, Meta::health
 
-       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>timeout</B> &lt;default: <I>"1s"</I>&gt;
+       <B>--timeout</B> &lt;default: <I>"1s"</I>&gt;
               The  timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit
               is specified, milliseconds are assumed.
 
@@ -105,45 +105,45 @@
        Configures the network transport used to make requests.
 
        yab can target both TChannel and HTTP endpoints. To specify a  TChannel
-       endpoint, specify the peerâ€™s host and port:
+       endpoint, specify the peer's host and port:
 
-            $ yab â€p localhost:9787 [options]
+            $ yab -p localhost:9787 [options]
 
        or
 
-            $ yab â€p tchannel://localhost:9787 [options]
+            $ yab -p tchannel://localhost:9787 [options]
 
        For HTTP endpoints, specify the URL as the peer,
 
-            $ yab â€p http://localhost:8080/thrift [options]
+            $ yab -p http://localhost:8080/thrift [options]
 
               The host:port of the service to call
 
-       âˆ<B>â</B>ˆ’<B>P</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>peer</B>â€<B>â</B>€<B>list</B>
+       <B>-P</B>, <B>--peer-list</B>
               Path of a JSON or YAML file containing a list of host:ports
 
-       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>caller</B>
+       <B>--caller</B>
               Caller  will  override  the  default  caller  name   (which   is
-              yabâ€$USER).
+              yab-$USER).
 
-       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>topt</B> Custom options for the specific transport being used
+       <B>--topt</B> Custom options for the specific transport being used
 
    <B>Benchmark</B> <B>Options</B>
        Configures benchmarking, which is disabled by default.
 
-       By  default,  yab will only make a single request. To enable benchmarkâ€
+       By  default,  yab will only make a single request. To enable benchmark-
        ing, you must specify the maximum duration for the benchmark by passing
-       â€d or â€â€maxâ€duration.
+       -d or --max-duration.
 
-       yab  will make requests until either the maximum requests (â€n or â€â€maxâ€
+       yab  will make requests until either the maximum requests (-n or --max-
        requests) or the maximum duration is reached.
 
-       You can control the rate at which yab makes requests  using  the  â€â€rps
+       You can control the rate at which yab makes requests  using  the  --rps
        flag.
 
        An example benchmark command might be:
 
-            yab â€p localhost:9787 moe â€â€health â€n 100000 â€d 10s â€â€rps 1000
+            yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
 
        This would make requests at 1000 RPS until either the maximum number of
        requests (100,000) or the maximum duration (10 seconds) is reached.
@@ -151,26 +151,26 @@
        By default, yab will create multiple  connections  (defaulting  to  the
        number  of CPUs on the machine), but will only have one concurrent call
        per connection.  The number of connections  and  concurrent  calls  per
-       connection can be controlled using â€â€connections and â€â€concurrency.
+       connection can be controlled using --connections and --concurrency.
 
 
-       âˆ<B>â</B>ˆ’<B>n</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>max</B>â€<B>â</B>€<B>requests</B> &lt;default: <I>"1000000"</I>&gt;
+       <B>-n</B>, <B>--max-requests</B> &lt;default: <I>"1000000"</I>&gt;
               The maximum number of requests to make
 
-       âˆ<B>â</B>ˆ’<B>d</B>, âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>max</B>â€<B>â</B>€<B>duration</B> &lt;default: <I>"0s"</I>&gt;
+       <B>-d</B>, <B>--max-duration</B> &lt;default: <I>"0s"</I>&gt;
               The maximum amount of time to run the benchmark for
 
-       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>cpus</B> The number of OS threads
+       <B>--cpus</B> The number of OS threads
 
-       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>connections</B>
+       <B>--connections</B>
               The number of TCP connections to use
 
-       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>warmup</B> &lt;default: <I>"10"</I>&gt;
+       <B>--warmup</B> &lt;default: <I>"10"</I>&gt;
               The number of requests to make to warmup each connection
 
-       âˆ<B>â</B>ˆ’âˆ<B>â</B>ˆ’<B>concurrency</B> &lt;default: <I>"1"</I>&gt;
+       <B>--concurrency</B> &lt;default: <I>"1"</I>&gt;
 
-                                  8 July 2016                           <B>yab(1)</B>
+                                 13 July 2016                           <B>yab(1)</B>
 </PRE>
 <HR>
 <ADDRESS>


### PR DESCRIPTION
This fixes some mis-alignment issues I noticed with our example code. Basically now if we start a line with a tab we'll try to re-write it in a more groff-friendly way.

I think the version of `man2html` that I'm using doesn't correctly support UTF-8 because it's messing up the charset.

@prashantv 