### PR TITLE
If ThriftFile is specified, default encoding to Thrift

### DIFF
--- a/request.go
+++ b/request.go
@@ -79,29 +79,19 @@ func getHeaders(inline, file string) (map[string]string, error) {
 
 // NewSerializer creates a Serializer for the specific encoding.
 func NewSerializer(opts RequestOptions) (encoding.Serializer, error) {
-	e := opts.Encoding
-
 	if opts.Health {
 		if opts.MethodName != "" {
 			return nil, errHealthAndMethod
 		}
 
-		return e.GetHealth()
+		return opts.Encoding.GetHealth()
 	}
 
 	if opts.MethodName == "" {
 		return nil, errMissingMethodName
 	}
 
-	if e == encoding.UnspecifiedEncoding {
-		if strings.Contains(opts.MethodName, "::") {
-			e = encoding.Thrift
-		} else {
-			e = encoding.JSON
-		}
-	}
-
-	switch e {
+	switch e := detectEncoding(opts); e {
 	case encoding.Thrift:
 		return encoding.NewThrift(opts.ThriftFile, opts.MethodName, opts.ThriftMultiplexed)
 	case encoding.JSON:
@@ -111,4 +101,16 @@ func NewSerializer(opts RequestOptions) (encoding.Serializer, error) {
 	}
 
 	return nil, errUnrecognizedEncoding
+}
+
+func detectEncoding(opts RequestOptions) encoding.Encoding {
+	if opts.Encoding != encoding.UnspecifiedEncoding {
+		return opts.Encoding
+	}
+
+	if strings.Contains(opts.MethodName, "::") || opts.ThriftFile != "" {
+		return encoding.Thrift
+	}
+
+	return encoding.JSON
 }

--- a/request_test.go
+++ b/request_test.go
@@ -247,3 +247,32 @@ func TestNewSerializer(t *testing.T) {
 		}
 	}
 }
+
+func TestDetectEncoding(t *testing.T) {
+	tests := []struct {
+		opts RequestOptions
+		want encoding.Encoding
+	}{
+		{
+			opts: RequestOptions{Encoding: encoding.Raw, MethodName: "method"},
+			want: encoding.Raw,
+		},
+		{
+			opts: RequestOptions{MethodName: "method"},
+			want: encoding.JSON,
+		},
+		{
+			opts: RequestOptions{MethodName: "Svc::foo"},
+			want: encoding.Thrift,
+		},
+		{
+			opts: RequestOptions{ThriftFile: validThrift, MethodName: "method"},
+			want: encoding.Thrift,
+		},
+	}
+
+	for _, tt := range tests {
+		got := detectEncoding(tt.opts)
+		assert.Equal(t, tt.want, got, "detectEncoding(%+v)", tt.opts)
+	}
+}


### PR DESCRIPTION
Event if the method name doesn't contain '::', assume Thrift, since
we will return better error messages (e.g., list all the available
services) rather than giving the error "please specify an encoding".