### PR TITLE
Make headers work consistent with YARPC for HTTP application headers

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -150,10 +150,9 @@ func (httpHandler) Bar(arg int32) (int32, error) {
 type yarpcHandler struct{}
 
 func (yarpcHandler) Bar(ctx context.Context, reqMeta yarpc.ReqMeta, arg *int32) (int32, yarpc.ResMeta, error) {
-	// TODO validate RPC headers over HTTP
-	// if err := verifyYARPCHeaders(reqMeta); err != nil {
-	// 	return 0, nil, err
-	// }
+	if err := verifyYARPCHeaders(reqMeta); err != nil {
+		return 0, nil, err
+	}
 	if err := verifyBaggage(ctx); err != nil {
 		return 0, nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -285,6 +285,7 @@ func runWithOptions(opts Options, out output) {
 	}
 
 	req.Headers = headers
+	req.TransportHeaders = opts.TOpts.Headers
 	req.Timeout = opts.ROpts.Timeout.Duration()
 	if req.Timeout == 0 {
 		req.Timeout = time.Second

--- a/main.go
+++ b/main.go
@@ -285,7 +285,7 @@ func runWithOptions(opts Options, out output) {
 	}
 
 	req.Headers = headers
-	req.TransportHeaders = opts.TOpts.Headers
+	req.TransportHeaders = opts.TOpts.TransportHeaders
 	req.Timeout = opts.ROpts.Timeout.Duration()
 	if req.Timeout == 0 {
 		req.Timeout = time.Second

--- a/options.go
+++ b/options.go
@@ -69,12 +69,12 @@ type RequestOptions struct {
 
 // TransportOptions are transport related options.
 type TransportOptions struct {
-	ServiceName  string            `short:"s" long:"service" description:"The TChannel/Hyperbahn service name"`
-	HostPorts    []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
-	HostPortFile string            `short:"P" long:"peer-list" description:"Path of a JSON or YAML file containing a list of host:ports"`
-	CallerName   string            `long:"caller" description:"Caller will override the default caller name (which is yab-$USER)."`
-	Jaeger       bool              `long:"jaeger" description:"Use the Jaeger tracing client to send Uber style traces and baggage headers"`
-	Headers      map[string]string `short:"T" long:"topt" description:"Transport options for TChannel, protocol headers for HTTP"`
+	ServiceName      string            `short:"s" long:"service" description:"The TChannel/Hyperbahn service name"`
+	HostPorts        []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
+	HostPortFile     string            `short:"P" long:"peer-list" description:"Path of a JSON or YAML file containing a list of host:ports"`
+	CallerName       string            `long:"caller" description:"Caller will override the default caller name (which is yab-$USER)."`
+	Jaeger           bool              `long:"jaeger" description:"Use the Jaeger tracing client to send Uber style traces and baggage headers"`
+	TransportHeaders map[string]string `short:"T" long:"topt" description:"Transport options for TChannel, protocol headers for HTTP"`
 }
 
 // BenchmarkOptions are benchmark-specific options

--- a/options.go
+++ b/options.go
@@ -69,12 +69,12 @@ type RequestOptions struct {
 
 // TransportOptions are transport related options.
 type TransportOptions struct {
-	ServiceName      string            `short:"s" long:"service" description:"The TChannel/Hyperbahn service name"`
-	HostPorts        []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
-	HostPortFile     string            `short:"P" long:"peer-list" description:"Path of a JSON or YAML file containing a list of host:ports"`
-	CallerName       string            `long:"caller" description:"Caller will override the default caller name (which is yab-$USER)."`
-	Jaeger           bool              `long:"jaeger" description:"Use the Jaeger tracing client to send Uber style traces and baggage headers"`
-	TransportOptions map[string]string `long:"topt" description:"Custom options for the specific transport being used"`
+	ServiceName  string            `short:"s" long:"service" description:"The TChannel/Hyperbahn service name"`
+	HostPorts    []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
+	HostPortFile string            `short:"P" long:"peer-list" description:"Path of a JSON or YAML file containing a list of host:ports"`
+	CallerName   string            `long:"caller" description:"Caller will override the default caller name (which is yab-$USER)."`
+	Jaeger       bool              `long:"jaeger" description:"Use the Jaeger tracing client to send Uber style traces and baggage headers"`
+	Headers      map[string]string `short:"T" long:"topt" description:"Transport options for TChannel, protocol headers for HTTP"`
 }
 
 // BenchmarkOptions are benchmark-specific options

--- a/transport.go
+++ b/transport.go
@@ -144,7 +144,7 @@ func getTransport(opts TransportOptions, encoding encoding.Encoding, tracer open
 			TargetService: opts.ServiceName,
 			HostPorts:     opts.HostPorts,
 			Encoding:      encoding.String(),
-			TransportOpts: opts.TransportOptions,
+			TransportOpts: opts.Headers,
 			Tracer:        tracer,
 		}
 		return transport.NewTChannel(topts)

--- a/transport.go
+++ b/transport.go
@@ -144,7 +144,7 @@ func getTransport(opts TransportOptions, encoding encoding.Encoding, tracer open
 			TargetService: opts.ServiceName,
 			HostPorts:     opts.HostPorts,
 			Encoding:      encoding.String(),
-			TransportOpts: opts.Headers,
+			TransportOpts: opts.TransportHeaders,
 			Tracer:        tracer,
 		}
 		return transport.NewTChannel(topts)

--- a/transport/http.go
+++ b/transport/http.go
@@ -98,10 +98,12 @@ func (h *httpTransport) newReq(ctx context.Context, r *Request) (*http.Request, 
 	req.Header.Add("RPC-Encoding", h.opts.Encoding)
 	req.Header.Add("Context-TTL-MS", strconv.Itoa(int(timeout/time.Millisecond)))
 
-	for hdr, val := range r.Headers {
-		// TODO add Rpc-Header- prefix to headers and add transport headers
-		// without modification.
-		req.Header.Add(hdr, val)
+	for key, val := range r.Headers {
+		req.Header.Add("Rpc-Header-"+key, val)
+	}
+
+	for key, val := range r.TransportHeaders {
+		req.Header.Add(key, val)
 	}
 
 	span := opentracing.SpanFromContext(ctx)

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -190,7 +190,7 @@ func TestHTTPCall(t *testing.T) {
 	require.NoError(t, err, "Failed to create HTTP transport")
 
 	for _, tt := range tests {
-		tt.r.Headers = map[string]string{"hook": tt.hook}
+		tt.r.TransportHeaders = map[string]string{"hook": tt.hook}
 		got, err := transport.Call(tt.ctx, tt.r)
 		if tt.errMsg != "" {
 			if assert.Error(t, err, "Call(%v, %v) should fail", tt.ctx, tt.r) {

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -191,6 +191,7 @@ func TestHTTPCall(t *testing.T) {
 
 	for _, tt := range tests {
 		tt.r.TransportHeaders = map[string]string{"hook": tt.hook}
+		tt.r.Headers = map[string]string{"headerkey": "headervalue"}
 		got, err := transport.Call(tt.ctx, tt.r)
 		if tt.errMsg != "" {
 			if assert.Error(t, err, "Call(%v, %v) should fail", tt.ctx, tt.r) {
@@ -216,6 +217,7 @@ func TestHTTPCall(t *testing.T) {
 		assert.Equal(t, lastReq.headers.Get("RPC-Caller"), "source", "Caller header mismatch")
 		assert.Equal(t, lastReq.headers.Get("RPC-Procedure"), tt.r.Method, "Method header mismatch")
 		assert.Equal(t, lastReq.headers.Get("RPC-Encoding"), "raw", "Encoding header mismatch")
+		assert.Equal(t, lastReq.headers.Get("RPC-Header-Headerkey"), "headervalue", "Application header is sent with prefix")
 
 		ttlMS, err := strconv.Atoi(lastReq.headers.Get("Context-TTL-MS"))
 		if assert.NoError(t, err, "Failed to parse TTLms header: %v", lastReq.headers.Get("YARPC-TTLms")) {

--- a/transport/interface.go
+++ b/transport/interface.go
@@ -29,12 +29,13 @@ import (
 
 // Request is the fields used to make an RPC.
 type Request struct {
-	Method   string
-	Timeout  time.Duration
-	Headers  map[string]string
-	Baggage  map[string]string
-	ShardKey string
-	Body     []byte
+	Method           string
+	Timeout          time.Duration
+	Headers          map[string]string
+	Baggage          map[string]string
+	TransportHeaders map[string]string
+	ShardKey         string
+	Body             []byte
 }
 
 // Response represents the result of an RPC.


### PR DESCRIPTION
YARPC expects application headers to be passed as HTTP headers with the Rpc-Header- prefix. This change makes the -H flag consistently work across TChannel and HTTP applications, and reuses the --topts transport header map (now also -T) for HTTP headers without a prefix. So -T consistently means "transport headers".

r @prashantv @abhinav 