### PR TITLE
Internal rename: Rename hostPort to peer

### DIFF
--- a/bench_method_test.go
+++ b/bench_method_test.go
@@ -60,23 +60,23 @@ func TestBenchmarkMethodWarmTransport(t *testing.T) {
 	s.register(fooMethod, methods.echo())
 
 	tests := []struct {
-		hostPort string
-		method   string
-		wantErr  string
+		peer    string
+		method  string
+		wantErr string
 	}{
 		{
-			hostPort: s.hostPort(),
+			peer: s.hostPort(),
 		},
 		// getTransport error
 		{
-			hostPort: testutils.GetClosedHostPort(t),
-			wantErr:  "connection refused",
+			peer:    testutils.GetClosedHostPort(t),
+			wantErr: "connection refused",
 		},
 		// makeRequest error
 		{
-			hostPort: s.hostPort(),
-			method:   "Simple::unknown",
-			wantErr:  "no handler for service",
+			peer:    s.hostPort(),
+			method:  "Simple::unknown",
+			wantErr: "no handler for service",
 		},
 	}
 
@@ -89,7 +89,7 @@ func TestBenchmarkMethodWarmTransport(t *testing.T) {
 		tOpts := TransportOptions{
 			CallerName:  "bar",
 			ServiceName: "foo",
-			HostPorts:   []string{tt.hostPort},
+			Peers:       []string{tt.peer},
 		}
 
 		transport, err := m.WarmTransport(tOpts, 1 /* warmupRequests */)
@@ -141,7 +141,7 @@ func TestBenchmarkMethodCall(t *testing.T) {
 	tOpts := TransportOptions{
 		CallerName:  "bar",
 		ServiceName: "foo",
-		HostPorts:   []string{s.hostPort()},
+		Peers:       []string{s.hostPort()},
 	}
 	tp, err := getTransport(tOpts, encoding.Thrift, opentracing.NoopTracer{})
 	require.NoError(t, err, "Failed to get transport")
@@ -165,40 +165,40 @@ func TestBenchmarkMethodCall(t *testing.T) {
 	}
 }
 
-func TestHostPortBalancer(t *testing.T) {
+func TestPeerBalancer(t *testing.T) {
 	tests := []struct {
-		seed      int64
-		hostPorts []string
-		want      []string
+		seed  int64
+		peers []string
+		want  []string
 	}{
 		{
-			seed:      1,
-			hostPorts: []string{"1"},
-			want:      []string{"1", "1", "1"},
+			seed:  1,
+			peers: []string{"1"},
+			want:  []string{"1", "1", "1"},
 		},
 		{
-			seed:      1,
-			hostPorts: []string{"1", "2"},
-			want:      []string{"2", "1", "2"},
+			seed:  1,
+			peers: []string{"1", "2"},
+			want:  []string{"2", "1", "2"},
 		},
 		{
-			seed:      2,
-			hostPorts: []string{"1", "2"},
-			want:      []string{"1", "2", "1"},
+			seed:  2,
+			peers: []string{"1", "2"},
+			want:  []string{"1", "2", "1"},
 		},
 		{
-			seed:      1,
-			hostPorts: []string{"1", "2", "3", "4", "5"},
-			want:      []string{"2", "3", "4"},
+			seed:  1,
+			peers: []string{"1", "2", "3", "4", "5"},
+			want:  []string{"2", "3", "4"},
 		},
 	}
 
 	for _, tt := range tests {
 		rand.Seed(tt.seed)
-		hostPortFor := hostPortBalancer(tt.hostPorts)
+		peerFor := peerBalancer(tt.peers)
 		for i, want := range tt.want {
-			got := hostPortFor(i)
-			assert.Equal(t, want, got, "hostPortBalancer(%v) seed %v i %v failed", tt.hostPorts, tt.seed, i)
+			got := peerFor(i)
+			assert.Equal(t, want, got, "peerBalancer(%v) seed %v i %v failed", tt.peers, tt.seed, i)
 		}
 	}
 }
@@ -223,7 +223,7 @@ func TestBenchmarkMethodWarmTransportsSuccess(t *testing.T) {
 	tOpts := TransportOptions{
 		CallerName:  "bar",
 		ServiceName: "foo",
-		HostPorts:   serverHPs,
+		Peers:       serverHPs,
 	}
 	transports, err := m.WarmTransports(numServers, tOpts, 1 /* warmupRequests */)
 	assert.NoError(t, err, "WarmTransports should not fail")
@@ -282,7 +282,7 @@ func TestBenchmarkMethodWarmTransportsError(t *testing.T) {
 		tOpts := TransportOptions{
 			CallerName:  "bar",
 			ServiceName: "foo",
-			HostPorts:   []string{s.hostPort()},
+			Peers:       []string{s.hostPort()},
 		}
 		_, err := m.WarmTransports(10, tOpts, tt.warmup)
 		if tt.wantErr {

--- a/integration_test.go
+++ b/integration_test.go
@@ -173,27 +173,27 @@ func TestIntegrationProtocols(t *testing.T) {
 
 	cases := []struct {
 		desc            string
-		setup           func() (hostPort string, shutdown func())
+		setup           func() (peer string, shutdown func())
 		multiplexed     bool
 		disableEnvelope bool
 	}{
 		{
 			desc: "TChannel",
-			setup: func() (hostPort string, shutdown func()) {
+			setup: func() (string, func()) {
 				ch := setupTChannelIntegrationServer(t, tracer)
 				return ch.PeerInfo().HostPort, ch.Close
 			},
 		},
 		{
 			desc: "Non-multiplexed HTTP",
-			setup: func() (hostPort string, shutdown func()) {
+			setup: func() (string, func()) {
 				httpServer := setupHTTPIntegrationServer(t, false /* multiplexed */)
 				return httpServer.URL, httpServer.Close
 			},
 		},
 		{
 			desc: "Multiplexed HTTP",
-			setup: func() (hostPort string, shutdown func()) {
+			setup: func() (string, func()) {
 				httpServer := setupHTTPIntegrationServer(t, true /* multiplexed */)
 				return httpServer.URL, httpServer.Close
 			},
@@ -201,7 +201,7 @@ func TestIntegrationProtocols(t *testing.T) {
 		},
 		{
 			desc: "YARPC TChannel",
-			setup: func() (hostPort string, shutdown func()) {
+			setup: func() (string, func()) {
 				ch, dispatcher := setupYARPCTChannel(t, tracer)
 				return ch.PeerInfo().HostPort, func() {
 					dispatcher.Stop()
@@ -210,7 +210,7 @@ func TestIntegrationProtocols(t *testing.T) {
 		},
 		{
 			desc: "YARPC HTTP (enveloped)",
-			setup: func() (hostPort string, shutdown func()) {
+			setup: func() (string, func()) {
 				addr, dispatcher := setupYARPCHTTP(t, tracer, true /* enveloped */)
 				return "http://" + addr.String(), func() {
 					dispatcher.Stop()
@@ -219,7 +219,7 @@ func TestIntegrationProtocols(t *testing.T) {
 		},
 		{
 			desc: "YARPC HTTP (non-enveloped)",
-			setup: func() (hostPort string, shutdown func()) {
+			setup: func() (string, func()) {
 				addr, dispatcher := setupYARPCHTTP(t, tracer, false /* enveloped */)
 				return "http://" + addr.String(), func() {
 					dispatcher.Stop()
@@ -251,7 +251,7 @@ func TestIntegrationProtocols(t *testing.T) {
 				},
 				TOpts: TransportOptions{
 					ServiceName: "foo",
-					HostPorts:   []string{peer},
+					Peers:       []string{peer},
 					Jaeger:      true,
 				},
 			}

--- a/main.go
+++ b/main.go
@@ -198,11 +198,11 @@ func overrideDefaults(defaults *Options, args []string) {
 	argsParser.ParseArgs(args)
 
 	// Clear default peers if the user has specified peer options in args.
-	if len(argsOnly.TOpts.HostPorts) > 0 {
-		defaults.TOpts.HostPortFile = ""
+	if len(argsOnly.TOpts.Peers) > 0 {
+		defaults.TOpts.PeerList = ""
 	}
-	if len(argsOnly.TOpts.HostPortFile) > 0 {
-		defaults.TOpts.HostPorts = nil
+	if len(argsOnly.TOpts.PeerList) > 0 {
+		defaults.TOpts.Peers = nil
 	}
 }
 
@@ -242,7 +242,7 @@ func parseDefaultConfigs(parser *flags.Parser) error {
 }
 
 func runWithOptions(opts Options, out output) {
-	if opts.TOpts.HostPortFile == "?" {
+	if opts.TOpts.PeerList == "?" {
 		for _, scheme := range peerprovider.Schemes() {
 			out.Printf("%s\n", scheme)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -88,7 +88,7 @@ func TestRunWithOptions(t *testing.T) {
 				},
 				TOpts: TransportOptions{
 					ServiceName: "foo",
-					HostPorts:   []string{"1.1.1.1:1"},
+					Peers:       []string{"1.1.1.1:1"},
 				},
 			},
 			errMsg: "while parsing request input",
@@ -99,7 +99,7 @@ func TestRunWithOptions(t *testing.T) {
 				ROpts: validRequestOpts,
 				TOpts: TransportOptions{
 					ServiceName: "foo",
-					HostPorts:   []string{closedHP},
+					Peers:       []string{closedHP},
 				},
 			},
 			errMsg: "Failed while making call",
@@ -110,7 +110,7 @@ func TestRunWithOptions(t *testing.T) {
 				ROpts: validRequestOpts,
 				TOpts: TransportOptions{
 					ServiceName: "foo",
-					HostPorts:   []string{echoServer(t, fooMethod, []byte{1, 1})},
+					Peers:       []string{echoServer(t, fooMethod, []byte{1, 1})},
 				},
 			},
 			errMsg: "Failed while parsing response",
@@ -125,7 +125,7 @@ func TestRunWithOptions(t *testing.T) {
 				},
 				TOpts: TransportOptions{
 					ServiceName: "foo",
-					HostPorts:   []string{echoServer(t, fooMethod, nil)},
+					Peers:       []string{echoServer(t, fooMethod, nil)},
 				},
 			},
 			errMsg: "timeout",
@@ -136,7 +136,7 @@ func TestRunWithOptions(t *testing.T) {
 				ROpts: validRequestOpts,
 				TOpts: TransportOptions{
 					ServiceName: "foo",
-					HostPorts:   []string{echoServer(t, fooMethod, nil)},
+					Peers:       []string{echoServer(t, fooMethod, nil)},
 				},
 			},
 			wants: []string{
@@ -247,7 +247,7 @@ func TestBenchmarkIntegration(t *testing.T) {
 		serverHPs[i] = server.hostPort()
 	}
 
-	hostFile := writeFile(t, "hostPorts", strings.Join(serverHPs, "\n"))
+	hostFile := writeFile(t, "Peers", strings.Join(serverHPs, "\n"))
 	defer os.Remove(hostFile)
 
 	os.Args = []string{
@@ -388,7 +388,7 @@ func TestAlises(t *testing.T) {
 				{"--peer-list", "file"},
 			},
 			validate: func(args cmdArgs, opts *Options) {
-				assert.Equal(t, "file", opts.TOpts.HostPortFile, "Args: %v", args)
+				assert.Equal(t, "file", opts.TOpts.PeerList, "Args: %v", args)
 			},
 		},
 		{
@@ -547,8 +547,8 @@ func TestConfigOverride(t *testing.T) {
 			msg:            "peer list in config",
 			configContents: `peer-list = "/hosts.json"`,
 			validateFn: func(opts *Options, msg string) {
-				assert.Equal(t, "/hosts.json", opts.TOpts.HostPortFile, msg)
-				assert.Empty(t, opts.TOpts.HostPorts, msg)
+				assert.Equal(t, "/hosts.json", opts.TOpts.PeerList, msg)
+				assert.Empty(t, opts.TOpts.Peers, msg)
 			},
 		},
 		{
@@ -556,8 +556,8 @@ func TestConfigOverride(t *testing.T) {
 			configContents: `peer-list = "/hosts.json"`,
 			args:           []string{"-P", "/hosts2.json"},
 			validateFn: func(opts *Options, msg string) {
-				assert.Equal(t, "/hosts2.json", opts.TOpts.HostPortFile, msg)
-				assert.Empty(t, opts.TOpts.HostPorts, msg)
+				assert.Equal(t, "/hosts2.json", opts.TOpts.PeerList, msg)
+				assert.Empty(t, opts.TOpts.Peers, msg)
 			},
 		},
 		{
@@ -567,8 +567,8 @@ func TestConfigOverride(t *testing.T) {
 				peer = 1.1.1.1:1
 			`,
 			validateFn: func(opts *Options, msg string) {
-				assert.Equal(t, "/hosts.json", opts.TOpts.HostPortFile, msg)
-				assert.Equal(t, []string{"1.1.1.1:1"}, opts.TOpts.HostPorts, msg)
+				assert.Equal(t, "/hosts.json", opts.TOpts.PeerList, msg)
+				assert.Equal(t, []string{"1.1.1.1:1"}, opts.TOpts.Peers, msg)
 			},
 		},
 		{
@@ -576,8 +576,8 @@ func TestConfigOverride(t *testing.T) {
 			configContents: `peer-list = "/hosts.json"`,
 			args:           []string{"-p", "1.1.1.1:1"},
 			validateFn: func(opts *Options, msg string) {
-				assert.Empty(t, opts.TOpts.HostPortFile, "%v: hosts file should be cleared", msg)
-				assert.Equal(t, []string{"1.1.1.1:1"}, opts.TOpts.HostPorts, "%v: hostPorts", msg)
+				assert.Empty(t, opts.TOpts.PeerList, "%v: hosts file should be cleared", msg)
+				assert.Equal(t, []string{"1.1.1.1:1"}, opts.TOpts.Peers, "%v: Peers", msg)
 			},
 		},
 		{
@@ -588,8 +588,8 @@ func TestConfigOverride(t *testing.T) {
 			`,
 			args: []string{"-p", "1.1.1.1:2"},
 			validateFn: func(opts *Options, msg string) {
-				assert.Empty(t, opts.TOpts.HostPortFile, "%v: hosts file should be cleared", msg)
-				assert.Equal(t, []string{"1.1.1.1:2"}, opts.TOpts.HostPorts, "%v: hostPorts", msg)
+				assert.Empty(t, opts.TOpts.PeerList, "%v: hosts file should be cleared", msg)
+				assert.Equal(t, []string{"1.1.1.1:2"}, opts.TOpts.Peers, "%v: Peers", msg)
 			},
 		},
 		{
@@ -600,8 +600,8 @@ func TestConfigOverride(t *testing.T) {
 			`,
 			args: []string{"-P", "/hosts2.json"},
 			validateFn: func(opts *Options, msg string) {
-				assert.Equal(t, "/hosts2.json", opts.TOpts.HostPortFile, msg)
-				assert.Empty(t, opts.TOpts.HostPorts, msg)
+				assert.Equal(t, "/hosts2.json", opts.TOpts.PeerList, msg)
+				assert.Empty(t, opts.TOpts.Peers, msg)
 			},
 		},
 	}

--- a/options.go
+++ b/options.go
@@ -72,8 +72,8 @@ type RequestOptions struct {
 // TransportOptions are transport related options.
 type TransportOptions struct {
 	ServiceName      string            `short:"s" long:"service" description:"The TChannel/Hyperbahn service name"`
-	HostPorts        []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
-	HostPortFile     string            `short:"P" long:"peer-list" description:"Path or URL of a JSON, YAML, or flat file containing a list of host:ports. -P? for supported protocols."`
+	Peers            []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
+	PeerList        string            `short:"P" long:"peer-list" description:"Path or URL of a JSON, YAML, or flat file containing a list of host:ports. -P? for supported protocols."`
 	CallerName       string            `long:"caller" description:"Caller will override the default caller name (which is yab-$USER)."`
 	RoutingKey       string            `long:"rk" description:"The routing key overrides the service name traffic group for proxies."`
 	RoutingDelegate  string            `long:"rd" description:"The routing delegate overrides the routing key traffic group for proxies."`

--- a/peerprovider/file.go
+++ b/peerprovider/file.go
@@ -11,10 +11,10 @@ import (
 type filePeerProvider struct{}
 
 func (filePeerProvider) Resolve(ctx context.Context, url *url.URL) ([]string, error) {
-	return parsePeersFile(url.Path)
+	return parsePeerList(url.Path)
 }
 
-func parsePeersFile(filename string) ([]string, error) {
+func parsePeerList(filename string) ([]string, error) {
 	contents, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open peer list: %v", err)

--- a/peerprovider/file_test.go
+++ b/peerprovider/file_test.go
@@ -39,16 +39,16 @@ func TestParseHostFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got, err := parsePeersFile("../testdata/" + tt.filename)
+		got, err := parsePeerList("../testdata/" + tt.filename)
 		if tt.errMsg != "" {
-			if assert.Error(t, err, "parsePeersFile(%v) should fail", tt.filename) {
-				assert.Contains(t, err.Error(), tt.errMsg, "Unexpected error for parsePeersFile(%v)", tt.filename)
+			if assert.Error(t, err, "parsePeerList(%v) should fail", tt.filename) {
+				assert.Contains(t, err.Error(), tt.errMsg, "Unexpected error for parsePeerList(%v)", tt.filename)
 			}
 			continue
 		}
 
-		if assert.NoError(t, err, "parsePeersFile(%v) should not fail", tt.filename) {
-			assert.Equal(t, tt.want, got, "parsePeersFile(%v) mismatch", tt.filename)
+		if assert.NoError(t, err, "parsePeerList(%v) should not fail", tt.filename) {
+			assert.Equal(t, tt.want, got, "parsePeerList(%v) mismatch", tt.filename)
 		}
 	}
 }

--- a/server_util_test.go
+++ b/server_util_test.go
@@ -64,7 +64,7 @@ func (s *server) transportOpts() TransportOptions {
 	return TransportOptions{
 		CallerName:  "bar",
 		ServiceName: "foo",
-		HostPorts:   []string{s.hostPort()},
+		Peers:   []string{s.hostPort()},
 	}
 }
 

--- a/template.go
+++ b/template.go
@@ -69,12 +69,12 @@ func readYAMLRequest(opts *Options) error {
 	}
 
 	if t.Peer != "" {
-		opts.TOpts.HostPorts = []string{t.Peer}
+		opts.TOpts.Peers = []string{t.Peer}
 	} else if len(t.Peers) > 0 {
-		opts.TOpts.HostPorts = t.Peers
+		opts.TOpts.Peers = t.Peers
 	}
 	if t.PeerList != "" {
-		opts.TOpts.HostPortFile = resolve(base, t.PeerList)
+		opts.TOpts.PeerList = resolve(base, t.PeerList)
 	}
 
 	// Baggage and headers specified with command line flags override those

--- a/template_test.go
+++ b/template_test.go
@@ -85,28 +85,28 @@ func TestPeerTemplate(t *testing.T) {
 	opts := newOptions()
 	opts.ROpts.YamlTemplate = "testdata/templates/peer.yaml"
 	mustReadYAMLRequest(t, opts)
-	assert.Equal(t, []string{"127.0.0.1:8080"}, opts.TOpts.HostPorts)
+	assert.Equal(t, []string{"127.0.0.1:8080"}, opts.TOpts.Peers)
 }
 
 func TestPeersTemplate(t *testing.T) {
 	opts := newOptions()
 	opts.ROpts.YamlTemplate = "testdata/templates/peers.yaml"
 	mustReadYAMLRequest(t, opts)
-	assert.Equal(t, []string{"127.0.0.1:8080", "127.0.0.1:8081"}, opts.TOpts.HostPorts)
+	assert.Equal(t, []string{"127.0.0.1:8080", "127.0.0.1:8081"}, opts.TOpts.Peers)
 }
 
 func TestPeerListTemplate(t *testing.T) {
 	opts := newOptions()
 	opts.ROpts.YamlTemplate = "testdata/templates/peerlist.yaml"
 	mustReadYAMLRequest(t, opts)
-	assert.Equal(t, "testdata/templates/peers.json", opts.TOpts.HostPortFile)
+	assert.Equal(t, "testdata/templates/peers.json", opts.TOpts.PeerList)
 }
 
 func TestAbsPeerListTemplate(t *testing.T) {
 	opts := newOptions()
 	opts.ROpts.YamlTemplate = "testdata/templates/abspeerlist.yaml"
 	mustReadYAMLRequest(t, opts)
-	assert.Equal(t, "/peers.json", opts.TOpts.HostPortFile)
+	assert.Equal(t, "/peers.json", opts.TOpts.PeerList)
 }
 
 func TestMerge(t *testing.T) {

--- a/transport/tchannel.go
+++ b/transport/tchannel.go
@@ -68,8 +68,8 @@ type TChannelOptions struct {
 	// LogLevel overrides the default LogLevel (Warn).
 	LogLevel *tchannel.LogLevel
 
-	// HostPorts is a list of host:ports to add to the channel.
-	HostPorts []string
+	// Peers is a list of host:ports to add to the channel.
+	Peers []string
 
 	// Encoding is used to set the TChannel format ("as" header).
 	Encoding string
@@ -113,7 +113,7 @@ func NewTChannel(opts TChannelOptions) (Transport, error) {
 		return nil, fmt.Errorf("failed to create TChannel: %v", err)
 	}
 
-	for _, hp := range opts.HostPorts {
+	for _, hp := range opts.Peers {
 		ch.Peers().Add(hp)
 	}
 

--- a/transport/tchannel_test.go
+++ b/transport/tchannel_test.go
@@ -52,7 +52,7 @@ func TestTChannelConstructor(t *testing.T) {
 			opts: TChannelOptions{SourceService: "svc"},
 		},
 		{
-			opts: TChannelOptions{SourceService: "svc", HostPorts: []string{"1.1.1.1:1"}},
+			opts: TChannelOptions{SourceService: "svc", Peers: []string{"1.1.1.1:1"}},
 		},
 		{
 			opts: TChannelOptions{SourceService: "svc", LogLevel: &warnLevel},
@@ -80,7 +80,7 @@ func setupServerAndTransport(t *testing.T, changeOpts ...func(*TChannelOptions))
 	opts := TChannelOptions{
 		SourceService: "yab",
 		TargetService: svr.ServiceName(),
-		HostPorts:     []string{svr.PeerInfo().HostPort},
+		Peers:     []string{svr.PeerInfo().HostPort},
 		Encoding:      "raw",
 	}
 

--- a/transport_test.go
+++ b/transport_test.go
@@ -40,7 +40,7 @@ import (
 
 func TestProtocolFor(t *testing.T) {
 	tests := []struct {
-		hostPort string
+		peer     string
 		protocol string
 	}{
 		{"1.1.1.1:1", "tchannel"},
@@ -53,64 +53,64 @@ func TestProtocolFor(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := protocolFor(tt.hostPort)
-		assert.Equal(t, tt.protocol, got, "protocolFor(%v)", tt.hostPort)
+		got := protocolFor(tt.peer)
+		assert.Equal(t, tt.protocol, got, "protocolFor(%v)", tt.peer)
 	}
 }
 
 func TestEnsureSameProtocol(t *testing.T) {
 	tests := []struct {
-		hostPorts []string
-		want      string // if want is empty, expect an error.
+		peers []string
+		want  string // if want is empty, expect an error.
 	}{
 		{
 			// tchannel host:ports
-			hostPorts: []string{"1.1.1.1:1234", "2.2.2.2:1234"},
-			want:      "tchannel",
+			peers: []string{"1.1.1.1:1234", "2.2.2.2:1234"},
+			want:  "tchannel",
 		},
 		{
 			// only hosts without port
-			hostPorts: []string{"1.1.1.1", "2.2.2.2"},
-			want:      "unknown",
+			peers: []string{"1.1.1.1", "2.2.2.2"},
+			want:  "unknown",
 		},
 		{
-			hostPorts: []string{"http://1.1.1.1", "http://2.2.2.2:8080"},
-			want:      "http",
+			peers: []string{"http://1.1.1.1", "http://2.2.2.2:8080"},
+			want:  "http",
 		},
 		{
 			// mix of http and https
-			hostPorts: []string{"https://1.1.1.1", "http://2.2.2.2:8080"},
+			peers: []string{"https://1.1.1.1", "http://2.2.2.2:8080"},
 		},
 		{
 			// mix of tchannel and unknown
-			hostPorts: []string{"1.1.1.1:1234", "1.1.1.1"},
+			peers: []string{"1.1.1.1:1234", "1.1.1.1"},
 		},
 	}
 
 	for _, tt := range tests {
-		got, err := ensureSameProtocol(tt.hostPorts)
+		got, err := ensureSameProtocol(tt.peers)
 		if tt.want == "" {
-			assert.Error(t, err, "Expect error for %v", tt.hostPorts)
+			assert.Error(t, err, "Expect error for %v", tt.peers)
 			continue
 		}
 
-		if assert.NoError(t, err, "Expect no error for %v", tt.hostPorts) {
-			assert.Equal(t, tt.want, got, "Wrong protocol for %v", tt.hostPorts)
+		if assert.NoError(t, err, "Expect no error for %v", tt.peers) {
+			assert.Equal(t, tt.want, got, "Wrong protocol for %v", tt.peers)
 		}
 	}
 }
 
-func TestLoadTransportHostPorts(t *testing.T) {
-	hostPortFile := writeFile(t, "hostPorts", "a:1\nb:2\nc:3")
-	defer os.Remove(hostPortFile)
+func TestLoadTransportPeers(t *testing.T) {
+	peerFile := writeFile(t, "peers", "a:1\nb:2\nc:3")
+	defer os.Remove(peerFile)
 
-	opts, err := loadTransportHostPorts(TransportOptions{
-		HostPortFile: hostPortFile,
+	opts, err := loadTransportPeers(TransportOptions{
+		PeerList: peerFile,
 	})
 	require.NoError(t, err, "Failed to load transports")
 
 	assert.Equal(t, TransportOptions{
-		HostPorts: []string{"a:1", "b:2", "c:3"},
+		Peers: []string{"a:1", "b:2", "c:3"},
 	}, opts, "Unexpected transport options")
 }
 
@@ -128,31 +128,31 @@ func TestGetTransport(t *testing.T) {
 			errMsg: errPeerRequired.Error(),
 		},
 		{
-			opts: TransportOptions{ServiceName: "svc", HostPorts: []string{"1.1.1.1:1"}},
+			opts: TransportOptions{ServiceName: "svc", Peers: []string{"1.1.1.1:1"}},
 		},
 		{
-			opts: TransportOptions{ServiceName: "svc", HostPorts: []string{"localhost:1234"}},
+			opts: TransportOptions{ServiceName: "svc", Peers: []string{"localhost:1234"}},
 		},
 		{
-			opts: TransportOptions{ServiceName: "svc", HostPortFile: "testdata/valid_peerlist.json"},
+			opts: TransportOptions{ServiceName: "svc", PeerList: "testdata/valid_peerlist.json"},
 		},
 		{
-			opts:   TransportOptions{ServiceName: "svc", HostPortFile: "testdata/invalid.json"},
+			opts:   TransportOptions{ServiceName: "svc", PeerList: "testdata/invalid.json"},
 			errMsg: "peer list should be YAML, JSON, or newline delimited strings",
 		},
 		{
-			opts:   TransportOptions{ServiceName: "svc", HostPortFile: "testdata/empty.txt"},
+			opts:   TransportOptions{ServiceName: "svc", PeerList: "testdata/empty.txt"},
 			errMsg: errPeerRequired.Error(),
 		},
 		{
-			opts:   TransportOptions{ServiceName: "svc", HostPorts: []string{"1.1.1.1:1"}, HostPortFile: "testdata/valid_peerlist.json"},
+			opts:   TransportOptions{ServiceName: "svc", Peers: []string{"1.1.1.1:1"}, PeerList: "testdata/valid_peerlist.json"},
 			errMsg: errPeerOptions.Error(),
 		},
 		{
-			opts: TransportOptions{ServiceName: "svc", HostPorts: []string{"http://1.1.1.1"}},
+			opts: TransportOptions{ServiceName: "svc", Peers: []string{"http://1.1.1.1"}},
 		},
 		{
-			opts:   TransportOptions{ServiceName: "svc", HostPorts: []string{"1.1.1.1:1", "http://1.1.1.1"}},
+			opts:   TransportOptions{ServiceName: "svc", Peers: []string{"1.1.1.1:1", "http://1.1.1.1"}},
 			errMsg: "found mixed protocols",
 		},
 	}
@@ -206,7 +206,7 @@ func TestGetTransportCallerName(t *testing.T) {
 
 		opts := TransportOptions{
 			ServiceName: server.ch.ServiceName(),
-			HostPorts:   []string{server.hostPort()},
+			Peers:       []string{server.hostPort()},
 			CallerName:  tt.caller,
 		}
 		tchan, err := getTransport(opts, encoding.Raw, opentracing.NoopTracer{})
@@ -247,7 +247,7 @@ func TestGetTransportTraceEnabled(t *testing.T) {
 	opts := TransportOptions{
 		ServiceName: s.ch.ServiceName(),
 		CallerName:  "qux",
-		HostPorts:   []string{s.hostPort()},
+		Peers:       []string{s.hostPort()},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
A peer is really a URL, not just a host:port, so rename to avoid
confusion. Keep references to TChannel addresses as hostPorts (as they
cannot be full URLs)