### PR TITLE
Change so Encoding without procedure shows explorable methods if possible

### DIFF
--- a/encoding/not_found.go
+++ b/encoding/not_found.go
@@ -25,11 +25,12 @@ import (
 	"strings"
 )
 
-type notFoundError struct {
-	msg       string
-	available []string
+// NotFoundError is a helpful responce error give better thrift encoding feeback
+type NotFoundError struct {
+	Msg       string
+	Available []string
 }
 
-func (e notFoundError) Error() string {
-	return fmt.Sprintf("%v\n\t%v", e.msg, strings.Join(e.available, "\n\t"))
+func (e NotFoundError) Error() string {
+	return fmt.Sprintf("%v\n\t%v", e.Msg, strings.Join(e.Available, "\n\t"))
 }

--- a/encoding/thrift_request.go
+++ b/encoding/thrift_request.go
@@ -35,7 +35,12 @@ import (
 
 const _multiplexedSeparator = ":"
 
-var defaultOpts = thrift.Options{UseEnvelopes: true}
+var (
+	defaultOpts = thrift.Options{UseEnvelopes: true}
+
+	// ErrSpecifyThriftFile when no thrift is specified when thift encoding is detected
+	ErrSpecifyThriftFile = errors.New("specify a Thrift file using --thrift")
+)
 
 type thriftSerializer struct {
 	methodName string
@@ -46,7 +51,7 @@ type thriftSerializer struct {
 // NewThrift returns a Thrift serializer.
 func NewThrift(thriftFile, methodName string, multiplexed bool) (Serializer, error) {
 	if thriftFile == "" {
-		return nil, errors.New("specify a Thrift file using --thrift")
+		return nil, ErrSpecifyThriftFile
 	}
 	if isFileMissing(thriftFile) {
 		return nil, fmt.Errorf("cannot find Thrift file: %q", thriftFile)
@@ -115,7 +120,7 @@ func findService(parsed *compile.Module, svcName string) (*compile.ServiceSpec, 
 	if svcName != "" {
 		errMsg = fmt.Sprintf("could not find service %q", svcName)
 	}
-	return nil, notFoundError{errMsg + ", available services:", available}
+	return nil, NotFoundError{errMsg + ", available services:", available}
 }
 
 func (e thriftSerializer) CheckSuccess(res *transport.Response) error {
@@ -150,7 +155,7 @@ func findMethod(service *compile.ServiceSpec, methodName string) (*compile.Funct
 	if methodName != "" {
 		errMsg = fmt.Sprintf("could not find method %q in %q", methodName, service.Name)
 	}
-	return nil, notFoundError{errMsg + ", available methods:", available}
+	return nil, NotFoundError{errMsg + ", available methods:", available}
 }
 
 func isFileMissing(f string) bool {

--- a/request.go
+++ b/request.go
@@ -91,16 +91,18 @@ func NewSerializer(opts RequestOptions) (encoding.Serializer, error) {
 		return opts.Encoding.GetHealth()
 	}
 
-	if opts.Procedure == "" {
-		return nil, errMissingProcedure
-	}
-
 	switch e := detectEncoding(opts); e {
 	case encoding.Thrift:
 		return encoding.NewThrift(opts.ThriftFile, opts.Procedure, opts.ThriftMultiplexed)
 	case encoding.JSON:
+		if opts.Procedure == "" {
+			return nil, errMissingProcedure
+		}
 		return encoding.NewJSON(opts.Procedure), nil
 	case encoding.Raw:
+		if opts.Procedure == "" {
+			return nil, errMissingProcedure
+		}
 		return encoding.NewRaw(opts.Procedure), nil
 	}
 

--- a/request_test.go
+++ b/request_test.go
@@ -241,6 +241,24 @@ func TestNewSerializer(t *testing.T) {
 		},
 		{
 			encoding: encoding.Thrift,
+			wantErr:  encoding.ErrSpecifyThriftFile,
+		},
+		{
+			encoding: encoding.Thrift,
+			opts:     RequestOptions{ThriftFile: validThrift},
+			wantErr: encoding.NotFoundError{
+				Msg:       "no Thrift service specified, specify --method Service::Method, available services:",
+				Available: []string{"Simple"},
+			},
+		},
+		{
+			encoding: encoding.JSON,
+			opts:     RequestOptions{ThriftFile: validThrift},
+			wantErr:  errMissingProcedure,
+		},
+		{
+			encoding: encoding.Raw,
+			opts:     RequestOptions{ThriftFile: validThrift},
 			wantErr:  errMissingProcedure,
 		},
 		{


### PR DESCRIPTION
Fixes #192 

Prints out the respective Methods or Services available based on `Encoding` and `ThirftFile`

Its quite generous in that if we specify JSON but also specify the Thrift file it will still explore the Services and Methods in the file. Let me know if we should limit to thrift encoding only.