### PR TITLE
Use context for HTTP transport

### DIFF
--- a/transport/http.go
+++ b/transport/http.go
@@ -144,7 +144,7 @@ func (h *httpTransport) Call(ctx context.Context, r *Request) (*Response, error)
 		return nil, err
 	}
 
-	resp, err := h.client.Do(req)
+	resp, err := h.client.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -72,6 +72,7 @@ func TestHTTPConstructor(t *testing.T) {
 
 func TestHTTPCall(t *testing.T) {
 	timeoutCtx, _ := context.WithTimeout(context.Background(), 3*time.Second)
+	immediateTimeout, _ := context.WithTimeout(context.Background(), time.Nanosecond)
 
 	tests := []struct {
 		ctx      context.Context
@@ -96,6 +97,11 @@ func TestHTTPCall(t *testing.T) {
 			ttlMin:   3*time.Second - 100*time.Millisecond,
 			ttlMax:   3 * time.Second,
 			wantCode: http.StatusOK,
+		},
+		{
+			ctx:    immediateTimeout,
+			r:      &Request{Method: "method", Body: []byte{1, 2, 3}},
+			errMsg: "request canceled",
 		},
 		{
 			ctx:  context.Background(),


### PR DESCRIPTION
Fixes #188 