### PR TITLE
Allow disabling thrift envelope in YAML template

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,7 +201,7 @@ func overrideDefaults(defaults *Options, args []string) error {
 
 	// If there's a YAML request specified, read that now.
 	if argsOnly.ROpts.YamlTemplate != "" {
-		if err := readYAMLRequest(argsOnly.ROpts.YamlTemplate, defaults); err != nil {
+		if err := readYAMLFile(argsOnly.ROpts.YamlTemplate, defaults); err != nil {
 			return fmt.Errorf("failed to read yaml template: %v", err)
 		}
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -57,7 +57,6 @@ func getWd(t *testing.T) string {
 
 func TestTemplate(t *testing.T) {
 	opts := newOptions()
-	opts.ROpts.ThriftDisableEnvelopes = true
 	mustReadYAMLFile(t, "testdata/templates/foo.yaml", opts)
 
 	assert.Equal(t, toAbsPath(t, "testdata/templates/foo.thrift"), opts.ROpts.ThriftFile)
@@ -72,7 +71,7 @@ func TestTemplate(t *testing.T) {
 	assert.Equal(t, true, opts.TOpts.Jaeger)
 	assert.Equal(t, "location:\n  cityId: 1\n  latitude: 37.7\n  longitude: -122.4\n  message: true\n", opts.ROpts.RequestJSON)
 	assert.Equal(t, timeMillisFlag(4500*time.Millisecond), opts.ROpts.Timeout)
-	assert.False(t, opts.ROpts.ThriftDisableEnvelopes)
+	assert.True(t, opts.ROpts.ThriftDisableEnvelopes)
 }
 
 func TestTemplateHeadersMerge(t *testing.T) {

--- a/template_test.go
+++ b/template_test.go
@@ -31,8 +31,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mustReadYAMLRequest(t *testing.T, yamlTemplate string, opts *Options) {
-	assert.NoError(t, readYAMLRequest(yamlTemplate, opts), "read request error")
+func mustReadYAMLFile(t *testing.T, yamlTemplate string, opts *Options) {
+	assert.NoError(t, readYAMLFile(yamlTemplate, opts), "read request error")
+}
+
+func mustReadYAMLRequest(t *testing.T, contents string, opts *Options) {
+	assert.NoError(t, readYAMLRequest("/base", []byte(contents), opts), "read request error")
 }
 
 func toAbsPath(t *testing.T, s string) string {
@@ -53,7 +57,8 @@ func getWd(t *testing.T) string {
 
 func TestTemplate(t *testing.T) {
 	opts := newOptions()
-	mustReadYAMLRequest(t, "testdata/templates/foo.yaml", opts)
+	opts.ROpts.ThriftDisableEnvelopes = true
+	mustReadYAMLFile(t, "testdata/templates/foo.yaml", opts)
 
 	assert.Equal(t, toAbsPath(t, "testdata/templates/foo.thrift"), opts.ROpts.ThriftFile)
 	assert.Equal(t, "Simple::foo", opts.ROpts.Procedure)
@@ -67,6 +72,7 @@ func TestTemplate(t *testing.T) {
 	assert.Equal(t, true, opts.TOpts.Jaeger)
 	assert.Equal(t, "location:\n  cityId: 1\n  latitude: 37.7\n  longitude: -122.4\n  message: true\n", opts.ROpts.RequestJSON)
 	assert.Equal(t, timeMillisFlag(4500*time.Millisecond), opts.ROpts.Timeout)
+	assert.False(t, opts.ROpts.ThriftDisableEnvelopes)
 }
 
 func TestTemplateHeadersMerge(t *testing.T) {
@@ -79,7 +85,7 @@ func TestTemplateHeadersMerge(t *testing.T) {
 		"header3": "from Headers",
 	}
 
-	mustReadYAMLRequest(t, "testdata/templates/foo.yaml", opts)
+	mustReadYAMLFile(t, "testdata/templates/foo.yaml", opts)
 
 	headers, err := getHeaders(opts.ROpts.HeadersJSON, opts.ROpts.HeadersFile, opts.ROpts.Headers)
 	assert.NoError(t, err, "failed to merge headers")
@@ -90,32 +96,32 @@ func TestTemplateHeadersMerge(t *testing.T) {
 // This test verifies that the string alias for method to procedure follows
 func TestMethodTemplate(t *testing.T) {
 	opts := newOptions()
-	mustReadYAMLRequest(t, "testdata/templates/foo-method.yaml", opts)
+	mustReadYAMLFile(t, "testdata/templates/foo-method.yaml", opts)
 
 	assert.Equal(t, "Simple::foo", opts.ROpts.Procedure)
 }
 
 func TestPeerTemplate(t *testing.T) {
 	opts := newOptions()
-	mustReadYAMLRequest(t, "testdata/templates/peer.yaml", opts)
+	mustReadYAMLFile(t, "testdata/templates/peer.yaml", opts)
 	assert.Equal(t, []string{"127.0.0.1:8080"}, opts.TOpts.Peers)
 }
 
 func TestPeersTemplate(t *testing.T) {
 	opts := newOptions()
-	mustReadYAMLRequest(t, "testdata/templates/peers.yaml", opts)
+	mustReadYAMLFile(t, "testdata/templates/peers.yaml", opts)
 	assert.Equal(t, []string{"127.0.0.1:8080", "127.0.0.1:8081"}, opts.TOpts.Peers)
 }
 
 func TestPeerListTemplate(t *testing.T) {
 	opts := newOptions()
-	mustReadYAMLRequest(t, "testdata/templates/peerlist.yaml", opts)
+	mustReadYAMLFile(t, "testdata/templates/peerlist.yaml", opts)
 	assert.Equal(t, toAbsURL(t, "testdata/templates/peers.json"), opts.TOpts.PeerList)
 }
 
 func TestAbsPeerListTemplate(t *testing.T) {
 	opts := newOptions()
-	mustReadYAMLRequest(t, "testdata/templates/abspeerlist.yaml", opts)
+	mustReadYAMLFile(t, "testdata/templates/abspeerlist.yaml", opts)
 	assert.Equal(t, "file:///peers.json", opts.TOpts.PeerList)
 }
 
@@ -212,10 +218,11 @@ func TestResolve(t *testing.T) {
 
 func TestTemplateAlias(t *testing.T) {
 	tests := []struct {
-		templates           []string
-		wantShardKey        string
-		wantRoutingKey      string
-		wantRoutingDelegate string
+		templates                 []string
+		wantShardKey              string
+		wantRoutingKey            string
+		wantRoutingDelegate       string
+		wantDisableThriftEnvelope *bool
 	}{
 		{
 			templates: []string{
@@ -244,6 +251,14 @@ func TestTemplateAlias(t *testing.T) {
 			},
 			wantRoutingDelegate: "routingdelegate",
 		},
+		{
+			templates: []string{
+				`disableThriftEnvelope: false`,
+				`disablethriftenvelope: false`,
+				`disable-thrift-envelope: false`,
+			},
+			wantDisableThriftEnvelope: new(bool),
+		},
 	}
 
 	for _, tt := range tests {
@@ -254,8 +269,46 @@ func TestTemplateAlias(t *testing.T) {
 				assert.Equal(t, tt.wantShardKey, templ.ShardKey, "shard key aliases expanded")
 				assert.Equal(t, tt.wantRoutingKey, templ.RoutingKey, "routing key aliases expanded")
 				assert.Equal(t, tt.wantRoutingDelegate, templ.RoutingDelegate, "routing delegate aliases expanded")
+				assert.Equal(t, tt.wantDisableThriftEnvelope, templ.DisableThriftEnvelope, "disable thrift envelope aliases expanded")
 			})
 		}
+	}
+}
+
+func TestDisableThriftEnvelopeOverride(t *testing.T) {
+	tests := []struct {
+		initial                   bool
+		yaml                      string
+		wantDisableThriftEnvelope bool
+	}{
+		{
+			initial: false,
+			yaml:    "method: foo",
+			wantDisableThriftEnvelope: false,
+		},
+		{
+			initial: true,
+			yaml:    "method: foo",
+			wantDisableThriftEnvelope: true,
+		},
+		{
+			initial: false,
+			yaml:    "disable-thrift-envelope: true",
+			wantDisableThriftEnvelope: true,
+		},
+		{
+			initial: true,
+			yaml:    "disable-thrift-envelope: true",
+			wantDisableThriftEnvelope: true,
+		},
+	}
+
+	for _, tt := range tests {
+		opts := newOptions()
+		opts.ROpts.ThriftDisableEnvelopes = tt.initial
+		mustReadYAMLRequest(t, tt.yaml, opts)
+		assert.Equal(t, tt.wantDisableThriftEnvelope, opts.ROpts.ThriftDisableEnvelopes,
+			"initial %v yaml: %v", tt.initial, tt.yaml)
 	}
 }
 
@@ -277,7 +330,7 @@ func TestReadYAMLRequestFails(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.yamlTemplate, func(t *testing.T) {
 			opts := newOptions()
-			err := readYAMLRequest(tt.yamlTemplate, opts)
+			err := readYAMLFile(tt.yamlTemplate, opts)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})

--- a/testdata/templates/foo.yaml
+++ b/testdata/templates/foo.yaml
@@ -6,6 +6,7 @@ routingKey: rk
 routingDelegate: rd
 thrift: foo.thrift
 timeout: 4.5s
+disableThriftEnvelope: false
 headers:
     header1: from template
     header3: overridden by Headers

--- a/testdata/templates/foo.yaml
+++ b/testdata/templates/foo.yaml
@@ -6,7 +6,7 @@ routingKey: rk
 routingDelegate: rd
 thrift: foo.thrift
 timeout: 4.5s
-disableThriftEnvelope: false
+disableThriftEnvelope: true
 headers:
     header1: from template
     header3: overridden by Headers


### PR DESCRIPTION
Currently, Thrift envelopes must be disabled at the command line. Allow
disabling the envelope from the YAML template.