### PR TITLE
Adding map to blacklist caller names, tcurl to start

### DIFF
--- a/bench_state_test.go
+++ b/bench_state_test.go
@@ -48,7 +48,7 @@ func TestBenchmarkStateErrors(t *testing.T) {
 		state1.recordError(nil)
 	})
 
-	buf, out := getOutput(t)
+	buf, _, out := getOutput(t)
 
 	// before merge
 	assert.Equal(t, state1.totalErrors, 4, "Error count mismatch")
@@ -83,7 +83,7 @@ func TestBenchmarkStateErrors(t *testing.T) {
 
 func TestBenchmarkStateNoError(t *testing.T) {
 	state := newBenchmarkState(statsd.Noop)
-	buf, out := getOutput(t)
+	buf, _, out := getOutput(t)
 	state.printErrors(out)
 	assert.Equal(t, 0, buf.Len(), "Expected no output with no errors, got: %s", buf.String())
 }
@@ -99,7 +99,7 @@ func TestBenchmarkStateLatencies(t *testing.T) {
 		latencies = append(latencies, latency)
 	}
 
-	buf, out := getOutput(t)
+	buf, _, out := getOutput(t)
 
 	assert.Equal(t, state.totalErrors, 0, "Error count mismatch")
 	assert.Equal(t, state.totalSuccess, 10001, "Success count mismatch")
@@ -149,7 +149,7 @@ func TestBenchmarkStateMergeLatencies(t *testing.T) {
 	assert.Equal(t, state1.totalSuccess, 10001, "Success count mismatch")
 	assert.Equal(t, state1.totalRequests, 10001, "Request count mismatch")
 
-	buf, out := getOutput(t)
+	buf, _, out := getOutput(t)
 	state1.printLatencies(out)
 
 	expected := []string{

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -76,7 +76,7 @@ func TestBenchmark(t *testing.T) {
 		requests.Store(0)
 
 		start := time.Now()
-		buf, out := getOutput(t)
+		buf, _, out := getOutput(t)
 		runBenchmark(out, Options{
 			BOpts: BenchmarkOptions{
 				MaxRequests: tt.n,

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func fromPositional(args []string, index int, s *string) bool {
 
 func main() {
 	log.SetFlags(0)
-	parseAndRun(consoleOutput{os.Stdout, os.Stderr})
+	parseAndRun(consoleOutput{os.Stdout})
 }
 
 var errExit = errors.New("sentinel error used to exit cleanly")
@@ -286,7 +286,7 @@ func runWithOptions(opts Options, out output) {
 	if opts.TOpts.CallerName != "" {
 		if _, ok := warningCallerNames[opts.TOpts.CallerName]; ok {
 			// TODO: when logger is hooked up this should use the WARN level message
-			out.Warnf("WARNING: Deprecated caller name: [%v]\nPlease change the caller name as it will be blocked in the next release.", opts.TOpts.CallerName)
+			out.Warnf("WARNING: Deprecated caller name: %q Please change the caller name as it will be blocked in the next release.\n", opts.TOpts.CallerName)
 		}
 		if _, ok := blockedCallerNames[opts.TOpts.CallerName]; ok {
 			out.Fatalf("Disallowed caller name: %v", opts.TOpts.CallerName)

--- a/main.go
+++ b/main.go
@@ -43,7 +43,11 @@ import (
 	"github.com/uber/tchannel-go"
 )
 
-var errHealthAndProcedure = errors.New("cannot specify procedure and use --health")
+var (
+	errHealthAndProcedure = errors.New("cannot specify procedure and use --health")
+	// map of caller names we do not want to be used.
+	disallowedCallerNames = map[string]bool{"tcurl": true}
+)
 
 func findGroup(parser *flags.Parser, group string) *flags.Group {
 	if g := parser.Group.Find(group); g != nil {
@@ -278,6 +282,9 @@ func runWithOptions(opts Options, out output) {
 	}
 
 	if opts.TOpts.CallerName != "" {
+		if val, ok := disallowedCallerNames[opts.TOpts.CallerName]; ok {
+			out.Fatalf("Disallowed caller name: %v", val)
+		}
 		if opts.BOpts.enabled() {
 			out.Fatalf("Cannot override caller name when running benchmarks\n")
 		}

--- a/main.go
+++ b/main.go
@@ -286,7 +286,7 @@ func runWithOptions(opts Options, out output) {
 	if opts.TOpts.CallerName != "" {
 		if _, ok := warningCallerNames[opts.TOpts.CallerName]; ok {
 			// TODO: when logger is hooked up this should use the WARN level message
-			out.Warnf("WARNING: Deprecated caller name: %v", opts.TOpts.CallerName)
+			out.Warnf("WARNING: Deprecated caller name: [%v]\nPlease change the caller name as it will be blocked in the next release.", opts.TOpts.CallerName)
 		}
 		if _, ok := blockedCallerNames[opts.TOpts.CallerName]; ok {
 			out.Fatalf("Disallowed caller name: %v", opts.TOpts.CallerName)

--- a/main_test.go
+++ b/main_test.go
@@ -154,6 +154,22 @@ func TestRunWithOptions(t *testing.T) {
 			},
 		},
 		{
+			desc: "No errors or warnings with a valid callername",
+			opts: Options{
+				ROpts: validRequestOpts,
+				TOpts: TransportOptions{
+					ServiceName: "foo",
+					Peers:       []string{echoServer(t, fooMethod, nil)},
+					CallerName:  "valid-caller-name",
+				},
+			},
+			wants: []string{
+				"{}",
+				`"ok": true`,
+				`"trace": "`,
+			},
+		},
+		{
 			desc: "Warn on caller names from the warning map",
 			opts: Options{
 				ROpts: validRequestOpts,

--- a/main_test.go
+++ b/main_test.go
@@ -145,6 +145,18 @@ func TestRunWithOptions(t *testing.T) {
 				`"trace": "`,
 			},
 		},
+		{
+			desc: "Fail to allow caller names from a map",
+			opts: Options{
+				ROpts: validRequestOpts,
+				TOpts: TransportOptions{
+					ServiceName: "foo",
+					Peers:       []string{echoServer(t, fooMethod, nil)},
+					CallerName:  "tcurl",
+				},
+			},
+			errMsg: "Disallowed caller",
+		},
 	}
 
 	var errBuf bytes.Buffer

--- a/main_test.go
+++ b/main_test.go
@@ -160,7 +160,7 @@ func TestRunWithOptions(t *testing.T) {
 					CallerName:  "tcurl",
 				},
 			},
-			warnMsg: "WARNING: Deprecated caller name: tcurl",
+			warnMsg: "WARNING: Deprecated caller name: [tcurl]\nPlease change the caller name as it will be blocked in the next release.",
 			wants: []string{
 				"{}",
 				`"ok": true`,

--- a/output.go
+++ b/output.go
@@ -32,16 +32,22 @@ type output interface {
 
 	Fatalf(format string, args ...interface{})
 	Printf(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
 }
 
 type consoleOutput struct {
 	*os.File
+	errFile *os.File
 }
 
-func (consoleOutput) Fatalf(format string, args ...interface{}) {
+func (c consoleOutput) Fatalf(format string, args ...interface{}) {
 	log.Fatalf(format, args...)
 }
 
-func (consoleOutput) Printf(format string, args ...interface{}) {
+func (c consoleOutput) Printf(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
+}
+
+func (c consoleOutput) Warnf(format string, args ...interface{}) {
+	fmt.Fprintf(c.errFile, format, args...)
 }

--- a/output.go
+++ b/output.go
@@ -37,17 +37,16 @@ type output interface {
 
 type consoleOutput struct {
 	*os.File
-	errFile *os.File
 }
 
-func (c consoleOutput) Fatalf(format string, args ...interface{}) {
+func (consoleOutput) Fatalf(format string, args ...interface{}) {
 	log.Fatalf(format, args...)
 }
 
-func (c consoleOutput) Printf(format string, args ...interface{}) {
+func (consoleOutput) Printf(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 
-func (c consoleOutput) Warnf(format string, args ...interface{}) {
-	fmt.Fprintf(c.errFile, format, args...)
+func (consoleOutput) Warnf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, args...)
 }

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -42,8 +42,8 @@ const (
 
 type testOutput struct {
 	*bytes.Buffer
-	warnBuf *bytes.Buffer
-	fatalf  func(string, ...interface{})
+	warnf  func(string, ...interface{})
+	fatalf func(string, ...interface{})
 }
 
 func (t testOutput) Fatalf(format string, args ...interface{}) {
@@ -56,16 +56,18 @@ func (t testOutput) Printf(format string, args ...interface{}) {
 }
 
 func (t testOutput) Warnf(format string, args ...interface{}) {
-	t.warnBuf.WriteString(fmt.Sprintf(format, args...))
+	t.warnf(format, args...)
 }
 
 func getOutput(t *testing.T) (*bytes.Buffer, *bytes.Buffer, output) {
 	outBuf := &bytes.Buffer{}
 	warnBuf := &bytes.Buffer{}
 	out := testOutput{
-		Buffer:  outBuf,
-		warnBuf: warnBuf,
-		fatalf:  t.Errorf,
+		Buffer: outBuf,
+		warnf: func(format string, args ...interface{}) {
+			warnBuf.WriteString(fmt.Sprintf(format, args...))
+		},
+		fatalf: t.Errorf,
 	}
 	return outBuf, warnBuf, out
 }

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -42,7 +42,8 @@ const (
 
 type testOutput struct {
 	*bytes.Buffer
-	fatalf func(string, ...interface{})
+	warnBuf *bytes.Buffer
+	fatalf  func(string, ...interface{})
 }
 
 func (t testOutput) Fatalf(format string, args ...interface{}) {
@@ -54,13 +55,19 @@ func (t testOutput) Printf(format string, args ...interface{}) {
 	t.WriteString(fmt.Sprintf(format, args...))
 }
 
-func getOutput(t *testing.T) (*bytes.Buffer, output) {
-	buf := &bytes.Buffer{}
+func (t testOutput) Warnf(format string, args ...interface{}) {
+	t.warnBuf.WriteString(fmt.Sprintf(format, args...))
+}
+
+func getOutput(t *testing.T) (*bytes.Buffer, *bytes.Buffer, output) {
+	outBuf := &bytes.Buffer{}
+	warnBuf := &bytes.Buffer{}
 	out := testOutput{
-		Buffer: buf,
-		fatalf: t.Errorf,
+		Buffer:  outBuf,
+		warnBuf: warnBuf,
+		fatalf:  t.Errorf,
 	}
-	return buf, out
+	return outBuf, warnBuf, out
 }
 
 func writeFile(t *testing.T, prefix, contents string) string {


### PR DESCRIPTION
Fixes #180  and allows us to blacklist other caller names as well. 

Thoughts while doing this is we could just append `USER` instead of block. Also we could do a `strings.contains` to get caller names with `tcurl` anywhere in the name. 

@blampe 