### PR TITLE
Allow specify TChannel peers using tchannel://host:port

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -192,7 +192,7 @@ func TestMainNoHeaders(t *testing.T) {
 		"yab",
 		"-t", validThrift,
 		"foo", fooMethod,
-		"-p", echoAddr,
+		"-p", "tchannel://" + echoAddr,
 	}
 
 	main()

--- a/transport_test.go
+++ b/transport_test.go
@@ -38,23 +38,26 @@ import (
 	"golang.org/x/net/context"
 )
 
-func TestProtocolFor(t *testing.T) {
+func TestParsePeer(t *testing.T) {
 	tests := []struct {
 		peer     string
 		protocol string
+		host     string
 	}{
-		{"1.1.1.1:1", "tchannel"},
-		{"some.host:1234", "tchannel"},
-		{"1.1.1.1", "unknown"},
-		{"ftp://1.1.1.1", "ftp"},
-		{"http://1.1.1.1", "http"},
-		{"https://1.1.1.1", "https"},
-		{"://asd", "unknown"},
+		{"1.1.1.1:1", "tchannel", "1.1.1.1:1"},
+		{"some.host:1234", "tchannel", "some.host:1234"},
+		{"1.1.1.1", "unknown", ""},
+		{"ftp://1.1.1.1", "ftp", "1.1.1.1"},
+		{"http://1.1.1.1", "http", "1.1.1.1"},
+		{"https://1.1.1.1", "https", "1.1.1.1"},
+		{"http://1.1.1.1:8080", "http", "1.1.1.1:8080"},
+		{"://asd", "unknown", ""},
 	}
 
 	for _, tt := range tests {
-		got := protocolFor(tt.peer)
-		assert.Equal(t, tt.protocol, got, "protocolFor(%v)", tt.peer)
+		protocol, host := parsePeer(tt.peer)
+		assert.Equal(t, tt.protocol, protocol, "unexpected protocol for %q", tt.peer)
+		assert.Equal(t, tt.host, host, "unexpected host for %q", tt.peer)
 	}
 }
 


### PR DESCRIPTION
Currently, the call fails with `dial tcp: too many colons in address [...]`.

The TChannel transport only works with host:ports, and does not accept URLs. Use just the host:port from the URL when a TChannel peer is specified as `tchannel://host:port`.