### PR TITLE
benchmarking: Allow unlimited requests (capped by max duration)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go:
 env:
     global:
         - GO15VENDOREXPERIMENT=1
+        - TEST_TIMEOUT_SCALE=10
 
 cache:
   directories:

--- a/benchmark.go
+++ b/benchmark.go
@@ -65,16 +65,16 @@ func runWorker(t transport.Transport, m benchmarkMethod, s *benchmarkState, run 
 func runBenchmark(out output, allOpts Options, m benchmarkMethod) {
 	opts := allOpts.BOpts
 
-	// By default, benchmarks are disabled. At least MaxDuration needs to
-	// be set to enable them.
-	if opts.MaxDuration == 0 {
+	// By default, benchmarks are disabled. At least MaxDuration or MaxRequests
+	// should be > 0 for the benchmark to start.
+	if opts.MaxDuration == 0 && opts.MaxRequests == 0 {
 		return
 	}
 
-	if opts.RPS > 0 {
+	if opts.RPS > 0 && opts.MaxDuration > 0 {
 		// The RPS * duration in seconds may cap opts.MaxRequests.
 		rpsMax := int(float64(opts.RPS) * opts.MaxDuration.Seconds())
-		if rpsMax < opts.MaxRequests {
+		if rpsMax < opts.MaxRequests || opts.MaxRequests == 0 {
 			opts.MaxRequests = rpsMax
 		}
 	}

--- a/benchmark.go
+++ b/benchmark.go
@@ -71,6 +71,13 @@ func runBenchmark(out output, allOpts Options, m benchmarkMethod) {
 		return
 	}
 
+	if opts.MaxDuration < 0 {
+		out.Fatalf("Benchmark duration cannot be negative")
+	}
+	if opts.MaxRequests < 0 {
+		out.Fatalf("Benchmark max requests cannot be negative")
+	}
+
 	if opts.RPS > 0 && opts.MaxDuration > 0 {
 		// The RPS * duration in seconds may cap opts.MaxRequests.
 		rpsMax := int(float64(opts.RPS) * opts.MaxDuration.Seconds())

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -28,9 +28,37 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/atomic"
+	"github.com/uber/tchannel-go/testutils"
 )
 
 func TestBenchmark(t *testing.T) {
+	tests := []struct {
+		msg          string
+		n            int
+		d            time.Duration
+		rps          int
+		want         int
+		wantDuration time.Duration
+	}{
+		{
+			msg:  "Capped by max requests",
+			n:    1000,
+			d:    100 * time.Second,
+			want: 1000,
+		},
+		{
+			msg:          "Capped by RPS * duration",
+			d:            500 * time.Millisecond,
+			rps:          1200,
+			want:         600,
+			wantDuration: 500 * time.Millisecond,
+		},
+		{
+			msg:          "Capped by duration",
+			d:            500 * time.Millisecond,
+			wantDuration: 500 * time.Millisecond,
+		},
+	}
 
 	var requests atomic.Int32
 	s := newServer(t)
@@ -40,24 +68,40 @@ func TestBenchmark(t *testing.T) {
 	}))
 
 	m := benchmarkMethodForTest(t, fooMethod, transport.TChannel)
-	buf, out := getOutput(t)
 
-	runBenchmark(out, Options{
-		BOpts: BenchmarkOptions{
-			MaxRequests:    1000,
-			MaxDuration:    time.Second,
-			Connections:    50,
-			WarmupRequests: 10,
-			Concurrency:    2,
-		},
-		TOpts: s.transportOpts(),
-	}, m)
+	for _, tt := range tests {
+		requests.Store(0)
 
-	bufStr := buf.String()
-	assert.Contains(t, bufStr, "Max RPS")
-	assert.NotContains(t, bufStr, "Errors")
+		start := time.Now()
+		buf, out := getOutput(t)
+		runBenchmark(out, Options{
+			BOpts: BenchmarkOptions{
+				MaxRequests:    tt.n,
+				MaxDuration:    tt.d,
+				RPS:            tt.rps,
+				Connections:    50,
+				WarmupRequests: 10,
+				Concurrency:    2,
+			},
+			TOpts: s.transportOpts(),
+		}, m)
 
-	// Due to warm up, we make:
-	// 10 * Connections extra requests
-	assert.EqualValues(t, 1000+10*50, requests.Load(), "Invalid number of requests")
+		bufStr := buf.String()
+		assert.Contains(t, bufStr, "Max RPS")
+		assert.NotContains(t, bufStr, "Errors")
+
+		warmupExtra := 10 * 50 // warmup requests * connections
+		if tt.want != 0 {
+			assert.EqualValues(t, tt.want+warmupExtra, requests.Load(),
+				"%v: Invalid number of requests", tt.msg)
+		}
+
+		if tt.wantDuration != 0 {
+			// Make sure the total duration is within a delta.
+			slack := testutils.Timeout(500 * time.Millisecond)
+			duration := time.Since(start)
+			assert.True(t, duration <= tt.wantDuration+slack && duration >= tt.wantDuration-slack,
+				"%v: Took %v, wanted duration %v", tt.msg, duration, tt.wantDuration)
+		}
+	}
 }

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -42,15 +42,15 @@ func TestBenchmark(t *testing.T) {
 	}{
 		{
 			msg:  "Capped by max requests",
-			n:    1000,
+			n:    100,
 			d:    100 * time.Second,
-			want: 1000,
+			want: 100,
 		},
 		{
 			msg:          "Capped by RPS * duration",
 			d:            500 * time.Millisecond,
-			rps:          1200,
-			want:         600,
+			rps:          120,
+			want:         60,
 			wantDuration: 500 * time.Millisecond,
 		},
 		{

--- a/limiter/limiter_test.go
+++ b/limiter/limiter_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go/testutils"
 )
 
 func TestSerial(t *testing.T) {
@@ -65,6 +66,26 @@ func TestStop(t *testing.T) {
 func TestTimeout(t *testing.T) {
 	run := New(1000 /* maxRequests */, 1000 /* rps */, time.Millisecond)
 	assert.True(t, run.More(), "Succeed within the timeout")
+	time.Sleep(5 * time.Millisecond)
+	assert.False(t, run.More(), "Fail after the timeout")
+}
+
+func TestUnlimitedRequests(t *testing.T) {
+	timeout := testutils.Timeout(100 * time.Millisecond)
+	run := New(0 /* maxRequests */, 1000 /* rps */, timeout)
+	for i := 0; i < 5; i++ {
+		assert.True(t, run.More(), "Unlimited should suceed till timeout")
+	}
+	time.Sleep(timeout)
+	assert.False(t, run.More(), "Fail after the timeout")
+}
+
+func TestUnlimitedStop(t *testing.T) {
+	run := New(0 /* maxRequests */, 0 /* rps */, 0 /* maxDuration */)
+	for i := 0; i < 5; i++ {
+		assert.True(t, run.More(), "Unlimited should suceed till Stop")
+	}
+	run.Stop()
 	time.Sleep(5 * time.Millisecond)
 	assert.False(t, run.More(), "Fail after the timeout")
 }

--- a/options.go
+++ b/options.go
@@ -82,8 +82,8 @@ type TransportOptions struct {
 
 // BenchmarkOptions are benchmark-specific options
 type BenchmarkOptions struct {
-	MaxRequests int           `short:"n" long:"max-requests" default:"1000000" description:"The maximum number of requests to make"`
-	MaxDuration time.Duration `short:"d" long:"max-duration" default:"0s" description:"The maximum amount of time to run the benchmark for"`
+	MaxRequests int           `short:"n" long:"max-requests" default:"0" description:"The maximum number of requests to make. Values <= 0 imply no limit."`
+	MaxDuration time.Duration `short:"d" long:"max-duration" default:"0s" description:"The maximum amount of time to run the benchmark for. Values <= 0 imply no duration limit."`
 
 	// NumCPUs is the value for GOMAXPROCS. The default value of 0 will not update GOMAXPROCS.
 	NumCPUs int `long:"cpus" description:"The number of OS threads"`

--- a/options.go
+++ b/options.go
@@ -82,8 +82,8 @@ type TransportOptions struct {
 
 // BenchmarkOptions are benchmark-specific options
 type BenchmarkOptions struct {
-	MaxRequests int           `short:"n" long:"max-requests" default:"0" description:"The maximum number of requests to make. Values <= 0 imply no limit."`
-	MaxDuration time.Duration `short:"d" long:"max-duration" default:"0s" description:"The maximum amount of time to run the benchmark for. Values <= 0 imply no duration limit."`
+	MaxRequests int           `short:"n" long:"max-requests" default:"0" description:"The maximum number of requests to make. 0 implies no limit."`
+	MaxDuration time.Duration `short:"d" long:"max-duration" default:"0s" description:"The maximum amount of time to run the benchmark for. 0 implies no duration limit."`
 
 	// NumCPUs is the value for GOMAXPROCS. The default value of 0 will not update GOMAXPROCS.
 	NumCPUs int `long:"cpus" description:"The number of OS threads"`


### PR DESCRIPTION
Currently we always require a MaxRequests. Instead change the default to
have no MaxRequests, and make only MaxRequests or MaxDuration required
for a benchmark.

If RPS and MaxDuration are provided, an implicit MaxRequests is
calculated. Otherwise, the test runs until the max duration is hit.

Fixes #105