### PR TITLE
Adding logger to output debugging information with Verbose flag

### DIFF
--- a/benchmark.go
+++ b/benchmark.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/uber-go/zap"
 	"github.com/yarpc/yab/limiter"
 	"github.com/yarpc/yab/statsd"
 	"github.com/yarpc/yab/transport"
@@ -114,6 +115,8 @@ func runBenchmark(out output, allOpts Options, m benchmarkMethod) {
 	out.Printf("  Max requests:    %v\n", opts.MaxRequests)
 	out.Printf("  Max duration:    %v\n", opts.MaxDuration)
 	out.Printf("  Max RPS:         %v\n", opts.RPS)
+
+	out.Debug("starting benchmark", zap.Int("numConns", numConns))
 
 	// Warm up number of connections.
 	connections, err := m.WarmTransports(numConns, allOpts.TOpts, opts.WarmupRequests)

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestBenchmark(t *testing.T) {
+
 	tests := []struct {
 		msg          string
 		n            int

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -81,12 +81,11 @@ func TestBenchmark(t *testing.T) {
 		start := time.Now()
 		runBenchmark(out, Options{
 			BOpts: BenchmarkOptions{
-				MaxRequests:    tt.n,
-				MaxDuration:    tt.d,
-				RPS:            tt.rps,
-				Connections:    50,
-				WarmupRequests: 10,
-				Concurrency:    2,
+				MaxRequests: tt.n,
+				MaxDuration: tt.d,
+				RPS:         tt.rps,
+				Connections: 50,
+				Concurrency: 2,
 			},
 			TOpts: s.transportOpts(),
 		}, m)
@@ -95,9 +94,8 @@ func TestBenchmark(t *testing.T) {
 		assert.Contains(t, bufStr, "Max RPS")
 		assert.NotContains(t, bufStr, "Errors")
 
-		warmupExtra := 10 * 50 // warmup requests * connections
 		if tt.want != 0 {
-			assert.EqualValues(t, tt.want+warmupExtra, requests.Load(),
+			assert.EqualValues(t, tt.want, requests.Load(),
 				"%v: Invalid number of requests", tt.msg)
 		}
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -101,8 +101,7 @@ func TestBenchmark(t *testing.T) {
 
 		if tt.wantDuration != 0 {
 			// Make sure the total duration is within a delta.
-			// Should account for the request timeout set in benchmarkMethodForTest
-			slack := testutils.Timeout(time.Second)
+			slack := testutils.Timeout(500 * time.Millisecond)
 			duration := time.Since(start)
 			assert.True(t, duration <= tt.wantDuration+slack && duration >= tt.wantDuration-slack,
 				"%v: Took %v, wanted duration %v", tt.msg, duration, tt.wantDuration)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 32feeffdab9bd406cac99e6c9e64aab4edf85e9ea71026712b7b00606c1335e7
-updated: 2017-02-11T19:49:23.417227238-08:00
+updated: 2017-02-11T21:32:42.372619241-08:00
 imports:
 - name: github.com/apache/thrift
   version: bff044667caf8a8c2b0dd30ed11b328ff2902cf5
@@ -61,8 +61,6 @@ imports:
   - tnet
   - trand
   - typed
-- name: go.uber.org/atomic
-  version: 0c9e689d64f004564b79d9a663634756df322902
 - name: go.uber.org/thriftrw
   version: c98a13058faa5dd41584a77221a268d2c72d832d
   subpackages:
@@ -102,9 +100,11 @@ imports:
   - transport/tchannel
   - transport/tchannel/internal
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: 61557ac0112b576429a0df080e1c2cef5dfbb642
   subpackages:
   - context
 - name: gopkg.in/yaml.v2
   version: a3f3340b5840cee44f372bddb5880fcbc419b46a
-testImports: []
+testImports:
+- name: go.uber.org/atomic
+  version: 0c9e689d64f004564b79d9a663634756df322902

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 3302c04cec4c419c4fa61537d845389b6a2a79faaed682ae9f45c370800e9609
-updated: 2017-01-30T19:15:44.243195884-08:00
+hash: 32feeffdab9bd406cac99e6c9e64aab4edf85e9ea71026712b7b00606c1335e7
+updated: 2017-02-11T19:49:23.417227238-08:00
 imports:
 - name: github.com/apache/thrift
-  version: 8d377fa6befb6ef9fd2364b5cc2972406e2a92a3
+  version: bff044667caf8a8c2b0dd30ed11b328ff2902cf5
   subpackages:
   - lib/go/thrift
 - name: github.com/cactus/go-statsd-client
@@ -18,7 +18,7 @@ imports:
 - name: github.com/jessevdk/go-flags
   version: 4e64e4a4e2552194cf594243e23aa9baf3b4297e
 - name: github.com/opentracing/opentracing-go
-  version: 0c3154a3c2ce79d3271985848659870599dfb77c
+  version: 6edb48674bd9467b8e91fda004f2bd7202d60ce4
   subpackages:
   - ext
   - log
@@ -33,6 +33,10 @@ imports:
   - require
 - name: github.com/uber-go/atomic
   version: 0c9e689d64f004564b79d9a663634756df322902
+- name: github.com/uber-go/zap
+  version: c064b5c44b285a7e2fd5c9b26e8c38228ce2bccb
+  subpackages:
+  - spy
 - name: github.com/uber/jaeger-client-go
   version: e39d0f1b622558cae3d9db0062a739cc6ffa700f
   subpackages:
@@ -43,7 +47,7 @@ imports:
   - transport
   - utils
 - name: github.com/uber/tchannel-go
-  version: aeda4836756434b4077ca7ef4b6a8c0d6b382101
+  version: 79387824978f91318be3bfb43ae12e04c38cfe97
   subpackages:
   - internal/argreader
   - json
@@ -57,6 +61,8 @@ imports:
   - tnet
   - trand
   - typed
+- name: go.uber.org/atomic
+  version: 0c9e689d64f004564b79d9a663634756df322902
 - name: go.uber.org/thriftrw
   version: c98a13058faa5dd41584a77221a268d2c72d832d
   subpackages:
@@ -71,17 +77,8 @@ imports:
   - protocol/binary
   - version
   - wire
-- name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
-  subpackages:
-  - context
-- name: gopkg.in/yaml.v2
-  version: 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
-testImports:
-- name: go.uber.org/atomic
-  version: 0c9e689d64f004564b79d9a663634756df322902
 - name: go.uber.org/yarpc
-  version: baf7b5524ecff45dad7aa6ff70c1fe422ea4aada
+  version: e4ae12793c38b4aea58721458670ded8bb4709a0
   subpackages:
   - api/encoding
   - api/middleware
@@ -104,3 +101,10 @@ testImports:
   - transport/http
   - transport/tchannel
   - transport/tchannel/internal
+- name: golang.org/x/net
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  subpackages:
+  - context
+- name: gopkg.in/yaml.v2
+  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,6 +8,7 @@ import:
   version: ^1
 - package: github.com/uber-go/atomic
   version: ^1
+- package: github.com/uber-go/zap
 - package: github.com/uber/tchannel-go
   version: ^1.2
 - package: golang.org/x/net
@@ -15,6 +16,8 @@ import:
 - package: github.com/opentracing/opentracing-go
   version: ^1
 - package: github.com/uber/jaeger-client-go
+  version: ^1
+- package: go.uber.org/yarpc
   version: ^1
 testImport:
 - package: github.com/apache/thrift

--- a/integration_test.go
+++ b/integration_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/uber-go/zap/spy"
 	"github.com/yarpc/yab/testdata/gen-go/integration"
 	yintegration "github.com/yarpc/yab/testdata/yarpc/integration"
 	"github.com/yarpc/yab/testdata/yarpc/integration/fooserver"
@@ -268,8 +269,10 @@ func TestIntegrationProtocols(t *testing.T) {
 func runTestWithOpts(opts Options) (string, string) {
 	var errBuf bytes.Buffer
 	var outBuf bytes.Buffer
+	testLogger, _ := spy.New()
 	out := testOutput{
 		Buffer: &outBuf,
+		Logger: testLogger,
 		fatalf: func(format string, args ...interface{}) {
 			errBuf.WriteString(fmt.Sprintf(format, args...))
 		},

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/uber-go/zap"
 	"github.com/yarpc/yab/encoding"
 	"github.com/yarpc/yab/transport"
 
@@ -42,7 +43,11 @@ import (
 	"github.com/uber/tchannel-go"
 )
 
-var errHealthAndMethod = errors.New("cannot specify method name and use --health")
+var (
+	// Logger Public Logger for logging verbose output
+	errExit            = errors.New("sentinel error used to exit cleanly")
+	errHealthAndMethod = errors.New("cannot specify method name and use --health")
+)
 
 func findGroup(parser *flags.Parser, group string) *flags.Group {
 	if g := parser.Group.Find(group); g != nil {
@@ -72,10 +77,8 @@ func fromPositional(args []string, index int, s *string) bool {
 
 func main() {
 	log.SetFlags(0)
-	parseAndRun(consoleOutput{os.Stdout})
+	parseAndRun(consoleOutput{os.Stdout, zap.New(zap.NewTextEncoder())})
 }
-
-var errExit = errors.New("sentinel error used to exit cleanly")
 
 func toGroff(s string) string {
 	// Expand tabbed lines beginning with "-" as items in a bullet list.
@@ -241,6 +244,8 @@ func parseDefaultConfigs(parser *flags.Parser) error {
 }
 
 func runWithOptions(opts Options, out output) {
+	out.Debug("testing this", zap.String("hello", "akshay"))
+
 	if opts.ROpts.YamlTemplate != "" {
 		if err := readYamlRequest(&opts); err != nil {
 			out.Fatalf("Failed while reading yaml template: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -244,7 +244,7 @@ func parseDefaultConfigs(parser *flags.Parser) error {
 }
 
 func runWithOptions(opts Options, out output) {
-	out.Debug("testing this", zap.String("hello", "akshay"))
+	out.Debug("testing this", zap.String("hello", "joe"))
 
 	if opts.ROpts.YamlTemplate != "" {
 		if err := readYamlRequest(&opts); err != nil {

--- a/main.go
+++ b/main.go
@@ -44,7 +44,6 @@ import (
 )
 
 var (
-	// Logger Public Logger for logging verbose output
 	errExit            = errors.New("sentinel error used to exit cleanly")
 	errHealthAndMethod = errors.New("cannot specify method name and use --health")
 

--- a/main_test.go
+++ b/main_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/uber-go/zap/spy"
 	"github.com/yarpc/yab/encoding"
 	"github.com/yarpc/yab/transport"
 
@@ -148,8 +149,10 @@ func TestRunWithOptions(t *testing.T) {
 
 	var errBuf bytes.Buffer
 	var outBuf bytes.Buffer
+	testLogger, _ := spy.New()
 	out := testOutput{
 		Buffer: &outBuf,
+		Logger: testLogger,
 		fatalf: func(format string, args ...interface{}) {
 			errBuf.WriteString(fmt.Sprintf(format, args...))
 		},

--- a/options.go
+++ b/options.go
@@ -33,6 +33,7 @@ type Options struct {
 	ROpts          RequestOptions   `group:"request"`
 	TOpts          TransportOptions `group:"transport"`
 	BOpts          BenchmarkOptions `group:"benchmark"`
+	Verbose        bool             `short:"v" long:"verbose" description:"Print more verbose information"`
 	DisplayVersion bool             `long:"version" description:"Displays the application version"`
 	ManPage        bool             `long:"man-page" hidden:"yes" description:"Print yab's man page to stdout"`
 }

--- a/output.go
+++ b/output.go
@@ -25,10 +25,13 @@ import (
 	"io"
 	"log"
 	"os"
+
+	"github.com/uber-go/zap"
 )
 
 type output interface {
 	io.Writer
+	zap.Logger
 
 	Fatalf(format string, args ...interface{})
 	Printf(format string, args ...interface{})
@@ -36,6 +39,7 @@ type output interface {
 
 type consoleOutput struct {
 	*os.File
+	zap.Logger
 }
 
 func (consoleOutput) Fatalf(format string, args ...interface{}) {

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/zap/spy"
 	"github.com/uber/jaeger-client-go"
 )
 
@@ -42,6 +43,8 @@ const (
 
 type testOutput struct {
 	*bytes.Buffer
+	*spy.Logger
+
 	fatalf func(string, ...interface{})
 }
 
@@ -56,8 +59,10 @@ func (t testOutput) Printf(format string, args ...interface{}) {
 
 func getOutput(t *testing.T) (*bytes.Buffer, output) {
 	buf := &bytes.Buffer{}
+	l, _ := spy.New()
 	out := testOutput{
 		Buffer: buf,
+		Logger: l,
 		fatalf: t.Errorf,
 	}
 	return buf, out


### PR DESCRIPTION
Fixes #51 by adding a `--verbose` or `-v` flag to yab to enabled Debug level logging. 

Hooking up the logger also allows to use the Info level logs to show status by default. 


The way I hooked this logger into the existing system was through the custom `output` interface made  for yab. Doing this allows all the methods using output to also log more information. 