### PR TITLE
Add Error Rate to benchmark output

### DIFF
--- a/bench_state.go
+++ b/bench_state.go
@@ -98,7 +98,7 @@ func (s *benchmarkState) printErrors(out output) {
 		out.Printf("  %4d: %v\n", v, k)
 	}
 	out.Printf("Total errors: %v\n", s.totalErrors)
-	out.Printf("Error rate: %.4f\n", float32(s.totalErrors)/float32(s.totalRequests))
+	out.Printf("Error rate: %.4f%%\n", 100*float32(s.totalErrors)/float32(s.totalRequests))
 }
 
 func (s *benchmarkState) getQuantile(q float64) time.Duration {

--- a/bench_state.go
+++ b/bench_state.go
@@ -86,6 +86,7 @@ func (s *benchmarkState) printErrors(out output) {
 		total += v
 	}
 	out.Printf("Total errors: %v\n", total)
+	out.Printf("Error rate: %.4f\n", float32(total)/float32(len(s.latencies)))
 }
 
 func (s *benchmarkState) getQuantile(q float64) time.Duration {

--- a/bench_state_test.go
+++ b/bench_state_test.go
@@ -50,14 +50,14 @@ func TestBenchmarkStateErrors(t *testing.T) {
 
 	buf, out := getOutput(t)
 
-	//before merge
+	// before merge
 	assert.Equal(t, state1.totalErrors, 4, "Error count mismatch")
 	assert.Equal(t, state1.totalSuccess, 0, "Success count mismatch")
 	assert.Equal(t, state1.totalRequests, 4, "Request count mismatch")
 
 	state1.merge(state2)
 
-	//after merge
+	// after merge
 	assert.Equal(t, state1.totalErrors, 7, "Error count mismatch")
 	assert.Equal(t, state1.totalSuccess, 0, "Success count mismatch")
 	assert.Equal(t, state1.totalRequests, 7, "Request count mismatch")

--- a/bench_state_test.go
+++ b/bench_state_test.go
@@ -49,7 +49,19 @@ func TestBenchmarkStateErrors(t *testing.T) {
 	})
 
 	buf, out := getOutput(t)
+
+	//before merge
+	assert.Equal(t, state1.totalErrors, 4, "Error count mismatch")
+	assert.Equal(t, state1.totalSuccess, 0, "Success count mismatch")
+	assert.Equal(t, state1.totalRequests, 4, "Request count mismatch")
+
 	state1.merge(state2)
+
+	//after merge
+	assert.Equal(t, state1.totalErrors, 7, "Error count mismatch")
+	assert.Equal(t, state1.totalSuccess, 0, "Success count mismatch")
+	assert.Equal(t, state1.totalRequests, 7, "Request count mismatch")
+
 	state1.printErrors(out)
 
 	expected := map[string]int{
@@ -88,6 +100,11 @@ func TestBenchmarkStateLatencies(t *testing.T) {
 	}
 
 	buf, out := getOutput(t)
+
+	assert.Equal(t, state.totalErrors, 0, "Error count mismatch")
+	assert.Equal(t, state.totalSuccess, 10001, "Success count mismatch")
+	assert.Equal(t, state.totalRequests, 10001, "Request count mismatch")
+
 	state.printLatencies(out)
 
 	expected := []string{
@@ -122,7 +139,15 @@ func TestBenchmarkStateMergeLatencies(t *testing.T) {
 			state2.recordLatency(time.Duration(i) * time.Microsecond)
 		}
 	}
+	assert.Equal(t, state1.totalErrors, 0, "Error count mismatch")
+	assert.Equal(t, state1.totalSuccess, 5001, "Success count mismatch")
+	assert.Equal(t, state1.totalRequests, 5001, "Request count mismatch")
+
 	state1.merge(state2)
+
+	assert.Equal(t, state1.totalErrors, 0, "Error count mismatch")
+	assert.Equal(t, state1.totalSuccess, 10001, "Success count mismatch")
+	assert.Equal(t, state1.totalRequests, 10001, "Request count mismatch")
 
 	buf, out := getOutput(t)
 	state1.printLatencies(out)

--- a/benchmark.go
+++ b/benchmark.go
@@ -138,8 +138,8 @@ func runBenchmark(out output, allOpts Options, m benchmarkMethod) {
 	overall.printLatencies(out)
 
 	out.Printf("Elapsed time:      %v\n", (total / time.Millisecond * time.Millisecond))
-	out.Printf("Total requests:    %v\n", len(overall.latencies))
-	out.Printf("RPS:               %.2f\n", float64(len(overall.latencies))/total.Seconds())
+	out.Printf("Total requests:    %v\n", overall.totalRequests)
+	out.Printf("RPS:               %.2f\n", float64(overall.totalRequests)/total.Seconds())
 }
 
 // stopOnInterrupt sets up a signal that will trigger the run to stop.


### PR DESCRIPTION
Example of new output

> Benchmark parameters:
  CPUs:            24
  Connections:     48
  Concurrency:     5
  Max requests:    18000
  Max duration:    1m0s
  Max RPS:         300
Errors:
   969: tchannel error ErrCodeDeclined: Service is not healthy
    27: tchannel error ErrCodeTimeout: request timed out after XXXXms (limit was XXXms)
   284: tchannel error ErrCodeTimeout: request timed out after XXXms (limit was XXXms)
  1005: tchannel error ErrCodeTimeout: timeout
Total errors: 2285
Error rate: 0.1535
Latencies:
  0.5000: 613.118244ms
  0.9000: 907.028082ms
  0.9500: 951.607273ms
  0.9900: 998.944412ms
  0.9990: 1.697313257s
  0.9995: 1.803770667s
  1.0000: 1.971703062s
Elapsed time:      1m1.077s
Total requests:    14883
RPS:               243.68