### PR TITLE
Override default peer options based on args

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,10 +193,10 @@ func overrideDefaults(defaults *Options, args []string) {
 	argsParser.ParseArgs(args)
 
 	// Clear default peers if the user has specified peer options in args.
-	if len(argsOnly.TOpts.HostPorts) > 0 && defaults.TOpts.HostPortFile != "" {
+	if len(argsOnly.TOpts.HostPorts) > 0 {
 		defaults.TOpts.HostPortFile = ""
 	}
-	if len(argsOnly.TOpts.HostPortFile) > 0 && len(defaults.TOpts.HostPorts) > 0 {
+	if len(argsOnly.TOpts.HostPortFile) > 0 {
 		defaults.TOpts.HostPorts = nil
 	}
 }

--- a/main.go
+++ b/main.go
@@ -109,6 +109,8 @@ yab is a benchmarking tool for TChannel and HTTP applications. It's primarily in
 		return nil, fmt.Errorf("error reading defaults: %v", err)
 	}
 
+	overrideDefaults(opts, args)
+
 	setGroupDescs(parser, "request", "Request Options", toGroff(_reqOptsDesc))
 	setGroupDescs(parser, "transport", "Transport Options", toGroff(_transportOptsDesc))
 	setGroupDescs(parser, "benchmark", "Benchmark Options", toGroff(_benchmarkOptsDesc))
@@ -179,6 +181,24 @@ func parseAndRun(out output) {
 		out.Fatalf("Failed to parse options: %v", err)
 	}
 	runWithOptions(*opts, out)
+}
+
+// overrideDefaults clears fields in the default options that may
+// clash with user-specified options.
+// E.g., if the defaults has a peer list file, and the user has specifed
+// a peer through the command line, then the final options should only
+// contain the peer specified in the args.
+func overrideDefaults(defaults *Options, args []string) {
+	argsParser, argsOnly := newParser()
+	argsParser.ParseArgs(args)
+
+	// Clear default peers if the user has specified peer options in args.
+	if len(argsOnly.TOpts.HostPorts) > 0 && defaults.TOpts.HostPortFile != "" {
+		defaults.TOpts.HostPortFile = ""
+	}
+	if len(argsOnly.TOpts.HostPortFile) > 0 && len(defaults.TOpts.HostPorts) > 0 {
+		defaults.TOpts.HostPorts = nil
+	}
 }
 
 // parseDefaultConfigs reads defaults from ~/.config/yab/defaults.ini if they're

--- a/main_test.go
+++ b/main_test.go
@@ -23,8 +23,10 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -500,7 +502,7 @@ func TestParseIniFile(t *testing.T) {
 	}{
 		{
 			message:    "valid ini file should parse correctly",
-			configPath: "valid",
+			configPath: "valid/timeout",
 		},
 		{
 			message:    "absent ini file should be ignored",
@@ -523,6 +525,108 @@ func TestParseIniFile(t *testing.T) {
 		} else {
 			assert.EqualError(t, err, "error reading defaults: "+tt.expectedError, tt.message)
 		}
+	}
+}
+
+func TestConfigOverride(t *testing.T) {
+	originalConfigHome := os.Getenv(_configHomeEnv)
+	defer os.Setenv(_configHomeEnv, originalConfigHome)
+
+	tests := []struct {
+		msg            string
+		configContents string
+		args           []string
+		validateFn     func(*Options, string)
+		wantErr        string
+	}{
+		{
+			msg:            "peer list in config",
+			configContents: `peer-list = "/hosts.json"`,
+			validateFn: func(opts *Options, msg string) {
+				assert.Equal(t, "/hosts.json", opts.TOpts.HostPortFile, msg)
+				assert.Empty(t, opts.TOpts.HostPorts, msg)
+			},
+		},
+		{
+			msg:            "peer list in config and args",
+			configContents: `peer-list = "/hosts.json"`,
+			args:           []string{"-P", "/hosts2.json"},
+			validateFn: func(opts *Options, msg string) {
+				assert.Equal(t, "/hosts2.json", opts.TOpts.HostPortFile, msg)
+				assert.Empty(t, opts.TOpts.HostPorts, msg)
+			},
+		},
+		{
+			msg: "peer and peer list in config",
+			configContents: `
+				peer-list = "/hosts.json"
+				peer = 1.1.1.1:1
+			`,
+			validateFn: func(opts *Options, msg string) {
+				assert.Equal(t, "/hosts.json", opts.TOpts.HostPortFile, msg)
+				assert.Equal(t, []string{"1.1.1.1:1"}, opts.TOpts.HostPorts, msg)
+			},
+		},
+		{
+			msg:            "peer list in config, peer in args",
+			configContents: `peer-list = "/hosts.json"`,
+			args:           []string{"-p", "1.1.1.1:1"},
+			validateFn: func(opts *Options, msg string) {
+				assert.Empty(t, opts.TOpts.HostPortFile, "%v: hosts file should be cleared", msg)
+				assert.Equal(t, []string{"1.1.1.1:1"}, opts.TOpts.HostPorts, "%v: hostPorts", msg)
+			},
+		},
+		{
+			msg: "peer and peer list in config, peer in args",
+			configContents: `
+				peer-list = "/hosts.json"
+				peer = 1.1.1.1:1
+			`,
+			args: []string{"-p", "1.1.1.1:2"},
+			validateFn: func(opts *Options, msg string) {
+				assert.Empty(t, opts.TOpts.HostPortFile, "%v: hosts file should be cleared", msg)
+				assert.Equal(t, []string{"1.1.1.1:2"}, opts.TOpts.HostPorts, "%v: hostPorts", msg)
+			},
+		},
+		{
+			msg: "peer and peer list in config, peerlist in args",
+			configContents: `
+				peer-list = "/hosts.json"
+				peer = 1.1.1.1:1
+			`,
+			args: []string{"-P", "/hosts2.json"},
+			validateFn: func(opts *Options, msg string) {
+				assert.Equal(t, "/hosts2.json", opts.TOpts.HostPortFile, msg)
+				assert.Empty(t, opts.TOpts.HostPorts, msg)
+			},
+		},
+	}
+
+	tempDir, err := ioutil.TempDir("", "config")
+	require.NoError(t, err, "Failed to create temporary directory")
+	err = os.Mkdir(filepath.Join(tempDir, "yab"), os.ModeDir|0777)
+	require.NoError(t, err, "failed to create yab directory in temporary config dir")
+	configPath := filepath.Join(tempDir, "yab", "defaults.ini")
+
+	os.Setenv(_configHomeEnv, tempDir)
+	for _, tt := range tests {
+		err := ioutil.WriteFile(configPath, []byte(tt.configContents), 0777)
+		require.NoError(t, err, "Failed to write out defaults file")
+
+		_, out := getOutput(t)
+		opts, err := getOptions(tt.args, out)
+		if err == errExit {
+			err = nil
+		}
+		if tt.wantErr != "" {
+			if assert.Error(t, err, tt.msg) {
+				assert.Contains(t, err.Error(), tt.wantErr, tt.msg)
+			}
+			continue
+		}
+
+		assert.NoError(t, err, tt.msg)
+		tt.validateFn(opts, tt.msg)
 	}
 }
 


### PR DESCRIPTION
If defaults sets the hosts file, but args sets a single peer, the
final options should only contain the single peer. If both are set,
yab returns an error.

This is required if we want to set a default peer list in a global
config that is only used when the user doesn't override the peer in
any way.