### PR TITLE
Add option to disable enveloping

### DIFF
--- a/bench_method_test.go
+++ b/bench_method_test.go
@@ -44,7 +44,7 @@ func benchmarkMethodForTest(t *testing.T, methodString string, p transport.Proto
 	serializer, err := NewSerializer(rOpts)
 	require.NoError(t, err, "Failed to create Thrift serializer")
 
-	serializer = withTransportSerializer(p, serializer)
+	serializer = withTransportSerializer(p, serializer, rOpts)
 
 	req, err := serializer.Request(nil)
 	require.NoError(t, err, "Failed to serialize Thrift body")

--- a/main.go
+++ b/main.go
@@ -222,7 +222,7 @@ func runWithOptions(opts Options, out output) {
 		out.Fatalf("Failed while parsing options: %v\n", err)
 	}
 
-	serializer = withTransportSerializer(transport.Protocol(), serializer)
+	serializer = withTransportSerializer(transport.Protocol(), serializer, opts.ROpts)
 
 	// req is the transport.Request that will be used to make a call.
 	req, err := serializer.Request(reqInput)
@@ -275,8 +275,10 @@ type noEnveloper interface {
 
 // withTransportSerializer may modify the serializer for the transport used.
 // E.g. Thrift payloads are not enveloped when used with TChannel.
-func withTransportSerializer(p transport.Protocol, s encoding.Serializer) encoding.Serializer {
-	if p == transport.TChannel && s.Encoding() == encoding.Thrift {
+func withTransportSerializer(p transport.Protocol, s encoding.Serializer, rOpts RequestOptions) encoding.Serializer {
+	switch {
+	case p == transport.TChannel && s.Encoding() == encoding.Thrift,
+		rOpts.DisableThriftEnvelopes:
 		s = s.(noEnveloper).WithoutEnvelopes()
 	}
 	return s

--- a/options.go
+++ b/options.go
@@ -39,15 +39,16 @@ type Options struct {
 
 // RequestOptions are request related options
 type RequestOptions struct {
-	Encoding    encoding.Encoding `short:"e" long:"encoding" description:"The encoding of the data, options are: Thrift, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified"`
-	ThriftFile  string            `short:"t" long:"thrift" description:"Path of the .thrift file"`
-	MethodName  string            `short:"m" long:"method" description:"The full Thrift method name (Svc::Method) to invoke"`
-	RequestJSON string            `short:"r" long:"request" description:"The request body, in JSON or YAML format"`
-	RequestFile string            `short:"f" long:"file" description:"Path of a file containing the request body in JSON or YAML"`
-	HeadersJSON string            `long:"headers" description:"The headers in JSON or YAML format"`
-	HeadersFile string            `long:"headers-file" description:"Path of a file containing the headers in JSON or YAML"`
-	Health      bool              `long:"health" description:"Hit the health endpoint, Meta::health"`
-	Timeout     timeMillisFlag    `long:"timeout" default:"1s" description:"The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
+	Encoding               encoding.Encoding `short:"e" long:"encoding" description:"The encoding of the data, options are: Thrift, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified"`
+	ThriftFile             string            `short:"t" long:"thrift" description:"Path of the .thrift file"`
+	MethodName             string            `short:"m" long:"method" description:"The full Thrift method name (Svc::Method) to invoke"`
+	RequestJSON            string            `short:"r" long:"request" description:"The request body, in JSON or YAML format"`
+	RequestFile            string            `short:"f" long:"file" description:"Path of a file containing the request body in JSON or YAML"`
+	HeadersJSON            string            `long:"headers" description:"The headers in JSON or YAML format"`
+	HeadersFile            string            `long:"headers-file" description:"Path of a file containing the headers in JSON or YAML"`
+	Health                 bool              `long:"health" description:"Hit the health endpoint, Meta::health"`
+	Timeout                timeMillisFlag    `long:"timeout" default:"1s" description:"The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
+	DisableThriftEnvelopes bool              `long:"disable-thrift-envelope" description:"Disables Thrift envelopes (disabled by default for TChannel)"`
 
 	// These are aliases for tcurl compatibility.
 	Aliases struct {


### PR DESCRIPTION
Some HTTP services don't use Thrift envelopes, so add option to disable
envelopes.