### PR TITLE
Fix parsing of strings from values that look like ints/bools

### DIFF
--- a/template_test.go
+++ b/template_test.go
@@ -68,7 +68,7 @@ func TestTemplate(t *testing.T) {
 	assert.Equal(t, "rd", opts.TOpts.RoutingDelegate)
 	assert.Equal(t, map[string]string{"baggage1": "value1", "baggage2": "value2"}, opts.ROpts.Baggage)
 	assert.Equal(t, true, opts.TOpts.Jaeger)
-	assert.Equal(t, "location:\n  cityId: 1\n  latitude: 37.7\n  longitude: -122.4\n", opts.ROpts.RequestJSON)
+	assert.Equal(t, "location:\n  cityId: 1\n  latitude: 37.7\n  longitude: -122.4\n  message: true\n", opts.ROpts.RequestJSON)
 	assert.Equal(t, timeMillisFlag(4500*time.Millisecond), opts.ROpts.Timeout)
 }
 

--- a/testdata/templates/foo.thrift
+++ b/testdata/templates/foo.thrift
@@ -2,6 +2,7 @@ struct QueryLocation {
   1: required double latitude
   2: required double longitude
   3: optional i32 cityId
+  4: optional string message
 }
 
 service Simple {

--- a/testdata/templates/foo.yaml
+++ b/testdata/templates/foo.yaml
@@ -18,3 +18,4 @@ request:
         latitude: 37.7
         longitude: -122.4
         cityId: 1
+        message: true

--- a/thrift/parse_test.go
+++ b/thrift/parse_test.go
@@ -95,6 +95,7 @@ func TestParseRequest(t *testing.T) {
 				16: optional map<i32, i32> i_i_map;
 				17: optional map<bool, i32> b_i_map;
 				18: optional Op op;
+				19: optional list<i32> i32_list;
       )
     }
 
@@ -284,9 +285,8 @@ func TestParseRequest(t *testing.T) {
 			errMsg: "must be specified using list[*]",
 		},
 		{
-			// wrong type for value in the list
 			request: map[string]interface{}{
-				"str_list": []interface{}{"a", 1, "c"},
+				"i32_list": []interface{}{1, "a"},
 			},
 			errMsg: "list item failed",
 		},

--- a/thrift/types.go
+++ b/thrift/types.go
@@ -169,12 +169,14 @@ func parseBinary(value interface{}) ([]byte, error) {
 		return parseBinaryList(v)
 	case map[interface{}]interface{}:
 		return parseBinaryMap(v)
-	default:
+	case bool, int, int8, int16, int32, int64, uint64, float32, float64:
 		// Since YAML tries to guess the type of a value, if the value
 		// looks like an integer, YAML will use int types even though the
 		// user needs a string. E.g., `msg: true` will treat "true" as a bool,
 		// but `msg: t` will be treat "t"" as a string. So instead of throwing
-		// an error at the user, convert the value we have to a string.
+		// an error at the user, coerce known YAML scalae types to a string.
 		return []byte(fmt.Sprint(v)), nil
+	default:
+		return nil, fmt.Errorf("cannot parse binary/string from %T: %v", value, v)
 	}
 }

--- a/thrift/types.go
+++ b/thrift/types.go
@@ -174,7 +174,7 @@ func parseBinary(value interface{}) ([]byte, error) {
 		// looks like an integer, YAML will use int types even though the
 		// user needs a string. E.g., `msg: true` will treat "true" as a bool,
 		// but `msg: t` will be treat "t"" as a string. So instead of throwing
-		// an error at the user, coerce known YAML scalae types to a string.
+		// an error at the user, coerce known YAML scalar types to a string.
 		return []byte(fmt.Sprint(v)), nil
 	default:
 		return nil, fmt.Errorf("cannot parse binary/string from %T: %v", value, v)

--- a/thrift/types.go
+++ b/thrift/types.go
@@ -170,6 +170,11 @@ func parseBinary(value interface{}) ([]byte, error) {
 	case map[interface{}]interface{}:
 		return parseBinaryMap(v)
 	default:
-		return nil, fmt.Errorf("cannot parse binary/string from %T: %v", value, v)
+		// Since YAML tries to guess the type of a value, if the value
+		// looks like an integer, YAML will use int types even though the
+		// user needs a string. E.g., `msg: true` will treat "true" as a bool,
+		// but `msg: t` will be treat "t"" as a string. So instead of throwing
+		// an error at the user, convert the value we have to a string.
+		return []byte(fmt.Sprint(v)), nil
 	}
 }

--- a/thrift/types_test.go
+++ b/thrift/types_test.go
@@ -317,16 +317,16 @@ func TestParseBinary(t *testing.T) {
 			errMsg: "no such file or directory",
 		},
 		{
-			value:  3.14159,
-			errMsg: "cannot parse binary/string",
+			value: 3.14159,
+			want:  []byte("3.14159"),
 		},
 		{
-			value:  true,
-			errMsg: "cannot parse binary/string",
+			value: true,
+			want:  []byte("true"),
 		},
 		{
-			value:  1,
-			errMsg: "cannot parse binary/string",
+			value: 1,
+			want:  []byte("1"),
 		},
 		{
 			value: []interface{}{0, 0, 0},

--- a/thrift/types_test.go
+++ b/thrift/types_test.go
@@ -329,6 +329,10 @@ func TestParseBinary(t *testing.T) {
 			want:  []byte("1"),
 		},
 		{
+			value:  []bool{true},
+			errMsg: "cannot parse binary/string",
+		},
+		{
 			value: []interface{}{0, 0, 0},
 			want:  []byte{0, 0, 0},
 		},


### PR DESCRIPTION
Since YAML tries to guess the type of a value, a string argument with a
value that looks like an int or a bool will not be a string type. We
should coerce these values into a string to users are not forced to
explicitly quote strings in their YAML file.