### PR TITLE
Update README with latest --help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,10 @@ Usage:
 Application Options:
       --version                  Displays the application version
 
-
 Request Options:
-  -e, --encoding=                The encoding of the data, options are:
-                                 Thrift, JSON, raw. Defaults to Thrift if the
-                                 method contains '::' or a Thrift file is
-                                 specified
+  -e, --encoding=                The encoding of the data, options are: Thrift,
+                                 JSON, raw. Defaults to Thrift if the method
+                                 contains '::' or a Thrift file is specified
   -t, --thrift=                  Path of the .thrift file
   -m, --method=                  The full Thrift method name (Svc::Method) to
                                  invoke
@@ -45,8 +43,8 @@ Request Options:
       --timeout=                 The timeout for each request. E.g., 100ms,
                                  0.5s, 1s. If no unit is specified,
                                  milliseconds are assumed. (default: 1s)
-      --disable-thrift-envelope  Disables Thrift envelopes (disabled by
-                                 default for TChannel)
+      --disable-thrift-envelope  Disables Thrift envelopes (disabled by default
+                                 for TChannel)
 
 Transport Options:
   -s, --service=                 The TChannel/Hyperbahn service name

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 `yab` (Yet Another Benchmarker) is tool to benchmark YARPC services. It currently
 supports making Thrift requests to both HTTP and TChannel services.
 
-**NOTE**: HTTP support is not cross-compatible with Apache Thrift yet, due to
-missing message envelope support.
-
 `yab` is currently in **beta** status.
 
 
@@ -25,28 +22,40 @@ This will install `yab` to `$GOPATH/bin/yab`.
 Usage:
   yab [<service> <method> <body>] [OPTIONS]
 
-Request Options:
-  -t, --thrift=      Path of the .thrift file
-  -m, --method=      The full Thrift method name (Svc::Method) to invoke
-  -r, --request=     The request body, in JSON format
-  -f, --file=        Path of a file containing the request body in JSON
+Application Options:
+      --version                  Displays the application version
+
+Request Option:
+  -e, --encoding=                The encoding of the data, options are: Thrift, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified
+  -t, --thrift=                  Path of the .thrift file
+  -m, --method=                  The full Thrift method name (Svc::Method) to invoke
+  -r, --request=                 The request body, in JSON or YAML format
+  -f, --file=                    Path of a file containing the request body in JSON or YAML
+      --headers=                 The headers in JSON or YAML format
+      --headers-file=            Path of a file containing the headers in JSON or YAML
+      --health                   Hit the health endpoint, Meta::health
+      --timeout=                 The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed. (default: 1s)
+      --disable-thrift-envelope  Disables Thrift envelopes (disabled by default for TChannel)
 
 Transport Options:
-  -s, --service=     The TChannel/Hyperbahn service name
-  -p, --peer=        The host:port of the service to call
-  -P, --peer-list=   Path of a JSON file containing a list of host:ports
+  -s, --service=                 The TChannel/Hyperbahn service name
+  -p, --peer=                    The host:port of the service to call
+  -P, --peer-list=               Path of a JSON or YAML file containing a list of host:ports
+      --caller=                  Caller will override the default caller name (which is yab-$USER).
+      --topt=                    Custom options for the specific transport being used
 
 Benchmark Options:
-  -n, --maxRequests= The maximum number of requests to make (default: 1000000)
-  -d, --maxDuration= The maximum amount of time to run the benchmark for (default: 0s)
-      --cpus=        The number of OS threads
-      --connections= The number of TCP connections to use
-      --concurrency= The number of concurrent calls per connection (default: 1)
-      --rps=         Limit on the number of requests per second. The default (0) is no limit. (default: 0)
-      --statsd=      Optional host:port of a StatsD server to report metrics
+  -n, --max-requests=            The maximum number of requests to make (default: 1000000)
+  -d, --max-duration=            The maximum amount of time to run the benchmark for (default: 0s)
+      --cpus=                    The number of OS threads
+      --connections=             The number of TCP connections to use
+      --warmup=                  The number of requests to make to warmup each connection (default: 10)
+      --concurrency=             The number of concurrent calls per connection (default: 1)
+      --rps=                     Limit on the number of requests per second. The default (0) is no limit. (default: 0)
+      --statsd=                  Optional host:port of a StatsD server to report metrics
 
 Help Options:
-  -h, --help         Show this help message
+  -h, --help                     Show this help message
   ```
 
 ### Making a single request

--- a/README.md
+++ b/README.md
@@ -22,41 +22,61 @@ This will install `yab` to `$GOPATH/bin/yab`.
 Usage:
   yab [<service> <method> <body>] [OPTIONS]
 
+
 Application Options:
       --version                  Displays the application version
 
-Request Option:
-  -e, --encoding=                The encoding of the data, options are: Thrift, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified
+
+Request Options:
+  -e, --encoding=                The encoding of the data, options are:
+                                 Thrift, JSON, raw. Defaults to Thrift if the
+                                 method contains '::' or a Thrift file is
+                                 specified
   -t, --thrift=                  Path of the .thrift file
-  -m, --method=                  The full Thrift method name (Svc::Method) to invoke
+  -m, --method=                  The full Thrift method name (Svc::Method) to
+                                 invoke
   -r, --request=                 The request body, in JSON or YAML format
-  -f, --file=                    Path of a file containing the request body in JSON or YAML
+  -f, --file=                    Path of a file containing the request body in
+                                 JSON or YAML
       --headers=                 The headers in JSON or YAML format
-      --headers-file=            Path of a file containing the headers in JSON or YAML
+      --headers-file=            Path of a file containing the headers in JSON
+                                 or YAML
       --health                   Hit the health endpoint, Meta::health
-      --timeout=                 The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed. (default: 1s)
-      --disable-thrift-envelope  Disables Thrift envelopes (disabled by default for TChannel)
+      --timeout=                 The timeout for each request. E.g., 100ms,
+                                 0.5s, 1s. If no unit is specified,
+                                 milliseconds are assumed. (default: 1s)
+      --disable-thrift-envelope  Disables Thrift envelopes (disabled by
+                                 default for TChannel)
 
 Transport Options:
   -s, --service=                 The TChannel/Hyperbahn service name
   -p, --peer=                    The host:port of the service to call
-  -P, --peer-list=               Path of a JSON or YAML file containing a list of host:ports
-      --caller=                  Caller will override the default caller name (which is yab-$USER).
-      --topt=                    Custom options for the specific transport being used
+  -P, --peer-list=               Path of a JSON or YAML file containing a list
+                                 of host:ports
+      --caller=                  Caller will override the default caller name
+                                 (which is yab-$USER).
+      --topt=                    Custom options for the specific transport
+                                 being used
 
 Benchmark Options:
-  -n, --max-requests=            The maximum number of requests to make (default: 1000000)
-  -d, --max-duration=            The maximum amount of time to run the benchmark for (default: 0s)
+  -n, --max-requests=            The maximum number of requests to make
+                                 (default: 1000000)
+  -d, --max-duration=            The maximum amount of time to run the
+                                 benchmark for (default: 0s)
       --cpus=                    The number of OS threads
       --connections=             The number of TCP connections to use
-      --warmup=                  The number of requests to make to warmup each connection (default: 10)
-      --concurrency=             The number of concurrent calls per connection (default: 1)
-      --rps=                     Limit on the number of requests per second. The default (0) is no limit. (default: 0)
-      --statsd=                  Optional host:port of a StatsD server to report metrics
+      --warmup=                  The number of requests to make to warmup each
+                                 connection (default: 10)
+      --concurrency=             The number of concurrent calls per connection
+                                 (default: 1)
+      --rps=                     Limit on the number of requests per second.
+                                 The default (0) is no limit. (default: 0)
+      --statsd=                  Optional host:port of a StatsD server to
+                                 report metrics
 
 Help Options:
   -h, --help                     Show this help message
-  ```
+```
 
 ### Making a single request
 

--- a/main.go
+++ b/main.go
@@ -48,14 +48,10 @@ func findGroup(parser *flags.Parser, group string) *flags.Group {
 	panic("no group called " + group + " found.")
 }
 
-func setGroupShortDesc(parser *flags.Parser, groupName, desc string) {
+func setGroupDescs(parser *flags.Parser, groupName, shortDesc, longDesc string) {
 	g := findGroup(parser, groupName)
-	g.ShortDescription = desc
-}
-
-func setGroupLongDesc(parser *flags.Parser, groupName, desc string) {
-	g := findGroup(parser, groupName)
-	g.LongDescription = desc
+	g.ShortDescription = shortDesc
+	g.LongDescription = longDesc
 }
 
 func fromPositional(args []string, index int, s *string) bool {
@@ -121,9 +117,9 @@ Default options can be specified in a ~/.config/yab/defaults.ini file with conte
 	warmup = 10
 `
 
-	setGroupShortDesc(parser, "request", "Request Options")
-	setGroupShortDesc(parser, "transport", "Transport Options")
-	setGroupShortDesc(parser, "benchmark", "Benchmark Options")
+	setGroupDescs(parser, "request", "Request Options", toGroff(_reqOptsDesc))
+	setGroupDescs(parser, "transport", "Transport Options", toGroff(_transportOptsDesc))
+	setGroupDescs(parser, "benchmark", "Benchmark Options", toGroff(_benchmarkOptsDesc))
 
 	// If there are no arguments specified, write the help.
 	if len(args) == 0 {
@@ -155,10 +151,7 @@ Default options can be specified in a ~/.config/yab/defaults.ini file with conte
 
 	if opts.ManPage {
 		parser.LongDescription = toGroff(parser.LongDescription)
-		setGroupLongDesc(parser, "request", toGroff(_reqOptsDesc))
-		setGroupLongDesc(parser, "transport", toGroff(_transportOptsDesc))
-		setGroupLongDesc(parser, "benchmark", toGroff(_benchmarkOptsDesc))
-		parser.WriteManPage(os.Stdout)
+		parser.WriteManPage(out)
 		return opts, errExit
 	}
 

--- a/main.go
+++ b/main.go
@@ -48,9 +48,13 @@ func findGroup(parser *flags.Parser, group string) *flags.Group {
 	panic("no group called " + group + " found.")
 }
 
-func setGroupDesc(parser *flags.Parser, groupName, newName, desc string) {
+func setGroupShortDesc(parser *flags.Parser, groupName, desc string) {
 	g := findGroup(parser, groupName)
-	g.ShortDescription = newName
+	g.ShortDescription = desc
+}
+
+func setGroupLongDesc(parser *flags.Parser, groupName, desc string) {
+	g := findGroup(parser, groupName)
 	g.LongDescription = desc
 }
 
@@ -117,6 +121,10 @@ Default options can be specified in a ~/.config/yab/defaults.ini file with conte
 	warmup = 10
 `
 
+	setGroupShortDesc(parser, "request", "Request Options")
+	setGroupShortDesc(parser, "transport", "Transport Options")
+	setGroupShortDesc(parser, "benchmark", "Benchmark Options")
+
 	// If there are no arguments specified, write the help.
 	if len(args) == 0 {
 		parser.WriteHelp(out)
@@ -147,9 +155,9 @@ Default options can be specified in a ~/.config/yab/defaults.ini file with conte
 
 	if opts.ManPage {
 		parser.LongDescription = toGroff(parser.LongDescription)
-		setGroupDesc(parser, "request", "Request Options", toGroff(_reqOptsDesc))
-		setGroupDesc(parser, "transport", "Transport Options", toGroff(_transportOptsDesc))
-		setGroupDesc(parser, "benchmark", "Benchmark Options", toGroff(_benchmarkOptsDesc))
+		setGroupLongDesc(parser, "request", toGroff(_reqOptsDesc))
+		setGroupLongDesc(parser, "transport", toGroff(_transportOptsDesc))
+		setGroupLongDesc(parser, "benchmark", toGroff(_benchmarkOptsDesc))
 		parser.WriteManPage(os.Stdout)
 		return opts, errExit
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -289,6 +289,17 @@ func TestHelpOutput(t *testing.T) {
 	}
 }
 
+func TestManPage(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	os.Args = []string{"yab", "--man-page"}
+
+	buf, out := getOutput(t)
+	parseAndRun(out)
+	assert.Contains(t, buf.String(), "SYNOPSIS")
+}
+
 func TestVersion(t *testing.T) {
 	origArgs := os.Args
 	defer func() { os.Args = origArgs }()

--- a/man/yab.1
+++ b/man/yab.1
@@ -1,4 +1,4 @@
-.TH yab 1 "15 July 2016"
+.TH yab 1 "20 July 2016"
 .SH NAME
 yab \- yet another benchmarker
 .SH SYNOPSIS
@@ -176,6 +176,9 @@ Hit the health endpoint, Meta::health
 .TP
 \fB\fB\-\-timeout\fR <default: \fI"1s"\fR>\fP
 The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed.
+.TP
+\fB\fB\-\-disable-thrift-envelope\fR\fP
+Disables Thrift envelopes (disabled by default for TChannel)
 .SS Transport Options
 Configures the network transport used to make requests.
 .PP

--- a/man/yab.html
+++ b/man/yab.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.19.2 -->
-<!-- CreationDate: Fri Jul 15 17:11:46 2016 -->
+<!-- CreationDate: Wed Jul 20 07:44:01 2016 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -246,6 +246,12 @@ Meta::health</p>
 <p style="margin-left:22%;">The timeout for each request.
 E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds
 are assumed.</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;disable-thrift-envelope</b></p>
+
+<p style="margin-left:22%;">Disables Thrift envelopes
+(disabled by default for TChannel)</p>
 
 <p style="margin-left:11%; margin-top: 1em"><b>Transport
 Options</b> <br>


### PR DESCRIPTION
Nitpicking our README and the output of `--help` -- my last change removed the titles for these groupings.

This doesn't need a release.