### PR TITLE
Support peer provider plugins

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/yarpc/yab/encoding"
+	"github.com/yarpc/yab/peerprovider"
 	"github.com/yarpc/yab/transport"
 
 	"github.com/casimir/xdg-go"
@@ -241,6 +242,13 @@ func parseDefaultConfigs(parser *flags.Parser) error {
 }
 
 func runWithOptions(opts Options, out output) {
+	if opts.TOpts.HostPortFile == "?" {
+		for _, scheme := range peerprovider.Schemes() {
+			out.Printf("%s\n", scheme)
+		}
+		return
+	}
+
 	if opts.ROpts.YamlTemplate != "" {
 		if err := readYamlRequest(&opts); err != nil {
 			out.Fatalf("Failed while reading yaml template: %v\n", err)

--- a/main_test.go
+++ b/main_test.go
@@ -922,3 +922,16 @@ func TestGetTracer(t *testing.T) {
 		assert.NotEqual(t, opentracing.NoopTracer{}, tracer, "Expected %+v to return real tracer")
 	}
 }
+
+func TestMainSupportedPeerProviderSchemes(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	os.Args = []string{"yab", "-P?"}
+
+	buf, out := getOutput(t)
+	parseAndRun(out)
+	contents := buf.String()
+	assert.Contains(t, contents, "file\n", "Expected file protocol support")
+	assert.NotContains(t, contents, "\n\n", "Expected no blank lines")
+}

--- a/options.go
+++ b/options.go
@@ -72,7 +72,7 @@ type RequestOptions struct {
 type TransportOptions struct {
 	ServiceName      string            `short:"s" long:"service" description:"The TChannel/Hyperbahn service name"`
 	HostPorts        []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
-	HostPortFile     string            `short:"P" long:"peer-list" description:"Path of a JSON or YAML file containing a list of host:ports"`
+	HostPortFile     string            `short:"P" long:"peer-list" description:"Path or URL of a JSON, YAML, or flat file containing a list of host:ports. -P? for supported protocols."`
 	CallerName       string            `long:"caller" description:"Caller will override the default caller name (which is yab-$USER)."`
 	RoutingKey       string            `long:"rk" description:"The routing key overrides the service name traffic group for proxies."`
 	RoutingDelegate  string            `long:"rd" description:"The routing delegate overrides the routing key traffic group for proxies."`

--- a/peerprovider/file.go
+++ b/peerprovider/file.go
@@ -1,0 +1,24 @@
+package peerprovider
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+
+	"golang.org/x/net/context"
+)
+
+type filePeerProvider struct{}
+
+func (filePeerProvider) Resolve(ctx context.Context, url *url.URL) ([]string, error) {
+	return parsePeersFile(url.Path)
+}
+
+func parsePeersFile(filename string) ([]string, error) {
+	contents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open peer list: %v", err)
+	}
+
+	return parsePeers(contents)
+}

--- a/peerprovider/file_test.go
+++ b/peerprovider/file_test.go
@@ -1,0 +1,54 @@
+package peerprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseHostFile(t *testing.T) {
+	tests := []struct {
+		filename string
+		errMsg   string
+		want     []string
+	}{
+		{
+			filename: "/fake/file",
+			errMsg:   "failed to open peer list",
+		},
+		{
+			filename: "valid_peerlist.json",
+			want:     []string{"1.1.1.1:1", "2.2.2.2:2"},
+		},
+		{
+			filename: "valid_peerlist.yaml",
+			want:     []string{"1.1.1.1:1", "2.2.2.2:2"},
+		},
+		{
+			filename: "valid_peerlist.txt",
+			want:     []string{"1.1.1.1:1", "2.2.2.2:2"},
+		},
+		{
+			filename: "invalid_peerlist.json",
+			errMsg:   errPeerListFile.Error(),
+		},
+		{
+			filename: "invalid.json",
+			errMsg:   errPeerListFile.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		got, err := parsePeersFile("../testdata/" + tt.filename)
+		if tt.errMsg != "" {
+			if assert.Error(t, err, "parsePeersFile(%v) should fail", tt.filename) {
+				assert.Contains(t, err.Error(), tt.errMsg, "Unexpected error for parsePeersFile(%v)", tt.filename)
+			}
+			continue
+		}
+
+		if assert.NoError(t, err, "parsePeersFile(%v) should not fail", tt.filename) {
+			assert.Equal(t, tt.want, got, "parsePeersFile(%v) mismatch", tt.filename)
+		}
+	}
+}

--- a/peerprovider/interface.go
+++ b/peerprovider/interface.go
@@ -10,7 +10,19 @@ import (
 var registry = make(map[string]PeerProvider)
 
 func init() {
+	RegisterPeerProvider("", filePeerProvider{})
 	RegisterPeerProvider("file", filePeerProvider{})
+}
+
+// Schemes returns supported peer provider protocol schemes.
+func Schemes() []string {
+	schemes := make([]string, 0, len(registry))
+	for scheme := range registry {
+		if scheme != "" {
+			schemes = append(schemes, scheme)
+		}
+	}
+	return schemes
 }
 
 // Resolve resolves a peer list from a URL, using the registered

--- a/peerprovider/interface.go
+++ b/peerprovider/interface.go
@@ -1,0 +1,37 @@
+package peerprovider
+
+import (
+	"fmt"
+	"net/url"
+
+	"golang.org/x/net/context"
+)
+
+var registry = make(map[string]PeerProvider)
+
+func init() {
+	RegisterPeerProvider("file", filePeerProvider{})
+}
+
+// Resolve resolves a peer list from a URL, using the registered
+// peer provider for that protocol scheme, albeit "file", "http", etc.
+func Resolve(ctx context.Context, u *url.URL) ([]string, error) {
+	if pp, ok := registry[u.Scheme]; ok {
+		return pp.Resolve(ctx, u)
+	}
+
+	return nil, fmt.Errorf("no peer provider available for scheme %q in URL %q", u.Scheme, u.String())
+}
+
+// PeerProvider provides a list of peers for a given peer provider URL.
+// Implementations are expected to define the behavior for the URL name space
+// and return strings suitable for passing to `--peer` for whatever protocol
+// the name specifies.
+type PeerProvider interface {
+	Resolve(context.Context, *url.URL) ([]string, error)
+}
+
+// RegisterPeerProvider registers a peer provider for a resolver protocol
+func RegisterPeerProvider(scheme string, pp PeerProvider) {
+	registry[scheme] = pp
+}

--- a/peerprovider/interface_test.go
+++ b/peerprovider/interface_test.go
@@ -1,0 +1,76 @@
+package peerprovider
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"golang.org/x/net/context"
+)
+
+type fakePeerProvider struct {
+	res []string
+	err error
+}
+
+func (fpp *fakePeerProvider) Resolve(ctx context.Context, u *url.URL) ([]string, error) {
+	return fpp.res, fpp.err
+}
+
+func TestSchemes(t *testing.T) {
+	oldRegistry := registry
+	defer func() { registry = oldRegistry }()
+	registry = make(map[string]PeerProvider)
+
+	f := &fakePeerProvider{res: []string{"who's on first"}}
+	RegisterPeerProvider("fake", f)
+
+	assert.Equal(t, registry, map[string]PeerProvider{
+		"fake": f,
+	}, "Expected registered fake")
+
+	res, err := Resolve(context.Background(), mustParseURL("fake://dekaf"))
+	assert.NoError(t, err, "should resolve without error")
+	assert.Equal(t, res, f.res, "should resolve fake:// name")
+}
+
+func TestResolveError(t *testing.T) {
+	oldRegistry := registry
+	defer func() { registry = oldRegistry }()
+	registry = make(map[string]PeerProvider)
+
+	f := &fakePeerProvider{err: fmt.Errorf("noope")}
+	RegisterPeerProvider("fake", f)
+
+	res, err := Resolve(context.Background(), mustParseURL("fake://dekaf"))
+	assert.Equal(t, err, f.err, "should resolve ith error")
+	assert.Equal(t, res, []string(nil), "should not resolve")
+}
+
+func TestEmptyScheme(t *testing.T) {
+	peers, err := Resolve(context.Background(), mustParseURL("../testdata/valid_peerlist.txt"))
+	assert.NoError(t, err, "error attempting to resolve peer list file")
+	assert.Equal(t, peers, []string{
+		"1.1.1.1:1",
+		"2.2.2.2:2",
+	}, "obtains expected peers")
+}
+
+func TestFileScheme(t *testing.T) {
+	abs, _ := filepath.Abs("../testdata/valid_peerlist.yaml")
+	u := mustParseURL("file:" + abs)
+	peers, err := Resolve(context.Background(), u)
+	assert.NoError(t, err, "error attempting to resolve peer list file")
+	assert.Equal(t, peers, []string{
+		"1.1.1.1:1",
+		"2.2.2.2:2",
+	}, "obtains expected peers")
+}
+
+func mustParseURL(s string) *url.URL {
+	u, _ := url.Parse(s)
+	return u
+}

--- a/peerprovider/parse.go
+++ b/peerprovider/parse.go
@@ -1,0 +1,61 @@
+package peerprovider
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+var errPeerListFile = errors.New("peer list should be YAML, JSON, or newline delimited strings")
+
+// parsePeers accepts a file in YAML, JSON, or newline-delimited format,
+// containing host:port peer addresses.
+func parsePeers(contents []byte) ([]string, error) {
+	// Try as JSON.
+	hosts, err := parseYAMLPeers(contents)
+	if err != nil {
+		hosts, err = parseNewlineDelimitedPeers(bytes.NewReader(contents))
+	}
+	if err != nil {
+		return nil, errPeerListFile
+	}
+
+	return hosts, nil
+}
+
+func parseYAMLPeers(contents []byte) ([]string, error) {
+	var hosts []string
+	return hosts, yaml.Unmarshal(contents, &hosts)
+}
+
+func parseNewlineDelimitedPeers(r io.Reader) ([]string, error) {
+	var hosts []string
+	rdr := bufio.NewReader(r)
+	for {
+		line, err := rdr.ReadString('\n')
+		if line == "" && err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		if _, _, err := net.SplitHostPort(line); err != nil {
+			return nil, err
+		}
+
+		hosts = append(hosts, line)
+	}
+
+	return hosts, nil
+}

--- a/transport.go
+++ b/transport.go
@@ -21,22 +21,20 @@
 package main
 
 import (
-	"bufio"
-	"bytes"
+	"context"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/yarpc/yab/encoding"
+	"github.com/yarpc/yab/peerprovider"
 	"github.com/yarpc/yab/transport"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber/tchannel-go"
-	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -45,7 +43,6 @@ var (
 	errTracerRequired  = errors.New("tracer is required, or explicit NoopTracer")
 	errPeerRequired    = errors.New("specify at least one peer using --peer or using --peer-list")
 	errPeerOptions     = errors.New("do not specify peers using --peer and --peer-list")
-	errPeerListFile    = errors.New("peer list should be a JSON file with a list of strings")
 )
 
 func remapLocalHost(hostPorts []string) {
@@ -87,28 +84,39 @@ func ensureSameProtocol(hostPorts []string) (string, error) {
 }
 
 func loadTransportHostPorts(opts TransportOptions) (TransportOptions, error) {
-	if len(opts.HostPorts) == 0 && opts.HostPortFile == "" {
+	peers := opts.HostPorts
+	if opts.HostPortFile != "" {
+		if len(peers) > 0 {
+			return opts, errPeerOptions
+		}
+
+		u, err := url.Parse(opts.HostPortFile)
+		if err != nil {
+			return opts, fmt.Errorf("could not parse peer provider URL: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		// Paths are a strict subset of the URL file protocol scheme. We
+		// explicate the file protocol as a key into the peer provider
+		// registry.
+		if u.Scheme == "" {
+			u.Scheme = "file"
+		}
+
+		peers, err = peerprovider.Resolve(ctx, u)
+		if err != nil {
+			return opts, err
+		}
+	}
+
+	if len(peers) == 0 {
 		return opts, errPeerRequired
 	}
 
-	hostPorts := opts.HostPorts
-	if opts.HostPortFile != "" {
-		if len(hostPorts) > 0 {
-			return opts, errPeerOptions
-		}
-		var err error
-		hostPorts, err = parseHostFile(opts.HostPortFile)
-		if err != nil {
-			return opts, fmt.Errorf("failed to parse host file: %v", err)
-		}
-
-		if len(hostPorts) == 0 {
-			return opts, errPeerRequired
-		}
-	}
-
 	opts.HostPortFile = ""
-	opts.HostPorts = hostPorts
+	opts.HostPorts = peers
 	return opts, nil
 }
 
@@ -164,54 +172,4 @@ func getTransport(opts TransportOptions, encoding encoding.Encoding, tracer open
 		Tracer:          tracer,
 	}
 	return transport.NewHTTP(hopts)
-}
-
-func parseHostFile(filename string) ([]string, error) {
-	contents, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open peer list: %v", err)
-	}
-
-	// Try as JSON.
-	hosts, err := parseHostFileYAML(contents)
-	if err != nil {
-		hosts, err = parseHostsFileNewLines(bytes.NewReader(contents))
-	}
-	if err != nil {
-		return nil, errPeerListFile
-	}
-
-	return hosts, nil
-}
-
-func parseHostFileYAML(contents []byte) ([]string, error) {
-	var hosts []string
-	return hosts, yaml.Unmarshal(contents, &hosts)
-}
-
-func parseHostsFileNewLines(r io.Reader) ([]string, error) {
-	var hosts []string
-	rdr := bufio.NewReader(r)
-	for {
-		line, err := rdr.ReadString('\n')
-		if line == "" && err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
-		}
-
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-
-		if _, _, err := net.SplitHostPort(line); err != nil {
-			return nil, err
-		}
-
-		hosts = append(hosts, line)
-	}
-
-	return hosts, nil
 }

--- a/transport.go
+++ b/transport.go
@@ -98,13 +98,6 @@ func loadTransportHostPorts(opts TransportOptions) (TransportOptions, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
-		// Paths are a strict subset of the URL file protocol scheme. We
-		// explicate the file protocol as a key into the peer provider
-		// registry.
-		if u.Scheme == "" {
-			u.Scheme = "file"
-		}
-
 		peers, err = peerprovider.Resolve(ctx, u)
 		if err != nil {
 			return opts, err

--- a/transport_test.go
+++ b/transport_test.go
@@ -138,7 +138,7 @@ func TestGetTransport(t *testing.T) {
 		},
 		{
 			opts:   TransportOptions{ServiceName: "svc", HostPortFile: "testdata/invalid.json"},
-			errMsg: errPeerListFile.Error(),
+			errMsg: "peer list should be YAML, JSON, or newline delimited strings",
 		},
 		{
 			opts:   TransportOptions{ServiceName: "svc", HostPortFile: "testdata/empty.txt"},
@@ -251,7 +251,6 @@ func TestGetTransportTraceEnabled(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		ctx, cancel := tchannel.NewContext(time.Second)
 		defer cancel()
 
@@ -267,52 +266,5 @@ func TestGetTransportTraceEnabled(t *testing.T) {
 		require.NoError(t, err, "transport.Call failed")
 
 		assert.Equal(t, tt.traceEnabled, res.Body[0], "TraceEnabled mismatch")
-	}
-}
-
-func TestParseHostFile(t *testing.T) {
-	tests := []struct {
-		filename string
-		errMsg   string
-		want     []string
-	}{
-		{
-			filename: "/fake/file",
-			errMsg:   "failed to open peer list",
-		},
-		{
-			filename: "testdata/valid_peerlist.json",
-			want:     []string{"1.1.1.1:1", "2.2.2.2:2"},
-		},
-		{
-			filename: "testdata/valid_peerlist.yaml",
-			want:     []string{"1.1.1.1:1", "2.2.2.2:2"},
-		},
-		{
-			filename: "testdata/valid_peerlist.txt",
-			want:     []string{"1.1.1.1:1", "2.2.2.2:2"},
-		},
-		{
-			filename: "testdata/invalid_peerlist.json",
-			errMsg:   errPeerListFile.Error(),
-		},
-		{
-			filename: "testdata/invalid.json",
-			errMsg:   errPeerListFile.Error(),
-		},
-	}
-
-	for _, tt := range tests {
-		got, err := parseHostFile(tt.filename)
-		if tt.errMsg != "" {
-			if assert.Error(t, err, "parseHostFile(%v) should fail", tt.filename) {
-				assert.Contains(t, err.Error(), tt.errMsg, "Unexpected error for parseHostFile(%v)", tt.filename)
-			}
-			continue
-		}
-
-		if assert.NoError(t, err, "parseHostFile(%v) should not fail", tt.filename) {
-			assert.Equal(t, tt.want, got, "parseHostFile(%v) mismatch", tt.filename)
-		}
 	}
 }


### PR DESCRIPTION
This change factors out a pluggable peer provider registry and extends the meaning of the `-P` flag to be a URI, currently only supporting the implicit or explicit `file:/` protocol scheme.