### PR TITLE
Fix benchmark taking longer than duration for low RPS

### DIFF
--- a/benchmark.go
+++ b/benchmark.go
@@ -71,6 +71,14 @@ func runBenchmark(out output, allOpts Options, m benchmarkMethod) {
 		return
 	}
 
+	if opts.RPS > 0 {
+		// The RPS * duration in seconds may cap opts.MaxRequests.
+		rpsMax := int(float64(opts.RPS) * opts.MaxDuration.Seconds())
+		if rpsMax < opts.MaxRequests {
+			opts.MaxRequests = rpsMax
+		}
+	}
+
 	goMaxProcs := opts.setGoMaxProcs()
 	numConns := opts.getNumConnections(goMaxProcs)
 	out.Printf("Benchmark parameters:\n")


### PR DESCRIPTION
When the RPS is a low number (like 1), each connection goroutine will
call Take which ends up causing a sleep for a second. Since the limiter
uses a lock, we end up serializing the Sleeps, so the benchmark runs for
connections * sleep amount.

Instead of sleeping arbitrarily, pass in a cancel channel to unblock the
sleep.

Fixes #73 cc @jeffbean