### PR TITLE
Release latest yab changes as 0.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install_ci: install
 update_man:
 	go install .
 	yab --man-page > man/yab.1
-	nroff -man man/yab.1 | man2html -title yab > man/yab.html
+	groff -man -T html man/yab.1 > man/yab.html
 	[[ -d ../yab_ghpages ]] && cp man/yab.html ../yab_ghpages/man.html
 	@echo "Please update gh-pages"
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ supports making Thrift requests to both HTTP and TChannel services.
 **NOTE**: HTTP support is not cross-compatible with Apache Thrift yet, due to
 missing message envelope support.
 
-`yab` is currently in **alpha** status.
+`yab` is currently in **beta** status.
 
 
 ### Installing

--- a/bench_method_test.go
+++ b/bench_method_test.go
@@ -44,7 +44,7 @@ func benchmarkMethodForTest(t *testing.T, methodString string, p transport.Proto
 	serializer, err := NewSerializer(rOpts)
 	require.NoError(t, err, "Failed to create Thrift serializer")
 
-	serializer = withTransportSerializer(p, serializer)
+	serializer = withTransportSerializer(p, serializer, rOpts)
 
 	req, err := serializer.Request(nil)
 	require.NoError(t, err, "Failed to serialize Thrift body")

--- a/benchmark.go
+++ b/benchmark.go
@@ -82,7 +82,6 @@ func runBenchmark(out output, allOpts Options, m benchmarkMethod) {
 	out.Printf("  Max RPS:         %v\n", opts.RPS)
 
 	// Warm up number of connections.
-	// TODO: If we're making N connections, we should try to select N unique peers
 	connections, err := m.WarmTransports(numConns, allOpts.TOpts, opts.WarmupRequests)
 	if err != nil {
 		out.Fatalf("Failed to warmup connections for benchmark: %v", err)

--- a/doc.go
+++ b/doc.go
@@ -19,7 +19,8 @@
 // THE SOFTWARE.
 
 // yab is a benchmarking tool for TChannel and HTTP applications.
-// It's primarily intended for Thrift applications but supports other encodings like JSON and binary (raw).
+// It's primarily intended for Thrift applications but supports other encodings
+// like JSON and binary (raw).
 //
 // It can be used in a curl-like fashion when benchmarking features are disabled.
 //
@@ -32,70 +33,88 @@ const _reqOptsDesc = `Configures the request data and the encoding.
 To make Thrift requests, specify a Thrift file and pass the Thrift
 service and procedure to the method argument (-m or --method) as
 Service::Method.
-  $ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
+
+	$ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
 
 You can also use positional arguments to specify the method and body:
-  $ yab -p localhost:9787  -t kv.thrift kv KeyValue::Count '{}'
+
+	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Count '{}'
 
 The TChannel health endpoint can be hit without specifying a Thrift file
 by passing --health.
 
 Thrift requests can be specified as JSON or YAML. For example, for a method
 defined as:
-  void addUser(1: string name, 2: i32 age)
+
+	void addUser(1: string name, 2: i32 age)
 
 You can pass the request as JSON: {"name": "Prashant", age: 100}
 or as YAML:
-  name: Prashant
-  age: 100
+
+	name: Prashant
+	age: 100
 
 The request body can be specified on the command line using -r or --request:
-  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get -r '{"key": "hello"}'
+
+	$ yab -p localhost:9787 -t kv.thrift kv \
+	    KeyValue::Get -r '{"key": "hello"}'
 
 Or it can be loaded from a file using -f or --file:
-  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
+
+	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
 
 Binary data can be specified in one of many ways:
-  - As a string or an array of bytes: "data" or [100, 97, 116, 97]
-  - As base64: {"base64": "ZGF0YQ=="}
-  - Loaded from a file: {"file": "data.bin"}
+	* As a string or an array of bytes: "data" or [100, 97, 116, 97]
+	* As base64: {"base64": "ZGF0YQ=="}
+	* Loaded from a file: {"file": "data.bin"}
 
 Examples:
-  $ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set -3 '{"key": "hello", "value": [100, 97, 116, 97]}'
-  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set -3 '{"key": "hello", "value": {"file": "data.bin"}}'
+
+	$ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set \
+	    -r '{"key": "hello", "value": [100, 97, 116, 97]}'
+
+	$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set \
+	    -r '{"key": "hello", "value": {"file": "data.bin"}}'
 `
 
 const _transportOptsDesc = `Configures the network transport used to make requests.
 
 yab can target both TChannel and HTTP endpoints. To specify a TChannel endpoint,
 specify the peer's host and port:
-  $ yab -p localhost:9787 [options]
+
+	$ yab -p localhost:9787 [options]
+
 or
-  $ yab -p tchannel://localhost:9787 [options]
+
+	$ yab -p tchannel://localhost:9787 [options]
 
 For HTTP endpoints, specify the URL as the peer,
-  $ yab -p http://localhost:8080/thrift [options]
 
-The Thrift encoded body will be POSTed to the specified URL.
+	$ yab -p http://localhost:8080/thrift [options]
+
+The Thrift-encoded body will be POSTed to the specified URL.
 
 Multiple peers can be specified using a peer list using -P or --peer-list.
 When making a single request, a single peer from this list is selected randomly.
-When benchmarking, each connection will randomly select a peer.
-  $ yab --peer-list hosts.json [options]
+When benchmarking, connections will be established in a round-robin fashion,
+starting with a random peer.
+
+	$ yab --peer-list hosts.json [options]
 `
 
 const _benchmarkOptsDesc = `Configures benchmarking, which is disabled by default.
 
-By default, yab will only make a single request. To enable benchmarking, you
-must specify the maximum duration for the benchmark by passing -d or --max-duration.
+By default, yab will only make a single request. To enable benchmarking,
+specify the maximum duration for the benchmark by passing -d or --max-duration.
 
-yab will make requests till either the maximum requests (-n or --max-requests)
+yab will make requests until either the maximum requests (-n or --max-requests)
 or the maximum duration is reached.
 
 You can control the rate at which yab makes requests using the --rps flag.
 
 An example benchmark command might be:
-  yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
+
+	$ yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
 
 This would make requests at 1000 RPS until either the maximum number of
 requests (100,000) or the maximum duration (10 seconds) is reached.
@@ -105,3 +124,5 @@ CPUs on the machine), but will only have one concurrent call per connection.
 The number of connections and concurrent calls per connection can be controlled
 using --connections and --concurrency.
 `
+
+/* vim: set tabstop=8:softtabstop=8:shiftwidth=8:noexpandtab */

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fd05ccae439afc6f74a6c576c98a279826a6111f91bf36db475bccf3bbd3f9eb
-updated: 2016-06-01T08:45:45.209063968-07:00
+hash: 0badca56130abf1fc7d731d7e6b3adc1e974185c6d63431ac32ec36c7671e2a6
+updated: 2016-07-08T16:43:42.1722035-07:00
 imports:
 - name: github.com/apache/thrift
   version: 39a09ac5e49481d39dd1bcb6757ffe182e3df20a
@@ -9,6 +9,8 @@ imports:
   version: 725f76bd0300c1f9562e76fd94c27aa17e41243e
   subpackages:
   - statsd
+- name: github.com/casimir/xdg-go
+  version: 372ccc2180dab73316615641d5617c5ed3e35529
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -28,3 +28,4 @@ import:
   version: master
   subpackages:
   - lib/go/thrift
+- package: github.com/casimir/xdg-go

--- a/main.go
+++ b/main.go
@@ -25,6 +25,8 @@ import (
 	"errors"
 	"log"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/yarpc/yab/encoding"
@@ -69,20 +71,38 @@ func main() {
 
 var errExit = errors.New("sentinel error used to exit cleanly")
 
+func toGroff(s string) string {
+	// Expand tabbed lines beginning with "-" as items in a bullet list.
+	s = strings.Replace(s, "\n\t* ", "\n.IP \\[bu]\n", -1 /* all occurences */)
+
+	// Two newlines start a new paragraph.
+	s = strings.Replace(s, "\n\n", "\n.PP\n", -1)
+
+	// Lines beginning with a tab are interpreted as example code.
+	//
+	// See http://liw.fi/manpages/ for an explanation of these
+	// commands -- tl;dr: turn of paragraph filling and indent the
+	// block one level.
+	indentRegexp := regexp.MustCompile(`\t(.*)\n`)
+	s = indentRegexp.ReplaceAllString(s, ".nf\n.RS\n$1\n.RE\n.fi\n")
+
+	return s
+}
+
 func getOptions(args []string, out output) (*Options, error) {
 	opts := newOptions()
 	parser := flags.NewParser(opts, flags.HelpFlag|flags.PassDoubleDash)
 	parser.Usage = "[<service> <method> <body>] [OPTIONS]"
 	parser.ShortDescription = "yet another benchmarker"
-	parser.LongDescription = `
+	parser.LongDescription = toGroff(`
 yab is a benchmarking tool for TChannel and HTTP applications. It's primarily intended for Thrift applications but supports other encodings like JSON and binary (raw).
 
 It can be used in a curl-like fashion when benchmarking features are disabled.
-`
+`)
 
-	setGroupDesc(parser, "request", "Request Options", _reqOptsDesc)
-	setGroupDesc(parser, "transport", "Transport Options", _transportOptsDesc)
-	setGroupDesc(parser, "benchmark", "Benchmark Options", _benchmarkOptsDesc)
+	setGroupDesc(parser, "request", "Request Options", toGroff(_reqOptsDesc))
+	setGroupDesc(parser, "transport", "Transport Options", toGroff(_transportOptsDesc))
+	setGroupDesc(parser, "benchmark", "Benchmark Options", toGroff(_benchmarkOptsDesc))
 
 	// If there are no arguments specified, write the help.
 	if len(args) == 0 {

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func getOptions(args []string, out output) (*Options, error) {
 	parser, opts := newParser()
 	parser.Usage = "[<service> <method> <body>] [OPTIONS]"
 	parser.ShortDescription = "yet another benchmarker"
-	parser.LongDescription = toGroff(`
+	parser.LongDescription = `
 yab is a benchmarking tool for TChannel and HTTP applications. It's primarily intended for Thrift applications but supports other encodings like JSON and binary (raw).
 
 It can be used in a curl-like fashion when benchmarking features are disabled.
@@ -115,11 +115,7 @@ Default options can be specified in a ~/.config/yab/defaults.ini file with conte
 
 	[benchmark]
 	warmup = 10
-`)
-
-	setGroupDesc(parser, "request", "Request Options", toGroff(_reqOptsDesc))
-	setGroupDesc(parser, "transport", "Transport Options", toGroff(_transportOptsDesc))
-	setGroupDesc(parser, "benchmark", "Benchmark Options", toGroff(_benchmarkOptsDesc))
+`
 
 	// If there are no arguments specified, write the help.
 	if len(args) == 0 {
@@ -150,6 +146,10 @@ Default options can be specified in a ~/.config/yab/defaults.ini file with conte
 	}
 
 	if opts.ManPage {
+		parser.LongDescription = toGroff(parser.LongDescription)
+		setGroupDesc(parser, "request", "Request Options", toGroff(_reqOptsDesc))
+		setGroupDesc(parser, "transport", "Transport Options", toGroff(_transportOptsDesc))
+		setGroupDesc(parser, "benchmark", "Benchmark Options", toGroff(_benchmarkOptsDesc))
 		parser.WriteManPage(os.Stdout)
 		return opts, errExit
 	}

--- a/main.go
+++ b/main.go
@@ -222,7 +222,7 @@ func runWithOptions(opts Options, out output) {
 		out.Fatalf("Failed while parsing options: %v\n", err)
 	}
 
-	serializer = withTransportSerializer(transport.Protocol(), serializer)
+	serializer = withTransportSerializer(transport.Protocol(), serializer, opts.ROpts)
 
 	// req is the transport.Request that will be used to make a call.
 	req, err := serializer.Request(reqInput)
@@ -275,8 +275,10 @@ type noEnveloper interface {
 
 // withTransportSerializer may modify the serializer for the transport used.
 // E.g. Thrift payloads are not enveloped when used with TChannel.
-func withTransportSerializer(p transport.Protocol, s encoding.Serializer) encoding.Serializer {
-	if p == transport.TChannel && s.Encoding() == encoding.Thrift {
+func withTransportSerializer(p transport.Protocol, s encoding.Serializer, rOpts RequestOptions) encoding.Serializer {
+	switch {
+	case p == transport.TChannel && s.Encoding() == encoding.Thrift,
+		rOpts.DisableThriftEnvelopes:
 		s = s.(noEnveloper).WithoutEnvelopes()
 	}
 	return s

--- a/main_test.go
+++ b/main_test.go
@@ -226,6 +226,9 @@ func TestHelpOutput(t *testing.T) {
 		buf, out := getOutput(t)
 		parseAndRun(out)
 		assert.Contains(t, buf.String(), "Usage:", "Expected help output")
+
+		// Make sure we didn't leak any groff from the man-page output.
+		assert.NotContains(t, buf.String(), ".PP")
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -360,3 +360,70 @@ func TestAlises(t *testing.T) {
 		}
 	}
 }
+
+func TestToGroff(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input: `
+not a bullet list
+
+	* bullet
+	* list
+
+not a bullet list`,
+			expected: `
+not a bullet list
+.PP
+.IP \[bu]
+bullet
+.IP \[bu]
+list
+.PP
+not a bullet list`,
+		},
+
+		{
+			input: `
+beginning
+
+	pre-formatted
+
+middle
+
+	pre-formatted
+	still pre-formatted
+
+end`,
+			expected: `
+beginning
+.PP
+.nf
+.RS
+pre-formatted
+.RE
+.fi
+.PP
+middle
+.PP
+.nf
+.RS
+pre-formatted
+.RE
+.fi
+.nf
+.RS
+still pre-formatted
+.RE
+.fi
+.PP
+end`,
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, toGroff(tt.input), tt.expected)
+	}
+}

--- a/man/yab.1
+++ b/man/yab.1
@@ -8,6 +8,41 @@ yab \- yet another benchmarker
 yab is a benchmarking tool for TChannel and HTTP applications. It's primarily intended for Thrift applications but supports other encodings like JSON and binary (raw).
 .PP
 It can be used in a curl-like fashion when benchmarking features are disabled.
+.PP
+Default options can be specified in a ~/.config/yab/defaults.ini file with contents similar to this:
+.PP
+.nf
+.RS
+[request]
+.RE
+.fi
+.nf
+.RS
+timeout = 2s
+.RE
+.fi
+.PP
+.nf
+.RS
+[transport]
+.RE
+.fi
+.nf
+.RS
+peer-list = "/path/to/peer/list.json"
+.RE
+.fi
+.PP
+.nf
+.RS
+[benchmark]
+.RE
+.fi
+.nf
+.RS
+warmup = 10
+.RE
+.fi
 
 .SH OPTIONS
 .SS Application Options

--- a/man/yab.1
+++ b/man/yab.1
@@ -1,4 +1,4 @@
-.TH yab 1 "30 June 2016"
+.TH yab 1 "15 July 2016"
 .SH NAME
 yab \- yet another benchmarker
 .SH SYNOPSIS
@@ -6,7 +6,7 @@ yab \- yet another benchmarker
 .SH DESCRIPTION
 
 yab is a benchmarking tool for TChannel and HTTP applications. It's primarily intended for Thrift applications but supports other encodings like JSON and binary (raw).
-
+.PP
 It can be used in a curl-like fashion when benchmarking features are disabled.
 
 .SH OPTIONS
@@ -16,41 +16,103 @@ It can be used in a curl-like fashion when benchmarking features are disabled.
 Displays the application version
 .SS Request Options
 Configures the request data and the encoding.
-
+.PP
 To make Thrift requests, specify a Thrift file and pass the Thrift
 service and procedure to the method argument (-m or --method) as
 Service::Method.
-  $ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
-
+.PP
+.nf
+.RS
+$ yab -p localhost:9787 kv -t kv.thrift -m KeyValue::Count -r '{}'
+.RE
+.fi
+.PP
 You can also use positional arguments to specify the method and body:
-  $ yab -p localhost:9787  -t kv.thrift kv KeyValue::Count '{}'
-
+.PP
+.nf
+.RS
+$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Count '{}'
+.RE
+.fi
+.PP
 The TChannel health endpoint can be hit without specifying a Thrift file
 by passing --health.
-
+.PP
 Thrift requests can be specified as JSON or YAML. For example, for a method
 defined as:
-  void addUser(1: string name, 2: i32 age)
-
+.PP
+.nf
+.RS
+void addUser(1: string name, 2: i32 age)
+.RE
+.fi
+.PP
 You can pass the request as JSON: {"name": "Prashant", age: 100}
 or as YAML:
-  name: Prashant
-  age: 100
-
+.PP
+.nf
+.RS
+name: Prashant
+.RE
+.fi
+.nf
+.RS
+age: 100
+.RE
+.fi
+.PP
 The request body can be specified on the command line using -r or --request:
-  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get -r '{"key": "hello"}'
-
+.PP
+.nf
+.RS
+$ yab -p localhost:9787 -t kv.thrift kv \\
+.RE
+.fi
+.nf
+.RS
+    KeyValue::Get -r '{"key": "hello"}'
+.RE
+.fi
+.PP
 Or it can be loaded from a file using -f or --file:
-  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
-
+.PP
+.nf
+.RS
+$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
+.RE
+.fi
+.PP
 Binary data can be specified in one of many ways:
-  - As a string or an array of bytes: "data" or [100, 97, 116, 97]
-  - As base64: {"base64": "ZGF0YQ=="}
-  - Loaded from a file: {"file": "data.bin"}
-
+.IP \\[bu]
+As a string or an array of bytes: "data" or [100, 97, 116, 97]
+.IP \\[bu]
+As base64: {"base64": "ZGF0YQ=="}
+.IP \\[bu]
+Loaded from a file: {"file": "data.bin"}
+.PP
 Examples:
-  $ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set -3 '{"key": "hello", "value": [100, 97, 116, 97]}'
-  $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set -3 '{"key": "hello", "value": {"file": "data.bin"}}'
+.PP
+.nf
+.RS
+$ yab -p localhost:9787 -t kv.thrift kv -m KeyValue::Set \\
+.RE
+.fi
+.nf
+.RS
+    -r '{"key": "hello", "value": [100, 97, 116, 97]}'
+.RE
+.fi
+.PP
+.nf
+.RS
+$ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set \\
+.RE
+.fi
+.nf
+.RS
+    -r '{"key": "hello", "value": {"file": "data.bin"}}'
+.RE
+.fi
 
 .TP
 \fB\fB\-e\fR, \fB\-\-encoding\fR\fP
@@ -81,22 +143,44 @@ Hit the health endpoint, Meta::health
 The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed.
 .SS Transport Options
 Configures the network transport used to make requests.
-
+.PP
 yab can target both TChannel and HTTP endpoints. To specify a TChannel endpoint,
 specify the peer's host and port:
-  $ yab -p localhost:9787 [options]
+.PP
+.nf
+.RS
+$ yab -p localhost:9787 [options]
+.RE
+.fi
+.PP
 or
-  $ yab -p tchannel://localhost:9787 [options]
-
+.PP
+.nf
+.RS
+$ yab -p tchannel://localhost:9787 [options]
+.RE
+.fi
+.PP
 For HTTP endpoints, specify the URL as the peer,
-  $ yab -p http://localhost:8080/thrift [options]
-
-The Thrift encoded body will be POSTed to the specified URL.
-
+.PP
+.nf
+.RS
+$ yab -p http://localhost:8080/thrift [options]
+.RE
+.fi
+.PP
+The Thrift-encoded body will be POSTed to the specified URL.
+.PP
 Multiple peers can be specified using a peer list using -P or --peer-list.
 When making a single request, a single peer from this list is selected randomly.
-When benchmarking, each connection will randomly select a peer.
-  $ yab --peer-list hosts.json [options]
+When benchmarking, connections will be established in a round-robin fashion,
+starting with a random peer.
+.PP
+.nf
+.RS
+$ yab --peer-list hosts.json [options]
+.RE
+.fi
 
 .TP
 \fB\fB\-s\fR, \fB\-\-service\fR\fP
@@ -115,21 +199,26 @@ Caller will override the default caller name (which is yab-$USER).
 Custom options for the specific transport being used
 .SS Benchmark Options
 Configures benchmarking, which is disabled by default.
-
-By default, yab will only make a single request. To enable benchmarking, you
-must specify the maximum duration for the benchmark by passing -d or --max-duration.
-
-yab will make requests till either the maximum requests (-n or --max-requests)
+.PP
+By default, yab will only make a single request. To enable benchmarking,
+specify the maximum duration for the benchmark by passing -d or --max-duration.
+.PP
+yab will make requests until either the maximum requests (-n or --max-requests)
 or the maximum duration is reached.
-
+.PP
 You can control the rate at which yab makes requests using the --rps flag.
-
+.PP
 An example benchmark command might be:
-  yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
-
+.PP
+.nf
+.RS
+$ yab -p localhost:9787 moe --health -n 100000 -d 10s --rps 1000
+.RE
+.fi
+.PP
 This would make requests at 1000 RPS until either the maximum number of
 requests (100,000) or the maximum duration (10 seconds) is reached.
-
+.PP
 By default, yab will create multiple connections (defaulting to the number of
 CPUs on the machine), but will only have one concurrent call per connection.
 The number of connections and concurrent calls per connection can be controlled

--- a/man/yab.html
+++ b/man/yab.html
@@ -1,178 +1,415 @@
-<HTML>
-<HEAD>
-<TITLE>yab</TITLE>
-<meta charset="utf-8">
-</HEAD>
-<BODY>
-<H1>yab</H1>
-<HR>
-<PRE>
-<!-- Manpage converted by man2html 3.0.1 -->
+<!-- Creator     : groff version 1.19.2 -->
+<!-- CreationDate: Fri Jul 15 07:43:13 2016 -->
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta name="generator" content="groff -Thtml, see www.gnu.org">
+<meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
+<meta name="Content-Style" content="text/css">
+<style type="text/css">
+       p     { margin-top: 0; margin-bottom: 0; }
+       pre   { margin-top: 0; margin-bottom: 0; }
+       table { margin-top: 0; margin-bottom: 0; }
+</style>
+<title>yab</title>
 
-</PRE>
-<H2>SYNOPSIS</H2><PRE>
-       <B>yab</B> [&lt;service&gt; &lt;method&gt; &lt;body&gt;] [OPTIONS]
+</head>
+<body>
 
+<h1 align=center>yab</h1>
 
-</PRE>
-<H2>DESCRIPTION</H2><PRE>
-       yab  is  a  benchmarking  tool for TChannel and HTTP applications. It’s
-       primarily intended for Thrift applications but supports other encodings
-       like JSON and binary (raw).
+<a href="#NAME">NAME</a><br>
+<a href="#SYNOPSIS">SYNOPSIS</a><br>
+<a href="#DESCRIPTION">DESCRIPTION</a><br>
+<a href="#OPTIONS">OPTIONS</a><br>
 
-       It  can  be  used in a curl‐like fashion when benchmarking features are
-       disabled.
-
-
-
-</PRE>
-<H2>OPTIONS</H2><PRE>
-   <B>Application</B> <B>Options</B>
-       --<B>version</B>
-              Displays the application version
-
-   <B>Request</B> <B>Options</B>
-       Configures the request data and the encoding.
-
-       To make Thrift requests, specify a Thrift file and pass the Thrift ser‐
-       vice  and  procedure  to  the  method argument (‐m or ‐‐method) as Ser‐
-       vice::Method.
-         $ yab ‐p localhost:9787 kv ‐t kv.thrift ‐m KeyValue::Count ‐r ’{}’
-
-       You can also use positional arguments to specify the method and body:
-         $ yab ‐p localhost:9787  ‐t kv.thrift kv KeyValue::Count ’{}’
-
-       The TChannel health endpoint can be hit  without  specifying  a  Thrift
-       file by passing ‐‐health.
-
-       Thrift  requests  can  be specified as JSON or YAML. For example, for a
-       method defined as:
-         void addUser(1: string name, 2: i32 age)
-
-       You can pass the request as JSON: {"name": "Prashant", age: 100} or  as
-       YAML:
-         name: Prashant
-         age: 100
-
-       The  request  body  can  be  specified  on the command line using ‐r or
-       ‐‐request:
-         $ yab ‐p localhost:9787 ‐t kv.thrift  kv  KeyValue::Get  ‐r  ’{"key":
-       "hello"}’
-
-       Or it can be loaded from a file using ‐f or ‐‐file:
-         $ yab ‐p localhost:9787 ‐t kv.thrift kv KeyValue::Get ‐‐file req.yaml
-
-       Binary data can be specified in one of many ways:
-         ‐ As a string or an array of bytes: "data" or [100, 97, 116, 97]
-         ‐ As base64: {"base64": "ZGF0YQ=="}
-         ‐ Loaded from a file: {"file": "data.bin"}
-              Path of the .thrift file
-
-       -<B>m</B>, --<B>method</B>
-              The full Thrift method name (Svc::Method) to invoke
-
-       -<B>r</B>, --<B>request</B>
-              The request body, in JSON or YAML format
-
-       -<B>f</B>, --<B>file</B>
-              Path of a file containing the request body in JSON or YAML
-
-       --<B>headers</B>
-              The headers in JSON or YAML format
-
-       --<B>headers</B>-<B>file</B>
-              Path of a file containing the headers in JSON or YAML
-
-       --<B>health</B>
-              Hit the health endpoint, Meta::health
-
-       --<B>timeout</B> &lt;default: <I>"1s"</I>&gt;
-              The timeout for each request. E.g., 100ms, 0.5s, 1s. If no  unit
-              is specified, milliseconds are assumed.
-
-   <B>Transport</B> <B>Options</B>
-       Configures the network transport used to make requests.
-
-       yab  can target both TChannel and HTTP endpoints. To specify a TChannel
-       endpoint, specify the peer’s host and port:
-         $ yab ‐p localhost:9787 [options] or
-         $ yab ‐p tchannel://localhost:9787 [options]
-
-       For HTTP endpoints, specify the URL as the peer,
-         $ yab ‐p http://localhost:8080/thrift [options]
-
-       The Thrift encoded body will be POSTed to the specified URL.
-
-       Multiple peers can be specified using a peer list using ‐P  or  ‐‐peer‐
-       list.   When  making  a single request, a single peer from this list is
-       selected randomly.  When benchmarking, each  connection  will  randomly
-       select a peer.
-         $ yab ‐‐peer‐list hosts.json [options]
+<hr>
 
 
-       -<B>s</B>, --<B>service</B>
-              The TChannel/Hyperbahn service name
-
-       -<B>p</B>, --<B>peer</B>
-              The host:port of the service to call
-
-       -<B>P</B>, --<B>peer</B>-<B>list</B>
-              Path of a JSON or YAML file containing a list of host:ports
-
-       yab will make requests till either the maximum requests (‐n  or  ‐‐max‐
-       requests) or the maximum duration is reached.
-
-       You  can  control  the rate at which yab makes requests using the ‐‐rps
-       flag.
-
-       An example benchmark command might be:
-         yab ‐p localhost:9787 moe ‐‐health ‐n 100000 ‐d 10s ‐‐rps 1000
-
-       This would make requests at 1000 RPS until either the maximum number of
-       requests (100,000) or the maximum duration (10 seconds) is reached.
-
-       By  default,  yab  will  create multiple connections (defaulting to the
-       number of CPUs on the machine), but will only have one concurrent  call
-       per  connection.   The  number  of connections and concurrent calls per
-       connection can be controlled using ‐‐connections and ‐‐concurrency.
+<a name="NAME"></a>
+<h2>NAME</h2>
 
 
-       -<B>n</B>, --<B>max</B>-<B>requests</B> &lt;default: <I>"1000000"</I>&gt;
-              The maximum number of requests to make
+<p style="margin-left:11%; margin-top: 1em">yab &minus; yet
+another benchmarker</p>
 
-       -<B>d</B>, --<B>max</B>-<B>duration</B> &lt;default: <I>"0s"</I>&gt;
-              The maximum amount of time to run the benchmark for
-
-       --<B>cpus</B> The number of OS threads
-
-       --<B>connections</B>
-              The number of TCP connections to use
-
-       --<B>warmup</B> &lt;default: <I>"10"</I>&gt;
-              The number of requests to make to warmup each connection
-
-       --<B>concurrency</B> &lt;default: <I>"1"</I>&gt;
-              The number of concurrent calls per connection
-
-       --<B>rps</B> &lt;default: <I>"0"</I>&gt;
-              Limit on the number of requests per second. The default  (0)  is
-              no limit.
-
-       --<B>statsd</B>
-              Optional host:port of a StatsD server to report metrics
-
-   <B>Help</B> <B>Options</B>
-       -<B>h</B>, --<B>help</B>
-              Show this help message
+<a name="SYNOPSIS"></a>
+<h2>SYNOPSIS</h2>
 
 
+<p style="margin-left:11%; margin-top: 1em"><b>yab</b>
+[&lt;service&gt; &lt;method&gt; &lt;body&gt;] [OPTIONS]</p>
 
-                                 30 June 2016                           <B>yab(1)</B>
-</PRE>
-<HR>
-<ADDRESS>
-Man(1) output converted with
-<a href="http://www.oac.uci.edu/indiv/ehood/man2html.html">man2html</a>
-</ADDRESS>
-</BODY>
-</HTML>
+<a name="DESCRIPTION"></a>
+<h2>DESCRIPTION</h2>
+
+
+<p style="margin-left:11%; margin-top: 1em">yab is a
+benchmarking tool for TChannel and HTTP applications.
+It&rsquo;s primarily intended for Thrift applications but
+supports other encodings like JSON and binary (raw).</p>
+
+<p style="margin-left:11%; margin-top: 1em">It can be used
+in a curl-like fashion when benchmarking features are
+disabled.</p>
+
+<a name="OPTIONS"></a>
+<h2>OPTIONS</h2>
+
+
+<p style="margin-left:11%; margin-top: 1em"><b>Application
+Options <br>
+&minus;&minus;version</b></p>
+
+<p style="margin-left:22%;">Displays the application
+version</p>
+
+<p style="margin-left:11%; margin-top: 1em"><b>Request
+Options</b> <br>
+Configures the request data and the encoding.</p>
+
+<p style="margin-left:11%; margin-top: 1em">To make Thrift
+requests, specify a Thrift file and pass the Thrift service
+and procedure to the method argument (-m or --method) as
+Service::Method.</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 kv -t kv.thrift -m KeyValue::Count -r
+&rsquo;{}&rsquo;</p>
+
+<p style="margin-left:11%; margin-top: 1em">You can also
+use positional arguments to specify the method and body:</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 -t kv.thrift kv KeyValue::Count
+&rsquo;{}&rsquo;</p>
+
+<p style="margin-left:11%; margin-top: 1em">The TChannel
+health endpoint can be hit without specifying a Thrift file
+by passing --health.</p>
+
+<p style="margin-left:11%; margin-top: 1em">Thrift requests
+can be specified as JSON or YAML. For example, for a method
+defined as:</p>
+
+<p style="margin-left:22%; margin-top: 1em">void addUser(1:
+string name, 2: i32 age)</p>
+
+<p style="margin-left:11%; margin-top: 1em">You can pass
+the request as JSON: {&quot;name&quot;:
+&quot;Prashant&quot;, age: 100} or as YAML:</p>
+
+<p style="margin-left:22%; margin-top: 1em">name: Prashant
+<br>
+age: 100</p>
+
+<p style="margin-left:11%; margin-top: 1em">The request
+body can be specified on the command line using -r or
+--request:</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 -t kv.thrift kv \ <br>
+KeyValue::Get -r &rsquo;{&quot;key&quot;:
+&quot;hello&quot;}&rsquo;</p>
+
+<p style="margin-left:11%; margin-top: 1em">Or it can be
+loaded from a file using -f or --file:</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 -t kv.thrift kv KeyValue::Get --file
+req.yaml</p>
+
+<p style="margin-left:11%; margin-top: 1em">Binary data can
+be specified in one of many ways:</p>
+
+<table width="100%" border=0 rules="none" frame="void"
+       cellspacing="0" cellpadding="0">
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="1%">
+
+
+<p style="margin-top: 1em" valign="top">&bull;</p></td>
+<td width="10%"></td>
+<td width="78%">
+
+
+<p style="margin-top: 1em" valign="top">As a string or an
+array of bytes: &quot;data&quot; or [100, 97, 116, 97]</p></td>
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="1%">
+
+
+<p style="margin-top: 1em" valign="top">&bull;</p></td>
+<td width="10%"></td>
+<td width="78%">
+
+
+<p style="margin-top: 1em" valign="top">As base64:
+{&quot;base64&quot;: &quot;ZGF0YQ==&quot;}</p></td>
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="1%">
+
+
+<p style="margin-top: 1em" valign="top">&bull;</p></td>
+<td width="10%"></td>
+<td width="78%">
+
+
+<p style="margin-top: 1em" valign="top">Loaded from a file:
+{&quot;file&quot;: &quot;data.bin&quot;}</p></td>
+</table>
+
+<p style="margin-left:11%; margin-top: 1em">Examples:</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 -t kv.thrift kv -m KeyValue::Set \ <br>
+-r &rsquo;{&quot;key&quot;: &quot;hello&quot;,
+&quot;value&quot;: [100, 97, 116, 97]}&rsquo;</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 -t kv.thrift kv KeyValue::Set \ <br>
+-r &rsquo;{&quot;key&quot;: &quot;hello&quot;,
+&quot;value&quot;: {&quot;file&quot;:
+&quot;data.bin&quot;}}&rsquo;</p>
+
+<p style="margin-left:11%;"><b>&minus;e</b>,
+<b>&minus;&minus;encoding</b></p>
+
+<p style="margin-left:22%;">The encoding of the data,
+options are: Thrift, JSON, raw. Defaults to Thrift if the
+method contains &rsquo;::&rsquo; or a Thrift file is
+specified</p>
+
+<p style="margin-left:11%;"><b>&minus;t</b>,
+<b>&minus;&minus;thrift</b></p>
+
+<p style="margin-left:22%;">Path of the .thrift file</p>
+
+<p style="margin-left:11%;"><b>&minus;m</b>,
+<b>&minus;&minus;method</b></p>
+
+<p style="margin-left:22%;">The full Thrift method name
+(Svc::Method) to invoke</p>
+
+<p style="margin-left:11%;"><b>&minus;r</b>,
+<b>&minus;&minus;request</b></p>
+
+<p style="margin-left:22%;">The request body, in JSON or
+YAML format</p>
+
+<p style="margin-left:11%;"><b>&minus;f</b>,
+<b>&minus;&minus;file</b></p>
+
+<p style="margin-left:22%;">Path of a file containing the
+request body in JSON or YAML</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;headers</b></p>
+
+<p style="margin-left:22%;">The headers in JSON or YAML
+format</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;headers-file</b></p>
+
+<p style="margin-left:22%;">Path of a file containing the
+headers in JSON or YAML</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;health</b></p>
+
+<p style="margin-left:22%;">Hit the health endpoint,
+Meta::health</p>
+
+<p style="margin-left:11%;"><b>&minus;&minus;timeout</b>
+&lt;default: <i>&quot;1s&quot;</i>&gt;</p>
+
+<p style="margin-left:22%;">The timeout for each request.
+E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds
+are assumed.</p>
+
+<p style="margin-left:11%; margin-top: 1em"><b>Transport
+Options</b> <br>
+Configures the network transport used to make requests.</p>
+
+<p style="margin-left:11%; margin-top: 1em">yab can target
+both TChannel and HTTP endpoints. To specify a TChannel
+endpoint, specify the peer&rsquo;s host and port:</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 [options]</p>
+
+<p style="margin-left:11%; margin-top: 1em">or</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+tchannel://localhost:9787 [options]</p>
+
+<p style="margin-left:11%; margin-top: 1em">For HTTP
+endpoints, specify the URL as the peer,</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+http://localhost:8080/thrift [options]</p>
+
+<p style="margin-left:11%; margin-top: 1em">The
+Thrift-encoded body will be POSTed to the specified URL.</p>
+
+<p style="margin-left:11%; margin-top: 1em">Multiple peers
+can be specified using a peer list using -P or --peer-list.
+When making a single request, a single peer from this list
+is selected randomly. When benchmarking, connections will be
+established in a round-robin fashion, starting with a random
+peer.</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab
+--peer-list hosts.json [options]</p>
+
+<p style="margin-left:11%;"><b>&minus;s</b>,
+<b>&minus;&minus;service</b></p>
+
+<p style="margin-left:22%;">The TChannel/Hyperbahn service
+name</p>
+
+<p style="margin-left:11%;"><b>&minus;p</b>,
+<b>&minus;&minus;peer</b></p>
+
+<p style="margin-left:22%;">The host:port of the service to
+call</p>
+
+<p style="margin-left:11%;"><b>&minus;P</b>,
+<b>&minus;&minus;peer-list</b></p>
+
+<p style="margin-left:22%;">Path of a JSON or YAML file
+containing a list of host:ports</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;caller</b></p>
+
+<p style="margin-left:22%;">Caller will override the
+default caller name (which is yab-$USER).</p>
+
+<table width="100%" border=0 rules="none" frame="void"
+       cellspacing="0" cellpadding="0">
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="9%">
+
+
+
+<p style="margin-top: 1em" valign="top"><b>&minus;&minus;topt</b></p> </td>
+<td width="2%"></td>
+<td width="78%">
+
+
+<p style="margin-top: 1em" valign="top">Custom options for
+the specific transport being used</p></td>
+</table>
+
+<p style="margin-left:11%; margin-top: 1em"><b>Benchmark
+Options</b> <br>
+Configures benchmarking, which is disabled by default.</p>
+
+<p style="margin-left:11%; margin-top: 1em">By default, yab
+will only make a single request. To enable benchmarking,
+specify the maximum duration for the benchmark by passing -d
+or --max-duration.</p>
+
+<p style="margin-left:11%; margin-top: 1em">yab will make
+requests until either the maximum requests (-n or
+--max-requests) or the maximum duration is reached.</p>
+
+<p style="margin-left:11%; margin-top: 1em">You can control
+the rate at which yab makes requests using the --rps
+flag.</p>
+
+<p style="margin-left:11%; margin-top: 1em">An example
+benchmark command might be:</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:9787 moe --health -n 100000 -d 10s --rps 1000</p>
+
+<p style="margin-left:11%; margin-top: 1em">This would make
+requests at 1000 RPS until either the maximum number of
+requests (100,000) or the maximum duration (10 seconds) is
+reached.</p>
+
+<p style="margin-left:11%; margin-top: 1em">By default, yab
+will create multiple connections (defaulting to the number
+of CPUs on the machine), but will only have one concurrent
+call per connection. The number of connections and
+concurrent calls per connection can be controlled using
+--connections and --concurrency. <b><br>
+&minus;n</b>, <b>&minus;&minus;max-requests</b> &lt;default:
+<i>&quot;1000000&quot;</i>&gt;</p>
+
+<p style="margin-left:22%;">The maximum number of requests
+to make</p>
+
+<p style="margin-left:11%;"><b>&minus;d</b>,
+<b>&minus;&minus;max-duration</b> &lt;default:
+<i>&quot;0s&quot;</i>&gt;</p>
+
+<p style="margin-left:22%;">The maximum amount of time to
+run the benchmark for</p>
+
+<table width="100%" border=0 rules="none" frame="void"
+       cellspacing="0" cellpadding="0">
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="9%">
+
+
+
+<p style="margin-top: 1em" valign="top"><b>&minus;&minus;cpus</b></p> </td>
+<td width="2%"></td>
+<td width="36%">
+
+
+<p style="margin-top: 1em" valign="top">The number of OS
+threads</p> </td>
+<td width="42%">
+</td>
+</table>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;connections</b></p>
+
+<p style="margin-left:22%;">The number of TCP connections
+to use</p>
+
+<p style="margin-left:11%;"><b>&minus;&minus;warmup</b>
+&lt;default: <i>&quot;10&quot;</i>&gt;</p>
+
+<p style="margin-left:22%;">The number of requests to make
+to warmup each connection</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;concurrency</b>
+&lt;default: <i>&quot;1&quot;</i>&gt;</p>
+
+<p style="margin-left:22%;">The number of concurrent calls
+per connection</p>
+
+<p style="margin-left:11%;"><b>&minus;&minus;rps</b>
+&lt;default: <i>&quot;0&quot;</i>&gt;</p>
+
+<p style="margin-left:22%;">Limit on the number of requests
+per second. The default (0) is no limit.</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;statsd</b></p>
+
+<p style="margin-left:22%;">Optional host:port of a StatsD
+server to report metrics</p>
+
+<p style="margin-left:11%; margin-top: 1em"><b>Help Options
+<br>
+&minus;h</b>, <b>&minus;&minus;help</b></p>
+
+<p style="margin-left:22%;">Show this help message</p>
+<hr>
+</body>
+</html>

--- a/man/yab.html
+++ b/man/yab.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.19.2 -->
-<!-- CreationDate: Fri Jul 15 07:43:13 2016 -->
+<!-- CreationDate: Fri Jul 15 17:11:46 2016 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -53,6 +53,21 @@ supports other encodings like JSON and binary (raw).</p>
 <p style="margin-left:11%; margin-top: 1em">It can be used
 in a curl-like fashion when benchmarking features are
 disabled.</p>
+
+<p style="margin-left:11%; margin-top: 1em">Default options
+can be specified in a ~/.config/yab/defaults.ini file with
+contents similar to this:</p>
+
+<p style="margin-left:22%; margin-top: 1em">[request] <br>
+timeout = 2s</p>
+
+<p style="margin-left:22%; margin-top: 1em">[transport]
+<br>
+peer-list = &quot;/path/to/peer/list.json&quot;</p>
+
+<p style="margin-left:22%; margin-top: 1em">[benchmark]
+<br>
+warmup = 10</p>
 
 <a name="OPTIONS"></a>
 <h2>OPTIONS</h2>

--- a/options.go
+++ b/options.go
@@ -39,15 +39,16 @@ type Options struct {
 
 // RequestOptions are request related options
 type RequestOptions struct {
-	Encoding    encoding.Encoding `short:"e" long:"encoding" description:"The encoding of the data, options are: Thrift, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified"`
-	ThriftFile  string            `short:"t" long:"thrift" description:"Path of the .thrift file"`
-	MethodName  string            `short:"m" long:"method" description:"The full Thrift method name (Svc::Method) to invoke"`
-	RequestJSON string            `short:"r" long:"request" description:"The request body, in JSON or YAML format"`
-	RequestFile string            `short:"f" long:"file" description:"Path of a file containing the request body in JSON or YAML"`
-	HeadersJSON string            `long:"headers" description:"The headers in JSON or YAML format"`
-	HeadersFile string            `long:"headers-file" description:"Path of a file containing the headers in JSON or YAML"`
-	Health      bool              `long:"health" description:"Hit the health endpoint, Meta::health"`
-	Timeout     timeMillisFlag    `long:"timeout" default:"1s" description:"The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
+	Encoding               encoding.Encoding `short:"e" long:"encoding" description:"The encoding of the data, options are: Thrift, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified"`
+	ThriftFile             string            `short:"t" long:"thrift" description:"Path of the .thrift file"`
+	MethodName             string            `short:"m" long:"method" description:"The full Thrift method name (Svc::Method) to invoke"`
+	RequestJSON            string            `short:"r" long:"request" description:"The request body, in JSON or YAML format"`
+	RequestFile            string            `short:"f" long:"file" description:"Path of a file containing the request body in JSON or YAML"`
+	HeadersJSON            string            `long:"headers" description:"The headers in JSON or YAML format"`
+	HeadersFile            string            `long:"headers-file" description:"Path of a file containing the headers in JSON or YAML"`
+	Health                 bool              `long:"health" description:"Hit the health endpoint, Meta::health"`
+	Timeout                timeMillisFlag    `long:"timeout" default:"1s" description:"The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
+	DisableThriftEnvelopes bool              `long:"disable-thrift-envelope" description:"Disables Thrift envelopes (disabled by default for TChannel)"`
 
 	// These are aliases for tcurl compatibility.
 	Aliases struct {

--- a/server_util_test.go
+++ b/server_util_test.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/uber/tchannel-go"
@@ -108,6 +109,14 @@ func (methodsT) errorIf(f func() bool) handler {
 			Arg3: args.Arg3,
 		}, nil
 	}
+}
+
+func (methodsT) counter() (*int32, handler) {
+	var count int32
+	return &count, methods.errorIf(func() bool {
+		atomic.AddInt32(&count, 1)
+		return false
+	})
 }
 
 func echoServer(t *testing.T, method string, overrideResp []byte) string {

--- a/testdata/ini/invalid/yab/defaults.ini
+++ b/testdata/ini/invalid/yab/defaults.ini
@@ -1,0 +1,2 @@
+[request]
+timeout = 3foo

--- a/testdata/ini/valid/yab/defaults.ini
+++ b/testdata/ini/valid/yab/defaults.ini
@@ -1,0 +1,2 @@
+[request]
+timeout = 2s

--- a/version.go
+++ b/version.go
@@ -22,4 +22,4 @@ package main
 
 // versionString is the sem-ver version string for yab.
 // It will be bumped explicitly on releases.
-var versionString = "0.3.1-dev"
+var versionString = "0.4.0"

--- a/version.go
+++ b/version.go
@@ -22,4 +22,4 @@ package main
 
 // versionString is the sem-ver version string for yab.
 // It will be bumped explicitly on releases.
-var versionString = "0.4.0"
+var versionString = "0.5.0"


### PR DESCRIPTION
Includes:
 - Round robin peer selection when benchmarking for better load distribution
 - Better man pages
 - Option to disable Thrift envelopes