### PR TITLE
Fix peer list bugs for benchmarking

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -107,6 +107,7 @@ func loadTransportHostPorts(opts TransportOptions) (TransportOptions, error) {
 		}
 	}
 
+	opts.HostPortFile = ""
 	opts.HostPorts = hostPorts
 	return opts, nil
 }
@@ -189,7 +190,7 @@ func parseHostsFileNewLines(r io.Reader) ([]string, error) {
 	rdr := bufio.NewReader(r)
 	for {
 		line, err := rdr.ReadString('\n')
-		if err != nil {
+		if line == "" && err != nil {
 			if err == io.EOF {
 				break
 			}

--- a/transport_test.go
+++ b/transport_test.go
@@ -97,6 +97,20 @@ func TestEnsureSameProtocol(t *testing.T) {
 	}
 }
 
+func TestLoadTransportHostPorts(t *testing.T) {
+	hostPortFile := writeFile(t, "hostPorts", "a:1\nb:2\nc:3")
+	defer os.Remove(hostPortFile)
+
+	opts, err := loadTransportHostPorts(TransportOptions{
+		HostPortFile: hostPortFile,
+	})
+	require.NoError(t, err, "Failed to load transports")
+
+	assert.Equal(t, TransportOptions{
+		HostPorts: []string{"a:1", "b:2", "c:3"},
+	}, opts, "Unexpected transport options")
+}
+
 func TestGetTransport(t *testing.T) {
 	tests := []struct {
 		opts   TransportOptions


### PR DESCRIPTION
Peer-list was ignoring the last line if it did not end with a "\n"
Benchmark warmup failed if --peer-list was used (introduced in
round-robin peer selection, #61).

Fixes #70