### PR TITLE
Progress bar for benchmark tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install:
 
 .PHONY: test
 test:
-	go test -cover -race $(PACKAGES)
+	go test -cover -race -count 100 $(PACKAGES)
 
 
 .PHONY: install_ci

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install:
 
 .PHONY: test
 test:
-	go test -cover -race -count 100 $(PACKAGES)
+	go test -cover -race $(PACKAGES)
 
 
 .PHONY: install_ci

--- a/benchmark.go
+++ b/benchmark.go
@@ -158,7 +158,7 @@ func runBenchmark(out output, allOpts Options, m benchmarkMethod) {
 	// Wait for all the worker goroutines to end.
 	wg.Wait()
 	total := time.Since(start)
-	progressBar.FinishPrint("Benchmark finished.")
+	progressBar.FinishPrint("Benchmark finished")
 
 	// Merge all the states into 0
 	overall := states[0]

--- a/benchmark.go
+++ b/benchmark.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"errors"
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"runtime"
@@ -144,7 +145,10 @@ func runBenchmark(out output, allOpts Options, m benchmarkMethod) {
 	progressMarker, progressUnit = progressBarSetup(&opts)
 	progressBar := pb.New(progressMarker)
 	progressBar.SetUnits(progressUnit)
-	progressBar.Output = out
+	progressBar.Output = ioutil.Discard
+	if opts.ProgressBar {
+		progressBar.Output = out
+	}
 	progressBar.Start()
 
 	run := limiter.New(opts.MaxRequests, opts.RPS, opts.MaxDuration)
@@ -168,8 +172,6 @@ func runBenchmark(out output, allOpts Options, m benchmarkMethod) {
 	// Wait for all the worker goroutines to end.
 	wg.Wait()
 	total := time.Since(start)
-	progressBar.Finish()
-	progressBar.Finish()
 	progressBar.Finish()
 
 	// progressBar.FinishPrint("Benchmark finished")
@@ -205,5 +207,5 @@ func progressBarSetup(opts *BenchmarkOptions) (int, pb.Units) {
 	if opts.MaxRequests > 0 {
 		return opts.MaxRequests, pb.U_NO
 	}
-	return int(opts.MaxDuration), pb.U_NO
+	return int(opts.MaxDuration), pb.U_DURATION
 }

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -90,7 +90,7 @@ func TestBenchmark(t *testing.T) {
 
 		bufStr := buf.String()
 		assert.Contains(t, bufStr, "Max RPS")
-		assert.Contains(t, bufStr, "Finished Benchmark")
+		assert.Contains(t, bufStr, "Benchmark finished")
 		assert.NotContains(t, bufStr, "Errors")
 
 		if tt.want != 0 {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -90,6 +90,7 @@ func TestBenchmark(t *testing.T) {
 
 		bufStr := buf.String()
 		assert.Contains(t, bufStr, "Max RPS")
+		assert.Contains(t, bufStr, "Finished Benchmark")
 		assert.NotContains(t, bufStr, "Errors")
 
 		if tt.want != 0 {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/testutils"
 	"go.uber.org/atomic"
+	"gopkg.in/cheggaaa/pb.v1"
 )
 
 func TestBenchmark(t *testing.T) {
@@ -41,12 +42,16 @@ func TestBenchmark(t *testing.T) {
 		rps          int
 		want         int
 		wantDuration time.Duration
+		wantMarker   int
+		wantUnit     pb.Units
 	}{
 		{
-			msg:  "Capped by max requests",
-			n:    100,
-			d:    100 * time.Second,
-			want: 100,
+			msg:        "Capped by max requests",
+			n:          100,
+			d:          100 * time.Second,
+			want:       100,
+			wantMarker: 100,
+			wantUnit:   pb.U_NO,
 		},
 		{
 			msg:          "Capped by RPS * duration",
@@ -54,11 +59,15 @@ func TestBenchmark(t *testing.T) {
 			rps:          120,
 			want:         60,
 			wantDuration: 500 * time.Millisecond,
+			wantMarker:   60,
+			wantUnit:     pb.U_NO,
 		},
 		{
 			msg:          "Capped by duration",
 			d:            500 * time.Millisecond,
 			wantDuration: 500 * time.Millisecond,
+			wantMarker:   int(500 * time.Millisecond),
+			wantUnit:     pb.U_DURATION,
 		},
 	}
 
@@ -71,18 +80,20 @@ func TestBenchmark(t *testing.T) {
 	}))
 
 	m := benchmarkMethodForTest(t, fooMethod, transport.TChannel)
+	buf, _, out := getOutput(t)
 
 	for _, tt := range tests {
+		buf.Reset()
 		requests.Store(0)
 
 		start := time.Now()
-		buf, _, out := getOutput(t)
+
 		runBenchmark(out, Options{
 			BOpts: BenchmarkOptions{
 				MaxRequests: tt.n,
 				MaxDuration: tt.d,
 				RPS:         tt.rps,
-				Connections: 50,
+				Connections: 25,
 				Concurrency: 2,
 			},
 			TOpts: s.transportOpts(),
@@ -90,13 +101,15 @@ func TestBenchmark(t *testing.T) {
 
 		bufStr := buf.String()
 		assert.Contains(t, bufStr, "Max RPS")
-		assert.Contains(t, bufStr, "Benchmark finished")
+		// assert.Contains(t, bufStr, "Benchmark finished")
 		assert.NotContains(t, bufStr, "Errors")
 
 		if tt.want != 0 {
 			assert.EqualValues(t, tt.want, requests.Load(),
 				"%v: Invalid number of requests", tt.msg)
 		}
+		assert.Equal(t, tt.wantMarker, progressMarker, "progress bar total should be: %v", tt.wantMarker)
+		assert.Equal(t, tt.wantUnit, progressUnit, "progress bar unit should be %v", tt.wantUnit)
 
 		if tt.wantDuration != 0 {
 			// Make sure the total duration is within a delta.
@@ -150,3 +163,68 @@ func TestRunBenchmarkErrors(t *testing.T) {
 		assert.Contains(t, fatalMessage, tt.wantErr, "Missing error for %+v", tt.opts)
 	}
 }
+
+// func TestBenchmarkProgressBar(t *testing.T) {
+// 	tests := []struct {
+// 		msg         string
+// 		maxRequests int
+// 		d           time.Duration
+// 		rps         int
+
+// 		wantMarker int
+// 		wantUnit   pb.Units
+// 	}{
+// 		{
+// 			msg:         "RPS simple progrss bar",
+// 			maxRequests: 100,
+// 			wantMarker:  100,
+// 			wantUnit:    pb.U_NO,
+// 		},
+// 		{
+// 			msg: "Duration progress bar",
+// 			d:   1 * time.Second,
+// 		},
+// 		{
+// 			msg:        "RPS times duration in seconds 1 second",
+// 			d:          1 * time.Second,
+// 			rps:        100,
+// 			wantMarker: 100,
+// 			wantUnit:   pb.U_NO,
+// 		},
+// 		{
+// 			msg:        "RPS times duration in seconds",
+// 			d:          500 * time.Millisecond,
+// 			rps:        100,
+// 			wantMarker: 50,
+// 			wantUnit:   pb.U_NO,
+// 		},
+// 	}
+// 	var requests atomic.Int32
+// 	s := newServer(t)
+// 	defer s.shutdown()
+// 	s.register(fooMethod, methods.errorIf(func() bool {
+// 		requests.Inc()
+// 		return false
+// 	}))
+
+// 	m := benchmarkMethodForTest(t, fooMethod, transport.TChannel)
+
+// 	buf, _, out := getOutput(t)
+// 	for _, tt := range tests {
+// 		buf.Reset()
+// 		requests.Store(0)
+
+// 		t.Run(fmt.Sprintf(tt.msg), func(t *testing.T) {
+// 			runBenchmark(out, Options{
+// 				BOpts: BenchmarkOptions{
+// 					MaxRequests: tt.maxRequests,
+// 					MaxDuration: tt.d,
+// 					RPS:         tt.rps,
+// 					Connections: 50,
+// 					Concurrency: 2,
+// 				},
+// 				TOpts: s.transportOpts(),
+// 			}, m)
+// 		})
+// 	}
+// }

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: da28cdd6cc388e155bde58369bf3f1d979954e11446888c23f3bb51187d1806a
-updated: 2017-04-25T15:16:31.435502477-07:00
+hash: 6a51f6735c878e11cbb14bf438625c6fd383bcc6f1eb21426fb37be1f6a2763e
+updated: 2017-04-29T15:21:47.342046953-07:00
 imports:
 - name: github.com/apache/thrift
-  version: 3311a9b2375276441234218f4351c6a8f66a6bc2
+  version: 19baeefd8c38d62085891d7956349601f79448b3
   subpackages:
   - lib/go/thrift
 - name: github.com/cactus/go-statsd-client
@@ -17,6 +17,8 @@ imports:
   - spew
 - name: github.com/jessevdk/go-flags
   version: 460c7bb0abd6e927f2767cadc91aa6ef776a98b4
+- name: github.com/mattn/go-runewidth
+  version: 14207d285c6c197daabb5c9793d63e7af9ab2d50
 - name: github.com/opentracing/opentracing-go
   version: 6edb48674bd9467b8e91fda004f2bd7202d60ce4
   subpackages:
@@ -32,7 +34,7 @@ imports:
   - assert
   - require
 - name: github.com/uber-go/atomic
-  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+  version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
 - name: github.com/uber/jaeger-client-go
   version: e39d0f1b622558cae3d9db0062a739cc6ffa700f
   subpackages:
@@ -78,8 +80,10 @@ imports:
   version: da118f7b8e5954f39d0d2130ab35d4bf0e3cb344
   subpackages:
   - context
+- name: gopkg.in/cheggaaa/pb.v1
+  version: b6229822fa186496fcbf34111237e7a9693c6971
 - name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 testImports:
 - name: go.uber.org/yarpc
   version: 6ae533f0810337028ef055b690360e050aa13219

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 6a51f6735c878e11cbb14bf438625c6fd383bcc6f1eb21426fb37be1f6a2763e
-updated: 2017-04-29T15:21:47.342046953-07:00
+hash: 449b3c6f4996b7e8fc006fe20f57caac03d3a38d85ed4a4707541bdbe3fd9a5f
+updated: 2017-05-31T11:04:29.93385975-07:00
 imports:
 - name: github.com/apache/thrift
-  version: 19baeefd8c38d62085891d7956349601f79448b3
+  version: e41e47c2b4b2407bac525d203b281c63fb253978
   subpackages:
   - lib/go/thrift
 - name: github.com/cactus/go-statsd-client
@@ -20,7 +20,7 @@ imports:
 - name: github.com/mattn/go-runewidth
   version: 14207d285c6c197daabb5c9793d63e7af9ab2d50
 - name: github.com/opentracing/opentracing-go
-  version: 6edb48674bd9467b8e91fda004f2bd7202d60ce4
+  version: 1949ddbfd147afd4d964a9f00b24eb291e0e7c38
   subpackages:
   - ext
   - log
@@ -34,7 +34,7 @@ imports:
   - assert
   - require
 - name: github.com/uber-go/atomic
-  version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
+  version: 0c9e689d64f004564b79d9a663634756df322902
 - name: github.com/uber/jaeger-client-go
   version: e39d0f1b622558cae3d9db0062a739cc6ffa700f
   subpackages:
@@ -77,16 +77,53 @@ imports:
   - version
   - wire
 - name: golang.org/x/net
-  version: da118f7b8e5954f39d0d2130ab35d4bf0e3cb344
+  version: 513929065c19401a1c7b76ecd942f9f86a0c061b
   subpackages:
   - context
 - name: gopkg.in/cheggaaa/pb.v1
-  version: b6229822fa186496fcbf34111237e7a9693c6971
+  version: f6ccf2184de4dd34495277e38dc19b6e7fbe0ea2
 - name: gopkg.in/yaml.v2
-  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports:
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
+- name: github.com/facebookgo/clock
+  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
+- name: github.com/golang/protobuf
+  version: 7cc19b78d562895b13596ddce7aafb59dd789318
+  subpackages:
+  - proto
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- name: github.com/prometheus/client_model
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: dd2f054febf4a6c00f2343686efb775948a8bff4
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  subpackages:
+  - xfs
+- name: github.com/uber-go/tally
+  version: e9b601813b0be4771b1b3995390567b67ab2b3fc
+- name: go.uber.org/multierr
+  version: a3d1fc1f1316d4132fc61f4ea1159ae0613fb474
 - name: go.uber.org/yarpc
-  version: 6ae533f0810337028ef055b690360e050aa13219
+  version: 6b9245d126758870690c44f27f695cc7e811f913
   subpackages:
   - api/encoding
   - api/middleware
@@ -102,7 +139,10 @@ testImports:
   - internal/introspection
   - internal/iopool
   - internal/net
+  - internal/observability
   - internal/outboundmiddleware
+  - internal/pally
+  - internal/procedure
   - internal/request
   - internal/sync
   - peer
@@ -110,3 +150,12 @@ testImports:
   - transport/http
   - transport/tchannel
   - transport/tchannel/internal
+- name: go.uber.org/zap
+  version: fab453050a7a08c35f31fc5fff6f2dbd962285ab
+  subpackages:
+  - buffer
+  - internal/bufferpool
+  - internal/color
+  - internal/exit
+  - internal/multierror
+  - zapcore

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,6 +16,7 @@ import:
   version: ^1
 - package: github.com/uber/jaeger-client-go
   version: ^1
+- package: gopkg.in/cheggaaa/pb.v1
 testImport:
 - package: github.com/apache/thrift
   version: master

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,6 +17,7 @@ import:
 - package: github.com/uber/jaeger-client-go
   version: ^1
 - package: gopkg.in/cheggaaa/pb.v1
+  version: ^1
 testImport:
 - package: github.com/apache/thrift
   version: master

--- a/options.go
+++ b/options.go
@@ -105,6 +105,9 @@ type BenchmarkOptions struct {
 
 	// Benchmark metrics can optionally be reported via statsd.
 	StatsdHostPort string `long:"statsd" description:"Optional host:port of a StatsD server to report metrics"`
+
+	// Output options
+	ProgressBar bool `long:"progress-bar" description:"show a progress bar for the benchmark."`
 }
 
 func newOptions() *Options {


### PR DESCRIPTION
Fixes #57 

Prints a Progress bar to the console based on request count. Using library that does atomic increments. Other notes is it uses the terminal width and we are not setting it manually.

Output:

`yab moe --health --rps 100 -d 10s `
```
{
  "body": {
    "result": {
      "ok": true
    }
  },
  "ok": true,
  "trace": "4802f563e101ee42"
}

Benchmark parameters:
  CPUs:            24
  Connections:     48
  Concurrency:     1
  Max requests:    1000
  Max duration:    10s
  Max RPS:         100
 1000 / 1000 [============================================================================================================================] 100.00% 10s
Benchmark finished
Latencies:
  0.5000: 785.466µs
  0.9000: 1.006528ms
  0.9500: 1.189203ms
  0.9900: 9.582816ms
  0.9990: 57.667579ms
  0.9995: 59.614299ms
  1.0000: 61.56102ms
Elapsed time:      10s
Total requests:    1000
RPS:               100.00
```


Test without finishing total requests `yab moe --health --rps 20000 -d 10s`
```
{
  "body": {
    "result": {
      "ok": true
    }
  },
  "ok": true,
  "trace": "78915b6b9d43168c"
}

Benchmark parameters:
  CPUs:            24
  Connections:     48
  Concurrency:     1
  Max requests:    200000
  Max duration:    10s
  Max RPS:         20000
 98210 / 200000 [===========================================================>-------------------------------------------------------------]  49.10% 10s
Benchmark finished
Latencies:
  0.5000: 565.675µs
  0.9000: 1.575297ms
  0.9500: 13.889164ms
  0.9900: 87.541209ms
  0.9990: 91.826491ms
  0.9995: 93.020593ms
  1.0000: 101.400753ms
Elapsed time:      10.045s
Total requests:    98210
RPS:               9776.14

```