### PR TITLE
Support --rk, --rd, and --sk universally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog
 * Add support for headers with flags like -H key:value.
 * Add support for baggage headers with flags like -B key:value when baggage
   propagation is enabled with --jaeger.
+* Add support for routing key, routing delegate, and shard key, for both
+  HTTP and TChannel, using --rk, --rd, and --sk flags.
 
 # 0.6.2
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Transport Options:
                                  of host:ports
       --caller=                  Caller will override the default caller name
                                  (which is yab-$USER).
+      --rk=                      The routing key overrides the service name
+                                 traffic group for proxies.
+      --rd=                      The routing delegate overrides the routing key
+                                 traffic group for proxies.
+      --sk=                      The shard key is a transport header that clues
+                                 where to send a request within a clustered
+                                 traffic group.
       --jaeger                   Use the Jaeger tracing client to send Uber
                                  style traces and baggage headers
   -T, --topt=                    Transport options for TChannel, protocol

--- a/man/yab.1
+++ b/man/yab.1
@@ -240,6 +240,15 @@ Path of a JSON or YAML file containing a list of host:ports
 \fB\fB\-\-caller\fR\fP
 Caller will override the default caller name (which is yab-$USER).
 .TP
+\fB\fB\-\-rk\fR\fP
+The routing key overrides the service name traffic group for proxies.
+.TP
+\fB\fB\-\-rd\fR\fP
+The routing delegate overrides the routing key traffic group for proxies.
+.TP
+\fB\fB\-\-sk\fR\fP
+The shard key is a transport header that clues where to send a request within a clustered traffic group.
+.TP
 \fB\fB\-\-jaeger\fR\fP
 Use the Jaeger tracing client to send Uber style traces and baggage headers
 .TP

--- a/man/yab.html
+++ b/man/yab.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.19.2 -->
-<!-- CreationDate: Wed Nov  2 11:52:06 2016 -->
+<!-- CreationDate: Wed Nov  2 15:00:07 2016 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -329,6 +329,51 @@ containing a list of host:ports</p>
 
 <p style="margin-left:22%;">Caller will override the
 default caller name (which is yab-$USER).</p>
+
+<table width="100%" border=0 rules="none" frame="void"
+       cellspacing="0" cellpadding="0">
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="6%">
+
+
+
+<p style="margin-top: 1em" valign="top"><b>&minus;&minus;rk</b></p> </td>
+<td width="5%"></td>
+<td width="78%">
+
+
+<p style="margin-top: 1em" valign="top">The routing key
+overrides the service name traffic group for proxies.</p></td>
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="6%">
+
+
+
+<p style="margin-top: 1em" valign="top"><b>&minus;&minus;rd</b></p> </td>
+<td width="5%"></td>
+<td width="78%">
+
+
+<p style="margin-top: 1em" valign="top">The routing
+delegate overrides the routing key traffic group for
+proxies.</p> </td>
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="6%">
+
+
+
+<p style="margin-top: 1em" valign="top"><b>&minus;&minus;sk</b></p> </td>
+<td width="5%"></td>
+<td width="78%">
+
+
+<p style="margin-top: 1em" valign="top">The shard key is a
+transport header that clues where to send a request within a
+clustered traffic group.</p></td>
+</table>
 
 
 <p style="margin-left:11%;"><b>&minus;&minus;jaeger</b></p>

--- a/options.go
+++ b/options.go
@@ -73,6 +73,9 @@ type TransportOptions struct {
 	HostPorts        []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
 	HostPortFile     string            `short:"P" long:"peer-list" description:"Path of a JSON or YAML file containing a list of host:ports"`
 	CallerName       string            `long:"caller" description:"Caller will override the default caller name (which is yab-$USER)."`
+	RoutingKey       string            `long:"rk" description:"The routing key overrides the service name traffic group for proxies."`
+	RoutingDelegate  string            `long:"rd" description:"The routing delegate overrides the routing key traffic group for proxies."`
+	ShardKey         string            `long:"sk" description:"The shard key is a transport header that clues where to send a request within a clustered traffic group."`
 	Jaeger           bool              `long:"jaeger" description:"Use the Jaeger tracing client to send Uber style traces and baggage headers"`
 	TransportHeaders map[string]string `short:"T" long:"topt" description:"Transport options for TChannel, protocol headers for HTTP"`
 }

--- a/transport.go
+++ b/transport.go
@@ -140,22 +140,28 @@ func getTransport(opts TransportOptions, encoding encoding.Encoding, tracer open
 		remapLocalHost(opts.HostPorts)
 
 		topts := transport.TChannelOptions{
-			SourceService: opts.CallerName,
-			TargetService: opts.ServiceName,
-			HostPorts:     opts.HostPorts,
-			Encoding:      encoding.String(),
-			TransportOpts: opts.TransportHeaders,
-			Tracer:        tracer,
+			SourceService:   opts.CallerName,
+			TargetService:   opts.ServiceName,
+			RoutingDelegate: opts.RoutingDelegate,
+			RoutingKey:      opts.RoutingKey,
+			ShardKey:        opts.ShardKey,
+			HostPorts:       opts.HostPorts,
+			Encoding:        encoding.String(),
+			TransportOpts:   opts.TransportHeaders,
+			Tracer:          tracer,
 		}
 		return transport.NewTChannel(topts)
 	}
 
 	hopts := transport.HTTPOptions{
-		SourceService: opts.CallerName,
-		TargetService: opts.ServiceName,
-		Encoding:      encoding.String(),
-		URLs:          opts.HostPorts,
-		Tracer:        tracer,
+		SourceService:   opts.CallerName,
+		TargetService:   opts.ServiceName,
+		RoutingDelegate: opts.RoutingDelegate,
+		RoutingKey:      opts.RoutingKey,
+		ShardKey:        opts.ShardKey,
+		Encoding:        encoding.String(),
+		URLs:            opts.HostPorts,
+		Tracer:          tracer,
 	}
 	return transport.NewHTTP(hopts)
 }

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -182,10 +182,13 @@ func TestHTTPCall(t *testing.T) {
 	defer svr.Close()
 
 	transport, err := NewHTTP(HTTPOptions{
-		URLs:          []string{svr.URL + "/rpc"},
-		SourceService: "source",
-		TargetService: "target",
-		Encoding:      "raw",
+		URLs:            []string{svr.URL + "/rpc"},
+		SourceService:   "source",
+		TargetService:   "target",
+		ShardKey:        "sk",
+		RoutingKey:      "rk",
+		RoutingDelegate: "rd",
+		Encoding:        "raw",
 	})
 	require.NoError(t, err, "Failed to create HTTP transport")
 
@@ -213,11 +216,14 @@ func TestHTTPCall(t *testing.T) {
 		}
 
 		assert.Equal(t, lastReq.url.Path, "/rpc", "Path mismatch")
-		assert.Equal(t, lastReq.headers.Get("RPC-Service"), "target", "Service header mismatch")
-		assert.Equal(t, lastReq.headers.Get("RPC-Caller"), "source", "Caller header mismatch")
-		assert.Equal(t, lastReq.headers.Get("RPC-Procedure"), tt.r.Method, "Method header mismatch")
-		assert.Equal(t, lastReq.headers.Get("RPC-Encoding"), "raw", "Encoding header mismatch")
-		assert.Equal(t, lastReq.headers.Get("RPC-Header-Headerkey"), "headervalue", "Application header is sent with prefix")
+		assert.Equal(t, lastReq.headers.Get("Rpc-Service"), "target", "Service header mismatch")
+		assert.Equal(t, lastReq.headers.Get("Rpc-Caller"), "source", "Caller header mismatch")
+		assert.Equal(t, lastReq.headers.Get("Rpc-Shard-Key"), "sk", "Shard key header mismatch")
+		assert.Equal(t, lastReq.headers.Get("Rpc-Routing-Key"), "rk", "Routing key header mismatch")
+		assert.Equal(t, lastReq.headers.Get("Rpc-Routing-Delegate"), "rd", "Routing delegate header mismatch")
+		assert.Equal(t, lastReq.headers.Get("Rpc-Procedure"), tt.r.Method, "Method header mismatch")
+		assert.Equal(t, lastReq.headers.Get("Rpc-Encoding"), "raw", "Encoding header mismatch")
+		assert.Equal(t, lastReq.headers.Get("Rpc-Header-Headerkey"), "headervalue", "Application header is sent with prefix")
 
 		ttlMS, err := strconv.Atoi(lastReq.headers.Get("Context-TTL-MS"))
 		if assert.NoError(t, err, "Failed to parse TTLms header: %v", lastReq.headers.Get("YARPC-TTLms")) {

--- a/transport/tchannel.go
+++ b/transport/tchannel.go
@@ -52,6 +52,19 @@ type TChannelOptions struct {
 	// TargetService is the service name being targeted.
 	TargetService string
 
+	// RoutingDelegate is a traffic group that overrides the routing key,
+	// to redirect to an application layer traffic proxy.
+	RoutingDelegate string
+
+	// RoutingKey is a traffic group that overrides the service name, for a
+	// proxy to redirect to a more specific traffic group than the service
+	// proper.
+	RoutingKey string
+
+	// ShardKey is an opaque blob that clues where to direct a request to an
+	// instance within a traffic group.
+	ShardKey string
+
 	// LogLevel overrides the default LogLevel (Warn).
 	LogLevel *tchannel.LogLevel
 
@@ -107,6 +120,7 @@ func NewTChannel(opts TChannelOptions) (Transport, error) {
 	callOpts := &tchannel.CallOptions{
 		Format: tchannel.Format(opts.Encoding),
 	}
+	applyRPCOptions(callOpts, opts)
 	applyTChanOptions(callOpts, opts.TransportOpts)
 
 	return &tchan{
@@ -235,6 +249,12 @@ func (t *tchan) writeArgs(call *tchannel.OutboundCall, r *Request) error {
 	}
 
 	return nil
+}
+
+func applyRPCOptions(callOpts *tchannel.CallOptions, opts TChannelOptions) {
+	callOpts.RoutingDelegate = opts.RoutingDelegate
+	callOpts.RoutingKey = opts.RoutingKey
+	callOpts.ShardKey = opts.ShardKey
 }
 
 func applyTChanOptions(callOpts *tchannel.CallOptions, opts map[string]string) {

--- a/transport/tchannel_test.go
+++ b/transport/tchannel_test.go
@@ -101,9 +101,12 @@ func setEncoding(encoding string) func(*TChannelOptions) {
 	}
 }
 
-func setOptions(options map[string]string) func(*TChannelOptions) {
+func setOptions(options TChannelCallOptionsTest) func(*TChannelOptions) {
 	return func(opts *TChannelOptions) {
-		opts.TransportOpts = options
+		opts.ShardKey = options.sk
+		opts.RoutingKey = options.rk
+		opts.RoutingDelegate = options.rd
+		opts.TransportOpts = options.opts
 	}
 }
 
@@ -235,15 +238,20 @@ func TestTChannelCallError(t *testing.T) {
 	}
 }
 
+type TChannelCallOptionsTest struct {
+	opts       map[string]string
+	wantCaller string
+	sk         string
+	rk         string
+	rd         string
+	wantSK     string
+	wantRK     string
+	wantRD     string
+	wantFormat tchannel.Format
+}
+
 func TestTChannelCallOptions(t *testing.T) {
-	tests := []struct {
-		opts       map[string]string
-		wantCaller string
-		wantSK     string
-		wantRK     string
-		wantRD     string
-		wantFormat tchannel.Format
-	}{
+	tests := []TChannelCallOptionsTest{
 		{
 			opts: nil,
 			// Nil map uses the defaults
@@ -276,10 +284,18 @@ func TestTChannelCallOptions(t *testing.T) {
 			wantRK:     "rk",
 			wantRD:     "rd",
 		},
+		{
+			sk:     "sk",
+			rd:     "rd",
+			rk:     "rk",
+			wantSK: "sk",
+			wantRK: "rk",
+			wantRD: "rd",
+		},
 	}
 
 	for _, tt := range tests {
-		svr, transport := setupServerAndTransport(t, setOptions(tt.opts))
+		svr, transport := setupServerAndTransport(t, setOptions(tt))
 		defer svr.Close()
 
 		wantCaller := "yab"


### PR DESCRIPTION
This is the proper support for routing flags with HTTP and TChannel covered with the YARPC conventions for equivalent properties.