### PR TITLE
Move info about default configs to the manpage and automatically update README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,12 @@ install_ci: install
 		go get golang.org/x/tools/cmd/cover
 
 
-.PHONY: update_man
-update_man:
+.PHONY: docs
+docs:
 	go install .
+	# Automatically update the Usage section of README.md with --help (wrapped to 80 characters).
+	screen -d -m bash -c 'stty cols 80 && ${GOPATH}/bin/yab --help | python -c "import re; import sys; f = open(\"README.md\"); r = re.compile(r\"\`\`\`\nUsage:.*?\`\`\`\", re.MULTILINE|re.DOTALL); print r.sub(\"\`\`\`\n\" + sys.stdin.read() + \"\`\`\`\", f.read().strip())" | sponge README.md'
+	# Update our manpage output and HTML pages.
 	$$GOPATH/bin/yab --man-page > man/yab.1
 	groff -man -T html man/yab.1 > man/yab.html
 	[[ -d ../yab_ghpages ]] && cp man/yab.html ../yab_ghpages/man.html

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ This will install `yab` to `$GOPATH/bin/yab`.
 Usage:
   yab [<service> <method> <body>] [OPTIONS]
 
+yab is a benchmarking tool for TChannel and HTTP applications. It's primarily
+intended for Thrift applications but supports other encodings like JSON and
+binary (raw). It can be used in a curl-like fashion when benchmarking features
+are disabled.
+
+
 Application Options:
       --version                  Displays the application version
 

--- a/main.go
+++ b/main.go
@@ -101,20 +101,7 @@ func getOptions(args []string, out output) (*Options, error) {
 	parser.Usage = "[<service> <method> <body>] [OPTIONS]"
 	parser.ShortDescription = "yet another benchmarker"
 	parser.LongDescription = `
-yab is a benchmarking tool for TChannel and HTTP applications. It's primarily intended for Thrift applications but supports other encodings like JSON and binary (raw).
-
-It can be used in a curl-like fashion when benchmarking features are disabled.
-
-Default options can be specified in a ~/.config/yab/defaults.ini file with contents similar to this:
-
-	[request]
-	timeout = 2s
-
-	[transport]
-	peer-list = "/path/to/peer/list.json"
-
-	[benchmark]
-	warmup = 10
+yab is a benchmarking tool for TChannel and HTTP applications. It's primarily intended for Thrift applications but supports other encodings like JSON and binary (raw). It can be used in a curl-like fashion when benchmarking features are disabled.
 `
 
 	// Read defaults if they're available, before we change the group names.
@@ -150,6 +137,18 @@ Default options can be specified in a ~/.config/yab/defaults.ini file with conte
 	}
 
 	if opts.ManPage {
+		parser.LongDescription += `
+Default options can be specified in a ~/.config/yab/defaults.ini file with contents similar to this:
+
+	[request]
+	timeout = 2s
+
+	[transport]
+	peer-list = "/path/to/peer/list.json"
+
+	[benchmark]
+	warmup = 10
+`
 		parser.LongDescription = toGroff(parser.LongDescription)
 		parser.WriteManPage(out)
 		return opts, errExit

--- a/main_test.go
+++ b/main_test.go
@@ -300,6 +300,7 @@ func TestHelpOutput(t *testing.T) {
 
 		// Make sure we didn't leak any groff from the man-page output.
 		assert.NotContains(t, buf.String(), ".PP")
+		assert.NotContains(t, buf.String(), "~/.config/yab/defaults.ini")
 	}
 }
 
@@ -312,6 +313,7 @@ func TestManPage(t *testing.T) {
 	buf, out := getOutput(t)
 	parseAndRun(out)
 	assert.Contains(t, buf.String(), "SYNOPSIS")
+	assert.Contains(t, buf.String(), "~/.config/yab/defaults.ini")
 }
 
 func TestVersion(t *testing.T) {


### PR DESCRIPTION
* Unclutters `--help` by moving config defaults to `yab.1`
* Adds an admittedly gross one-liner to automatically update `README.md` in the same way we update our manpages. (`brew install moreutils` if you're on OS X and missing `sponge`)