### PR TITLE
Update glide and use testImports for test deps

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,18 @@
-hash: 8e5d5d46415cfa0f686537efda563c9d39bc2cad2ae2b9b6c5bece08e710f3d5
-updated: 2016-08-03T09:34:42.07213616-07:00
+hash: 55fd0a7525390f35a5dfcc739bd4aee790f7cc81aa3ce4576de948675bb3fca1
+updated: 2016-08-24T23:17:59.856656069-07:00
 imports:
 - name: github.com/apache/thrift
-  version: bcad91771b7f0bff28a1cac1981d7ef2b9bcef3c
+  version: e4ba16495e8d8177eb85d6bfcc69089b38753e39
   subpackages:
   - lib/go/thrift
 - name: github.com/cactus/go-statsd-client
-  version: 91c326c3f7bd20f0226d3d1c289dd9f8ce28d33d
+  version: 1c27c506c7a0584d017ca479f91b88d6a6538332
   subpackages:
   - statsd
 - name: github.com/casimir/xdg-go
   version: 372ccc2180dab73316615641d5617c5ed3e35529
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 6cf5744a041a0022271cefed95ba843f6d87fd51
   subpackages:
   - spew
 - name: github.com/jessevdk/go-flags
@@ -31,50 +31,52 @@ imports:
   subpackages:
   - ast
   - compile
-  - protocol
-  - wire
   - envelope
-  - idl
   - envelope/internal/exception
-  - protocol/binary
+  - idl
   - idl/internal
+  - protocol
+  - protocol/binary
+  - wire
 - name: github.com/uber-go/atomic
   version: 0c9e689d64f004564b79d9a663634756df322902
 - name: github.com/uber/tchannel-go
   version: cddba8c9bdf3a761b261382a6d7e7253e332790c
   subpackages:
-  - thrift
-  - raw
-  - testutils
   - json
+  - raw
   - relay
+  - relay/relaytest
+  - testutils
+  - testutils/goroutines
+  - thrift
+  - thrift/gen-go/meta
   - tnet
   - trand
   - typed
-  - thrift/gen-go/meta
-  - relay/relaytest
-  - testutils/goroutines
 - name: github.com/yarpc/yarpc-go
-  version: d722930e6be36d490b702fe375858b9bbd17370b
+  version: bb96e40a398063240ea18ed77810fd8470a22bec
   subpackages:
   - encoding/thrift
-  - transport
-  - transport/tchannel
   - encoding/thrift/internal
-  - internal/encoding
-  - internal/meta
   - internal
-  - internal/errors
   - internal/baggage
-  - internal/request
-  - transport/tchannel/internal
+  - internal/encoding
+  - internal/errors
   - internal/filter
   - internal/interceptor
+  - internal/meta
+  - internal/request
   - internal/sync
+  - transport
+  - transport/http
+  - transport/tchannel
+  - transport/tchannel/internal
 - name: golang.org/x/net
-  version: 57bfaa875b96fb91b4766077f34470528d4b03e9
+  version: 3a1f9ef983bc408afd0a9e63fd9c962ae853e543
   subpackages:
   - context
+  - context/ctxhttp
 - name: gopkg.in/yaml.v2
   version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,16 +1,29 @@
 package: github.com/yarpc/yab
 import:
+- package: github.com/cactus/go-statsd-client
+  version: master
+  subpackages:
+  - statsd
+- package: github.com/casimir/xdg-go
+  version: master
 - package: github.com/jessevdk/go-flags
   version: master
+- package: github.com/stretchr/testify
+  version: master
+  subpackages:
+  - require
 - package: github.com/thriftrw/thriftrw-go
-  version: 13abcf75760f008b6f92ee3185a9534e286b64a0
+  version: master
   subpackages:
   - ast
   - compile
+  - envelope
   - protocol
   - wire
+- package: github.com/uber-go/atomic
+  version: ^1.0.0
 - package: github.com/uber/tchannel-go
-  version: master
+  version: ^1.0.9
   subpackages:
   - thrift
 - package: golang.org/x/net
@@ -19,21 +32,15 @@ import:
   - context
 - package: gopkg.in/yaml.v2
   version: master
-- package: github.com/stretchr/testify
-  subpackages:
-  - assert
-  - require
+testImport:
 - package: github.com/apache/thrift
   version: master
   subpackages:
   - lib/go/thrift
-- package: github.com/casimir/xdg-go
-- package: github.com/uber-go/atomic
-  version: v1.0.0
 - package: github.com/yarpc/yarpc-go
+  version: master
   subpackages:
   - encoding/thrift
   - transport
   - transport/http
   - transport/tchannel
-  version: master

--- a/integration_test.go
+++ b/integration_test.go
@@ -45,6 +45,7 @@ import (
 	ytransport "github.com/yarpc/yarpc-go/transport"
 	yhttp "github.com/yarpc/yarpc-go/transport/http"
 	ytchan "github.com/yarpc/yarpc-go/transport/tchannel"
+	"golang.org/x/net/context"
 )
 
 //go:generate thriftrw-go --yarpc -out ./testdata/yarpc ./testdata/integration.thrift
@@ -93,7 +94,7 @@ func (httpHandler) Bar(arg int32) (int32, error) {
 
 type yarpcHandler struct{}
 
-func (yarpcHandler) Bar(reqMeta yarpc.ReqMeta, arg *int32) (int32, yarpc.ResMeta, error) {
+func (yarpcHandler) Bar(ctx context.Context, reqMeta yarpc.ReqMeta, arg *int32) (int32, yarpc.ResMeta, error) {
 	argVal := int32(0)
 	if arg != nil {
 		argVal = *arg
@@ -102,7 +103,7 @@ func (yarpcHandler) Bar(reqMeta yarpc.ReqMeta, arg *int32) (int32, yarpc.ResMeta
 	if _, ok := err.(*integration.NotFound); ok {
 		err = &yintegration.NotFound{}
 	}
-	return res, yarpc.NewResMeta(reqMeta.Context()), err
+	return res, yarpc.NewResMeta(), err
 }
 
 func TestIntegrationProtocols(t *testing.T) {

--- a/testdata/yarpc/integration/yarpc/fooclient/client.go
+++ b/testdata/yarpc/integration/yarpc/fooclient/client.go
@@ -10,10 +10,11 @@ import (
 	yarpc "github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/encoding/thrift"
 	"github.com/yarpc/yarpc-go/transport"
+	"golang.org/x/net/context"
 )
 
 type Interface interface {
-	Bar(reqMeta yarpc.CallReqMeta, arg *int32) (int32, yarpc.CallResMeta, error)
+	Bar(ctx context.Context, reqMeta yarpc.CallReqMeta, arg *int32) (int32, yarpc.CallResMeta, error)
 }
 
 func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
@@ -22,10 +23,10 @@ func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
 
 type client struct{ c thrift.Client }
 
-func (c client) Bar(reqMeta yarpc.CallReqMeta, arg *int32) (success int32, resMeta yarpc.CallResMeta, err error) {
+func (c client) Bar(ctx context.Context, reqMeta yarpc.CallReqMeta, arg *int32) (success int32, resMeta yarpc.CallResMeta, err error) {
 	args := foo.BarHelper.Args(arg)
 	var body wire.Value
-	body, resMeta, err = c.c.Call(reqMeta, args)
+	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
 	if err != nil {
 		return
 	}

--- a/testdata/yarpc/integration/yarpc/fooserver/server.go
+++ b/testdata/yarpc/integration/yarpc/fooserver/server.go
@@ -9,10 +9,11 @@ import (
 	"github.com/yarpc/yab/testdata/yarpc/integration/service/foo"
 	yarpc "github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/encoding/thrift"
+	"golang.org/x/net/context"
 )
 
 type Interface interface {
-	Bar(reqMeta yarpc.ReqMeta, arg *int32) (int32, yarpc.ResMeta, error)
+	Bar(ctx context.Context, reqMeta yarpc.ReqMeta, arg *int32) (int32, yarpc.ResMeta, error)
 }
 
 func New(impl Interface) thrift.Service {
@@ -35,12 +36,12 @@ func (s service) Handlers() map[string]thrift.Handler {
 
 type handler struct{ impl Interface }
 
-func (h handler) Bar(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Response, error) {
+func (h handler) Bar(ctx context.Context, reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Response, error) {
 	var args foo.BarArgs
 	if err := args.FromWire(body); err != nil {
 		return thrift.Response{}, err
 	}
-	success, resMeta, err := h.impl.Bar(reqMeta, args.Arg)
+	success, resMeta, err := h.impl.Bar(ctx, reqMeta, args.Arg)
 	hadError := err != nil
 	result, err := foo.BarHelper.WrapResponse(success, err)
 	var response thrift.Response


### PR DESCRIPTION
Recreated the `glide.yaml` using `glide init` which automatically put test dependencies in `testImport`. This doesn't work as well for test subpackages (e.g., tchannel-go/testutils).