### PR TITLE
Allow yaml templates to specify RPC calls

### DIFF
--- a/main.go
+++ b/main.go
@@ -237,6 +237,10 @@ func parseDefaultConfigs(parser *flags.Parser) error {
 }
 
 func runWithOptions(opts Options, out output) {
+	if opts.ROpts.YamlTemplate != "" {
+		readYamlRequest(&opts)
+	}
+
 	reqInput, err := getRequestInput(opts.ROpts.RequestJSON, opts.ROpts.RequestFile)
 	if err != nil {
 		out.Fatalf("Failed while loading body input: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -238,7 +238,11 @@ func parseDefaultConfigs(parser *flags.Parser) error {
 
 func runWithOptions(opts Options, out output) {
 	if opts.ROpts.YamlTemplate != "" {
-		readYamlRequest(&opts)
+		err := readYamlRequest(&opts)
+		if err != nil {
+			out.Fatalf("Failed while reading yaml template: %v\n", err)
+		}
+
 	}
 
 	reqInput, err := getRequestInput(opts.ROpts.RequestJSON, opts.ROpts.RequestFile)

--- a/main_test.go
+++ b/main_test.go
@@ -839,3 +839,17 @@ func TestNoWarmupBenchmark(t *testing.T) {
 	assert.Contains(t, buf.String(), "Total errors: 100")
 	assert.Contains(t, buf.String(), "Error rate: 100")
 }
+
+func TestTemplates(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	echoAddr := echoServer(t, "", []byte{0})
+	os.Args = []string{
+		"yab",
+		"-y", exampleTemplate,
+		"-p", echoAddr,
+	}
+
+	main()
+}

--- a/options.go
+++ b/options.go
@@ -39,15 +39,16 @@ type Options struct {
 
 // RequestOptions are request related options
 type RequestOptions struct {
-	Encoding    encoding.Encoding `short:"e" long:"encoding" description:"The encoding of the data, options are: Thrift, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified"`
-	ThriftFile  string            `short:"t" long:"thrift" description:"Path of the .thrift file"`
-	MethodName  string            `short:"m" long:"method" description:"The full Thrift method name (Svc::Method) to invoke"`
-	RequestJSON string            `short:"r" long:"request" unquote:"false" description:"The request body, in JSON or YAML format"`
-	RequestFile string            `short:"f" long:"file" description:"Path of a file containing the request body in JSON or YAML"`
-	HeadersJSON string            `long:"headers" unquote:"false" description:"The headers in JSON or YAML format"`
-	HeadersFile string            `long:"headers-file" description:"Path of a file containing the headers in JSON or YAML"`
-	Health      bool              `long:"health" description:"Hit the health endpoint, Meta::health"`
-	Timeout     timeMillisFlag    `long:"timeout" default:"1s" description:"The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
+	Encoding     encoding.Encoding `short:"e" long:"encoding" description:"The encoding of the data, options are: Thrift, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified"`
+	ThriftFile   string            `short:"t" long:"thrift" description:"Path of the .thrift file"`
+	MethodName   string            `short:"m" long:"method" description:"The full Thrift method name (Svc::Method) to invoke"`
+	RequestJSON  string            `short:"r" long:"request" unquote:"false" description:"The request body, in JSON or YAML format"`
+	RequestFile  string            `short:"f" long:"file" description:"Path of a file containing the request body in JSON or YAML"`
+	HeadersJSON  string            `long:"headers" unquote:"false" description:"The headers in JSON or YAML format"`
+	HeadersFile  string            `long:"headers-file" description:"Path of a file containing the headers in JSON or YAML"`
+	Health       bool              `long:"health" description:"Hit the health endpoint, Meta::health"`
+	Timeout      timeMillisFlag    `long:"timeout" default:"1s" description:"The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
+	YamlTemplate string            `short:"y" long:"yaml-template" description:"Send a tchannel request specified by a yaml template"`
 
 	// Thrift options
 	ThriftDisableEnvelopes bool `long:"disable-thrift-envelope" description:"Disables Thrift envelopes (disabled by default for TChannel)"`

--- a/template.go
+++ b/template.go
@@ -45,4 +45,6 @@ func readYamlRequest(opts *Options) error {
 	opts.ROpts.HeadersJSON = string(headers)
 	opts.ROpts.RequestJSON = string(body)
 	opts.ROpts.Timeout = timeMillisFlag(t.Timeout)
+
+	return nil
 }

--- a/template.go
+++ b/template.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"gopkg.in/yaml.v2"
+	"time"
 )
 
 type template struct {
@@ -13,6 +14,7 @@ type template struct {
 	Method  string            `yaml:"method"`
 	Headers map[string]string `yaml:"headers"`
 	Request interface{}       `yaml:"request"`
+	Timeout time.Duration     `yaml:"timeout"`
 }
 
 func readYamlRequest(opts *Options) {
@@ -44,4 +46,5 @@ func readYamlRequest(opts *Options) {
 	opts.TOpts.ServiceName = t.Service
 	opts.ROpts.HeadersJSON = string(headers)
 	opts.ROpts.RequestJSON = string(body)
+	opts.ROpts.Timeout = timeMillisFlag(t.Timeout)
 }

--- a/template.go
+++ b/template.go
@@ -3,9 +3,9 @@ package main
 import (
 	"io/ioutil"
 	"log"
+	"time"
 
 	"gopkg.in/yaml.v2"
-	"time"
 )
 
 type template struct {

--- a/template.go
+++ b/template.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+
+	"gopkg.in/yaml.v2"
+)
+
+type template struct {
+	Service string            `yaml:"service"`
+	Thrift  string            `yaml:"thrift"`
+	Method  string            `yaml:"method"`
+	Headers map[string]string `yaml:"headers"`
+	Request interface{}       `yaml:"request"`
+}
+
+func readYamlRequest(opts *Options) {
+	t := template{}
+
+	bytes, err := ioutil.ReadFile(opts.ROpts.YamlTemplate)
+	if err != nil {
+		log.Fatalf("Unable to read file: %v\n", err)
+	}
+
+	err = yaml.Unmarshal(bytes, &t)
+	if err != nil {
+		log.Fatalf("Unable to parse file: %v\n", err)
+	}
+
+	body, err := yaml.Marshal(t.Request)
+	if err != nil {
+		log.Fatalf("Unable to marshal yaml: %v\n", err)
+	}
+
+	headers, err := yaml.Marshal(t.Headers)
+	if err != nil {
+		log.Fatalf("Unable to marshal yaml: %v\n", err)
+	}
+
+	// Should we overwrite if these clash with options specified on the command line?
+	opts.ROpts.ThriftFile = t.Thrift
+	opts.ROpts.MethodName = t.Method
+	opts.TOpts.ServiceName = t.Service
+	opts.ROpts.HeadersJSON = string(headers)
+	opts.ROpts.RequestJSON = string(body)
+}

--- a/template.go
+++ b/template.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io/ioutil"
-	"log"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -17,30 +16,29 @@ type template struct {
 	Timeout time.Duration     `yaml:"timeout"`
 }
 
-func readYamlRequest(opts *Options) {
+func readYamlRequest(opts *Options) error {
 	t := template{}
 
 	bytes, err := ioutil.ReadFile(opts.ROpts.YamlTemplate)
 	if err != nil {
-		log.Fatalf("Unable to read file: %v\n", err)
+		return err;
 	}
 
 	err = yaml.Unmarshal(bytes, &t)
 	if err != nil {
-		log.Fatalf("Unable to parse file: %v\n", err)
+		return err;
 	}
 
 	body, err := yaml.Marshal(t.Request)
 	if err != nil {
-		log.Fatalf("Unable to marshal yaml: %v\n", err)
+		return err;
 	}
 
 	headers, err := yaml.Marshal(t.Headers)
 	if err != nil {
-		log.Fatalf("Unable to marshal yaml: %v\n", err)
+		return err;
 	}
 
-	// Should we overwrite if these clash with options specified on the command line?
 	opts.ROpts.ThriftFile = t.Thrift
 	opts.ROpts.MethodName = t.Method
 	opts.TOpts.ServiceName = t.Service

--- a/testdata/templates/foo.thrift
+++ b/testdata/templates/foo.thrift
@@ -1,0 +1,9 @@
+struct QueryLocation {
+  1: required double latitude
+  2: required double longitude
+  3: optional i32 cityId
+}
+
+service Simple {
+  void foo(1: QueryLocation location)
+}

--- a/testdata/templates/foo.yaml
+++ b/testdata/templates/foo.yaml
@@ -1,0 +1,12 @@
+service: foo
+method: Simple::foo
+thrift: testdata/templates/foo.thrift
+timeout: 4.5s
+headers:
+    header1: value1
+    header2: value2
+request:
+    location:
+        latitude: 37.7
+        longitude: -122.4
+        cityId: 1

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -32,8 +32,9 @@ import (
 
 // Constants useful for tests
 const (
-	validThrift = "testdata/simple.thrift"
-	fooMethod   = "Simple::foo"
+	validThrift     = "testdata/simple.thrift"
+	fooMethod       = "Simple::foo"
+	exampleTemplate = "testdata/templates/foo.yaml"
 )
 
 type testOutput struct {


### PR DESCRIPTION
This will allow you to specify RPCs as template files on the command line:

`yab --timeout 3s --peer 127.0.0.1:21300 -y time.yaml`

Example contents of `time.yaml`:

```
service: "time"
method: "time::queryV2"
thrift: "path/to/some/files/time.idl"
headers:
    header1: value1
    header2: value2
request:
    location: 
        latitude: 37.7
        longitude: -122.4
        cityId: 1
```

I'm planning a template generator which will come in a later PR.
