### PR TITLE
Improve digit handling for errors during benchmark

### DIFF
--- a/bench_state.go
+++ b/bench_state.go
@@ -136,24 +136,27 @@ func (p byDuration) Less(i, j int) bool { return p[i] < p[j] }
 func (p byDuration) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // errorToMessage takes an error and converts it to a message that's stored.
-// It strips out all multi-digit numbers, as the message set should be small.
+// It strips out digits and replaces them with a single X.
 func errorToMessage(err error) string {
-	msg := []byte(err.Error())
+	origMsg := err.Error()
 	consecutiveDigits := 0
-	for i := range msg {
-		if msg[i] < '0' || msg[i] > '9' {
+	buf := make([]byte, 0, len(origMsg))
+	for i := 0; i < len(origMsg); i++ {
+		c := origMsg[i]
+		switch {
+		case c < '0', c > '9':
 			consecutiveDigits = 0
-			continue
+		default:
+			c = 'X'
+			consecutiveDigits++
+			if consecutiveDigits > 1 {
+				// We only append a single X for consecutive digits.
+				continue
+			}
 		}
 
-		consecutiveDigits++
-		if consecutiveDigits > 1 {
-			if consecutiveDigits == 2 {
-				msg[i-1] = 'X'
-			}
-			msg[i] = 'X'
-		}
+		buf = append(buf, c)
 	}
 
-	return string(msg)
+	return string(buf)
 }

--- a/bench_state_test.go
+++ b/bench_state_test.go
@@ -65,10 +65,7 @@ func TestBenchmarkStateErrors(t *testing.T) {
 	state1.printErrors(out)
 
 	expected := map[string]int{
-		"failed after 9ms":    1,
-		"failed after XXms":   2,
-		"failed after XXXms":  3,
-		"failed after XXXXms": 1,
+		"failed after Xms": 7,
 	}
 
 	bufStr := buf.String()
@@ -173,9 +170,10 @@ func TestErrorToMessage(t *testing.T) {
 		want string
 	}{
 		{errors.New("no digits"), "no digits"},
-		{errors.New("has 1 digit"), "has 1 digit"},
-		{errors.New("has two 22 digits"), "has two XX digits"},
-		{errors.New("has lots 12345 digits"), "has lots XXXXX digits"},
+		{errors.New("has 1 digit"), "has X digit"},
+		{errors.New("has two 22 digits"), "has two X digits"},
+		{errors.New("has lots 12345 digits"), "has lots X digits"},
+		{errors.New("has an ip 10.2.40.5"), "has an ip X.X.X.X"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Currently, we replace each digit with an X, if the digit is part of a
multi-digit number. However, this leads to some weird experiences, e.g.,
IPs are partially replaced (10.1.10.0 becomes XX.1.XX.0)

Even if we replace all digits with X, we still get multiple error
messages for different IPs (XX.X.X.X vs XX.XX.X.X). Instead, we should
replace all consecutive digits with a single X.

Fixes #200.