### PR TITLE
Remove warmup from TestBenchmark

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -79,12 +79,11 @@ func TestBenchmark(t *testing.T) {
 		buf, out := getOutput(t)
 		runBenchmark(out, Options{
 			BOpts: BenchmarkOptions{
-				MaxRequests:    tt.n,
-				MaxDuration:    tt.d,
-				RPS:            tt.rps,
-				Connections:    50,
-				WarmupRequests: 10,
-				Concurrency:    2,
+				MaxRequests: tt.n,
+				MaxDuration: tt.d,
+				RPS:         tt.rps,
+				Connections: 50,
+				Concurrency: 2,
 			},
 			TOpts: s.transportOpts(),
 		}, m)
@@ -93,9 +92,8 @@ func TestBenchmark(t *testing.T) {
 		assert.Contains(t, bufStr, "Max RPS")
 		assert.NotContains(t, bufStr, "Errors")
 
-		warmupExtra := 10 * 50 // warmup requests * connections
 		if tt.want != 0 {
-			assert.EqualValues(t, tt.want+warmupExtra, requests.Load(),
+			assert.EqualValues(t, tt.want, requests.Load(),
 				"%v: Invalid number of requests", tt.msg)
 		}
 


### PR DESCRIPTION
When measuring the duration taken by the test, on a slow machine, warmup
requests can take so long that we go over the slack.

Instead, let's disable warmup requests so the test is not flaky on slow
machines.