### PR TITLE
Set RPC-Thrift-Envelope HTTP header for Thrift requests

### DIFF
--- a/bench_method_test.go
+++ b/bench_method_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/yarpc/yab/encoding"
+	"github.com/yarpc/yab/merge"
 	"github.com/yarpc/yab/transport"
 
 	"github.com/opentracing/opentracing-go"
@@ -45,10 +46,11 @@ func benchmarkMethodForTest(t *testing.T, procedure string, p transport.Protocol
 	serializer, err := NewSerializer(rOpts)
 	require.NoError(t, err, "Failed to create Thrift serializer")
 
-	serializer = withTransportSerializer(p, serializer, rOpts)
+	tHeaders, serializer := withTransportSerializer(p, serializer, rOpts)
 
 	req, err := serializer.Request(nil)
 	require.NoError(t, err, "Failed to serialize Thrift body")
+	req.TransportHeaders = merge.Headers(req.TransportHeaders, tHeaders)
 
 	req.Timeout = time.Second
 	return benchmarkMethod{serializer, req}

--- a/merge/headers.go
+++ b/merge/headers.go
@@ -1,0 +1,21 @@
+package merge
+
+// Headers merges the set of headers, preferring values in right
+// over left if a key exists in both maps.
+func Headers(left, right map[string]string) map[string]string {
+	if len(left) == 0 {
+		return right
+	}
+	if len(right) == 0 {
+		return left
+	}
+
+	merged := make(map[string]string, len(left)+len(right))
+	for k, v := range left {
+		merged[k] = v
+	}
+	for k, v := range right {
+		merged[k] = v
+	}
+	return merged
+}

--- a/merge/headers_test.go
+++ b/merge/headers_test.go
@@ -1,0 +1,41 @@
+package merge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeaders(t *testing.T) {
+	tests := []struct {
+		left  map[string]string
+		right map[string]string
+		want  map[string]string
+	}{
+		{
+			left:  nil,
+			right: nil,
+			want:  nil,
+		},
+		{
+			left:  nil,
+			right: map[string]string{},
+			want:  map[string]string{},
+		},
+		{
+			left:  map[string]string{"a": "1"},
+			right: nil,
+			want:  map[string]string{"a": "1"},
+		},
+		{
+			left:  map[string]string{"a": "1", "b": "1"},
+			right: map[string]string{"a": "2", "c": "2"},
+			want:  map[string]string{"a": "2", "b": "1", "c": "2"},
+		},
+	}
+
+	for _, tt := range tests {
+		got := Headers(tt.left, tt.right)
+		assert.Equal(t, tt.want, got)
+	}
+}

--- a/template.go
+++ b/template.go
@@ -128,8 +128,8 @@ func readYAMLRequest(base string, contents []byte, templateArgs map[string]strin
 
 	// Baggage and headers specified with command line flags override those
 	// specified in YAML templates.
-	opts.ROpts.Headers = merge(opts.ROpts.Headers, t.Headers)
-	opts.ROpts.Baggage = merge(opts.ROpts.Baggage, t.Baggage)
+	opts.ROpts.Headers = mergeInto(opts.ROpts.Headers, t.Headers)
+	opts.ROpts.Baggage = mergeInto(opts.ROpts.Baggage, t.Baggage)
 	if t.Jaeger {
 		opts.TOpts.Jaeger = true
 	}
@@ -197,7 +197,7 @@ type headers map[string]string
 
 // In these cases, the existing item (target, from flags) overrides the source
 // (template).
-func merge(target, source headers) headers {
+func mergeInto(target, source headers) headers {
 	if len(source) == 0 {
 		return target
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -155,7 +155,7 @@ func TestAbsPeerListTemplate(t *testing.T) {
 	assert.Equal(t, "file:///peers.json", opts.TOpts.PeerList)
 }
 
-func TestMerge(t *testing.T) {
+func TestMergeInto(t *testing.T) {
 	tests := []struct {
 		msg         string
 		left, right headers
@@ -198,7 +198,7 @@ func TestMerge(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.msg, func(t *testing.T) {
-			assert.Equal(t, merge(tt.left, tt.right), tt.want, "merge properly")
+			assert.Equal(t, mergeInto(tt.left, tt.right), tt.want, "merge properly")
 		})
 	}
 }

--- a/transport/http.go
+++ b/transport/http.go
@@ -34,6 +34,8 @@ import (
 	"golang.org/x/net/context"
 )
 
+const HTTPThriftEnvelopeheader = "RPC-Thrift-Envelope"
+
 type httpTransport struct {
 	opts   HTTPOptions
 	client *http.Client


### PR DESCRIPTION
See yarpc/yarpc-go/issues/741 for more details. This is the first step in making
yab work with YARPC for HTTP+Thrift transparently regardless of whether the request is enveloped or not.