### PR TITLE
Only deploy on go1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,5 @@ deploy:
       script: scripts/release.sh $TRAVIS_TAG
       skip_cleanup: true
       on:
+          go: 1.8
           tags: true


### PR DESCRIPTION
Created a tag to test this out, and the logs show that `go1.7` skipped the deployment:
https://travis-ci.org/yarpc/yab/jobs/207103053
`Skipping a deployment with the script provider because this is not on the required runtime`

And go1.8 attempted to deploy:
https://travis-ci.org/yarpc/yab/jobs/207103054