### PR TITLE
Default to JSON encoding for endpoints without '::'

### DIFF
--- a/request.go
+++ b/request.go
@@ -93,8 +93,12 @@ func NewSerializer(opts RequestOptions) (encoding.Serializer, error) {
 		return nil, errMissingMethodName
 	}
 
-	if e == encoding.UnspecifiedEncoding && strings.Contains(opts.MethodName, "::") {
-		e = encoding.Thrift
+	if e == encoding.UnspecifiedEncoding {
+		if strings.Contains(opts.MethodName, "::") {
+			e = encoding.Thrift
+		} else {
+			e = encoding.JSON
+		}
 	}
 
 	switch e {

--- a/request_test.go
+++ b/request_test.go
@@ -201,6 +201,11 @@ func TestNewSerializer(t *testing.T) {
 			want:     encoding.Thrift,
 		},
 		{
+			encoding: encoding.UnspecifiedEncoding,
+			opts:     RequestOptions{MethodName: "hello"},
+			want:     encoding.JSON,
+		},
+		{
 			encoding: encoding.JSON,
 			opts:     RequestOptions{MethodName: "Test::foo"},
 			want:     encoding.JSON,


### PR DESCRIPTION
Currently, the user is forced to specify `-e json` if they are making a
JSON call, which is a little different from tcurl and a little more
verbose.

We only support Thrift, JSON and Raw, and since Thrift can be inferred
based on the method name, and raw is rarely used, defaulting to JSON
should lead to a better user experience.