### PR TITLE
Add linux build; Ensure build makes a binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
-PACKAGES := $(shell glide novendor)
+PACKAGES := $(filter-out ., $(shell glide novendor))
 
 export GO15VENDOREXPERIMENT=1
+
+.DEFAULT_GOAL:=build
 
 
 .PHONY: build
 build:
 	go build -i $(PACKAGES)
+	go build -i .
 
+build_prod:
+	env GOOS=linux GOARCH=amd64 $(MAKE)
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGES := $(filter-out ., $(shell glide novendor))
+PACKAGES := $(shell glide novendor)
 
 export GO15VENDOREXPERIMENT=1
 
@@ -9,9 +9,6 @@ export GO15VENDOREXPERIMENT=1
 build:
 	go build -i $(PACKAGES)
 	go build -i .
-
-build_prod:
-	env GOOS=linux GOARCH=amd64 $(MAKE)
 
 .PHONY: install
 install:


### PR DESCRIPTION
Add a build target which will build a linux compatible binary.
Additionally ensure that the build target will actually build a binary
it seems that `go build -i ./a/... ./number/... ./of/... ./pkgs/... .`
only builds the libraries so we strip the local dir out of $PACKAGES
and then explicitly build it.

Also add a DEFAULT_GOAL to be explicit and avoid ever accidentally
breaking the default behaviour by adding a target in the wrong place.