### PR TITLE
Add --no-jaeger flag to disable jaeger

### DIFF
--- a/main.go
+++ b/main.go
@@ -317,7 +317,7 @@ func getTracer(opts Options, out output) (opentracing.Tracer, io.Closer) {
 		tracer opentracing.Tracer = opentracing.NoopTracer{}
 		closer io.Closer
 	)
-	if opts.TOpts.Jaeger {
+	if opts.TOpts.Jaeger && !opts.TOpts.NoJaeger {
 		tracer, closer = jaeger.NewTracer(opts.TOpts.CallerName, jaeger.NewConstSampler(true), jaeger.NewNullReporter())
 	} else if len(opts.ROpts.Baggage) > 0 {
 		out.Fatalf("To propagate baggage, you must opt-into a tracing client, i.e., --jaeger")

--- a/main_test.go
+++ b/main_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/yarpc/yab/encoding"
 	"github.com/yarpc/yab/transport"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/testutils"
@@ -853,4 +854,71 @@ func TestTemplates(t *testing.T) {
 	}
 
 	main()
+}
+
+func TestGetTracer(t *testing.T) {
+	tests := []struct {
+		opts      Options
+		wantNoop  bool
+		wantFatal string
+	}{
+		{
+			opts:     Options{},
+			wantNoop: true,
+		},
+		{
+			opts: Options{
+				TOpts: TransportOptions{
+					CallerName: "test",
+					Jaeger:     true,
+				},
+			},
+		},
+		{
+			opts: Options{
+				TOpts: TransportOptions{
+					CallerName: "test",
+					Jaeger:     true,
+					NoJaeger:   true,
+				},
+			},
+			wantNoop: true,
+		},
+		{
+			opts: Options{
+				ROpts: RequestOptions{
+					Baggage: map[string]string{"k": "v"},
+				},
+			},
+			wantFatal: "propagate baggage",
+		},
+	}
+
+	for _, tt := range tests {
+		var fatalMsg string
+		out := &testOutput{
+			fatalf: func(msg string, _ ...interface{}) { fatalMsg = msg },
+		}
+
+		var tracer opentracing.Tracer
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			tracer, _ = getTracer(tt.opts, out)
+		}()
+		<-done
+
+		if tt.wantFatal != "" {
+			assert.Contains(t, fatalMsg, tt.wantFatal, "Fatal message for %+v", tt.opts)
+			continue
+		}
+
+		assert.Empty(t, fatalMsg, "Unexpected fatal for %+v", tt.opts)
+		if tt.wantNoop {
+			assert.Equal(t, opentracing.NoopTracer{}, tracer, "Expected %+v to return noop tracer", tt.opts)
+			continue
+		}
+
+		assert.NotEqual(t, opentracing.NoopTracer{}, tracer, "Expected %+v to return real tracer")
+	}
 }

--- a/options.go
+++ b/options.go
@@ -78,8 +78,14 @@ type TransportOptions struct {
 	RoutingDelegate  string            `long:"rd" description:"The routing delegate overrides the routing key traffic group for proxies."`
 	ShardKey         string            `long:"sk" description:"The shard key is a transport header that clues where to send a request within a clustered traffic group."`
 	Jaeger           bool              `long:"jaeger" description:"Use the Jaeger tracing client to send Uber style traces and baggage headers"`
-	NoJaeger         bool              `long:"no-jaeger" hidden:"true"` // go-flags doesn't make it easy to flip off bool flags, https://github.com/jessevdk/go-flags/issues/191
 	TransportHeaders map[string]string `short:"T" long:"topt" description:"Transport options for TChannel, protocol headers for HTTP"`
+
+	// This is a hack to work around go-flags not allowing disabling flags:
+	// https://github.com/jessevdk/go-flags/issues/191
+	// Do not specify this value in a defaults.ini file as it is not possible
+	// to enable Jaeger via CLI.
+	// Our plan is to change go-flags to support "--no-FLAG" and remove this hack.
+	NoJaeger bool `long:"no-jaeger" hidden:"true"`
 }
 
 // BenchmarkOptions are benchmark-specific options

--- a/options.go
+++ b/options.go
@@ -78,6 +78,7 @@ type TransportOptions struct {
 	RoutingDelegate  string            `long:"rd" description:"The routing delegate overrides the routing key traffic group for proxies."`
 	ShardKey         string            `long:"sk" description:"The shard key is a transport header that clues where to send a request within a clustered traffic group."`
 	Jaeger           bool              `long:"jaeger" description:"Use the Jaeger tracing client to send Uber style traces and baggage headers"`
+	NoJaeger         bool              `long:"no-jaeger" hidden:"true"` // go-flags doesn't make it easy to flip off bool flags, https://github.com/jessevdk/go-flags/issues/191
 	TransportHeaders map[string]string `short:"T" long:"topt" description:"Transport options for TChannel, protocol headers for HTTP"`
 }
 


### PR DESCRIPTION
If jaeger is enabled by default in a defaults.ini file, it cannot
currently be disabled due to
https://github.com/jessevdk/go-flags/issues/191

We need a better long term solution for boolean flags, but for now, add
a separate no-jaeger flag that will disable Jaeger.