### PR TITLE
Fix timeouts in templates being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+# 0.10.2 (Unreleased)
+* Fix timeouts specified in tempaltes being ignored.
+
 # 0.10.1 (2017-04-24)
 * Fix for HTTP not respecting context timeout.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Changelog
 =========
 
 # 0.10.2 (Unreleased)
-* Fix timeouts specified in tempaltes being ignored.
+* Fix timeouts specified in templates being ignored.
 
 # 0.10.1 (2017-04-24)
 * Fix for HTTP not respecting context timeout.

--- a/options.go
+++ b/options.go
@@ -51,7 +51,7 @@ type RequestOptions struct {
 	HeadersFile  string            `long:"headers-file" description:"Path of a file containing the headers in JSON or YAML"`
 	Baggage      map[string]string `short:"B" long:"baggage" description:"Individual context baggage header as a key:value pair per flag"`
 	Health       bool              `long:"health" description:"Hit the health endpoint, Meta::health"`
-	Timeout      timeMillisFlag    `long:"timeout" default:"1s" description:"The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
+	Timeout      timeMillisFlag    `long:"timeout" default-mask:"1s" description:"The timeout for each request. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
 	YamlTemplate string            `short:"y" long:"yaml-template" description:"Send a tchannel request specified by a YAML template"`
 	TemplateArgs map[string]string `short:"A" long:"arg" description:"A list of key-value template arguments, specified as -A foo:bar -A user:me"`
 
@@ -110,6 +110,11 @@ type BenchmarkOptions struct {
 
 func newOptions() *Options {
 	var opts Options
+
+	// Defaults
+	opts.ROpts.Timeout = timeMillisFlag(time.Second)
+
+	// Set flag aliases
 	opts.ROpts.MethodName.dest = &opts.ROpts.Procedure
 	aliases := &opts.ROpts.Aliases
 	aliases.Arg1.dest = &opts.ROpts.Procedure
@@ -128,6 +133,10 @@ func (t *timeMillisFlag) setDuration(d time.Duration) {
 
 func (t timeMillisFlag) Duration() time.Duration {
 	return time.Duration(t)
+}
+
+func (t timeMillisFlag) String() string {
+	return time.Duration(t).String()
 }
 
 func (t *timeMillisFlag) UnmarshalFlag(value string) error {

--- a/options_test.go
+++ b/options_test.go
@@ -63,5 +63,6 @@ func TestTimeMillisFlag(t *testing.T) {
 
 		assert.NoError(t, err, "UnmarshalFlag(%v) should not fail", tt.value)
 		assert.Equal(t, tt.want, timeMillis.Duration(), "UnmarshalFlag(%v) expected %v", tt.value, tt.want)
+		assert.Equal(t, tt.want.String(), timeMillis.String(), "String mismatch")
 	}
 }


### PR DESCRIPTION
We parse YAML templates before flags so that users can override template
args using flags. This didn't work for timeout since we used the
`default` flag, which will always set the option in the struct if the
flag was not specified. This caused the timeout value read from YAML to
be overridden.

We can avoid go-flags from setting the value by setting the default
value on the struct. go-flags displayed this default as an integer, so
use default-mask to display it as a human readable string.

Fixes #208