### PR TITLE
Add flag parser plugin for injecting custom CLI flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/yarpc/yab/encoding"
 	"github.com/yarpc/yab/peerprovider"
+	"github.com/yarpc/yab/plugin"
 	"github.com/yarpc/yab/transport"
 
 	"github.com/casimir/xdg-go"
@@ -135,6 +136,12 @@ yab includes a full man page (man yab), which is also available online: http://y
 	setGroupDescs(parser, "request", "Request Options", toGroff(_reqOptsDesc))
 	setGroupDescs(parser, "transport", "Transport Options", toGroff(_transportOptsDesc))
 	setGroupDescs(parser, "benchmark", "Benchmark Options", toGroff(_benchmarkOptsDesc))
+
+	if errs := plugin.AddToParser(pluginParserAdapter{parser}); errs != nil {
+		for _, err := range errs {
+			out.Warnf("WARNING: Error adding plugin-based custom flags: %v. Continuing.", err)
+		}
+	}
 
 	remaining, err := parser.ParseArgs(args)
 	// If there are no arguments specified, write the help.

--- a/main.go
+++ b/main.go
@@ -41,7 +41,6 @@ import (
 	opentracing_ext "github.com/opentracing/opentracing-go/ext"
 	"github.com/uber/jaeger-client-go"
 	"github.com/uber/tchannel-go"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 
@@ -139,9 +138,7 @@ yab includes a full man page (man yab), which is also available online: http://y
 	setGroupDescs(parser, "benchmark", "Benchmark Options", toGroff(_benchmarkOptsDesc))
 
 	if err := plugin.AddToParser(pluginParserAdapter{parser}); err != nil {
-		for _, err := range multierr.Errors(err) {
-			out.Warnf("WARNING: Error adding plugin-based custom flags: %v. Continuing.", err)
-		}
+		out.Warnf("WARNING: Error adding plugin-based custom flags: %+v.", err)
 	}
 
 	remaining, err := parser.ParseArgs(args)

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	opentracing_ext "github.com/opentracing/opentracing-go/ext"
 	"github.com/uber/jaeger-client-go"
 	"github.com/uber/tchannel-go"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 
@@ -137,8 +138,8 @@ yab includes a full man page (man yab), which is also available online: http://y
 	setGroupDescs(parser, "transport", "Transport Options", toGroff(_transportOptsDesc))
 	setGroupDescs(parser, "benchmark", "Benchmark Options", toGroff(_benchmarkOptsDesc))
 
-	if errs := plugin.AddToParser(pluginParserAdapter{parser}); errs != nil {
-		for _, err := range errs {
+	if err := plugin.AddToParser(pluginParserAdapter{parser}); err != nil {
+		for _, err := range multierr.Errors(err) {
 			out.Warnf("WARNING: Error adding plugin-based custom flags: %v. Continuing.", err)
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/yarpc/yab/encoding"
+	"github.com/yarpc/yab/plugin"
 	"github.com/yarpc/yab/transport"
 
 	"github.com/opentracing/opentracing-go"
@@ -426,6 +427,22 @@ func TestGetOptionsAlias(t *testing.T) {
 
 		assert.Equal(t, tt.flagValue, opts.ROpts.RequestJSON, "Unexpected request body for %v", flags)
 	}
+}
+
+type testOptions struct {
+	Test string `long:"testing"`
+}
+
+func TestGetOptionsAppliesPlugin(t *testing.T) {
+	tOpts := &testOptions{}
+	plugin.AddFlags("Test Options", "", tOpts)
+
+	flags := []string{"--testing", "this is only a test"}
+	_, _, out := getOutput(t)
+
+	_, err := getOptions(flags, out)
+	require.NoError(t, err, "getOptions(%v) failed", flags)
+	require.Equal(t, "this is only a test", tOpts.Test)
 }
 
 func TestAlises(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -445,6 +445,26 @@ func TestGetOptionsAppliesPlugin(t *testing.T) {
 	require.Equal(t, "this is only a test", tOpts.Test)
 }
 
+// this struct triggers a go-flags error, since adding a group with duplicate `long` tags will fail
+type testOptionsDuplicate struct {
+	Test  string `long:"testing"`
+	Test1 string `long:"testing"`
+}
+
+func TestGetOptionsPrintsPluginErrors(t *testing.T) {
+	tOpts := &testOptionsDuplicate{}
+	plugin.AddFlags("Test Options", "", tOpts)
+
+	flags := []string{"--testing", "this is only a test"}
+	_, warnBuf, out := getOutput(t)
+
+	_, err := getOptions(flags, out)
+	require.NoError(t, err, "getOptions(%v) failed", flags)
+	// parsing a duplicate flag should fail to parse anything at all, and should print a warning
+	require.Equal(t, "", tOpts.Test)
+	require.Contains(t, warnBuf.String(), "WARNING: Error adding plugin-based custom flags")
+}
+
 func TestAlises(t *testing.T) {
 	type cmdArgs []string
 

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	flags "github.com/jessevdk/go-flags"
+	"github.com/yarpc/yab/plugin"
+)
+
+// provides a bridge between the plugin::Parser interface and the go-flags::Parser struct
+type pluginParserAdapter struct {
+	*flags.Parser
+}
+
+func (p pluginParserAdapter) AddFlagGroup(shortDescription, longDescription string, data interface{}) error {
+	_, err := p.AddGroup(shortDescription, longDescription, data)
+	return err
+}
+
+var _ plugin.Parser = (*pluginParserAdapter)(nil)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,6 +1,10 @@
 package plugin
 
-import "fmt"
+import (
+	"fmt"
+
+	"go.uber.org/multierr"
+)
 
 // AddFlags should be used by embedded modules to inject custom flags into `yab`.
 // It adds a set of custom flags with heading `shortDescription`.
@@ -40,15 +44,15 @@ type Parser interface {
 // AddToParser adds all registered flags to the passed Parser.
 // This operation is not atomic, flags are applied on a best-effort basis (not "all-or-nothing")
 // Returns a slice of errors indicating which flags groups failed to be added.
-func AddToParser(p Parser) []error {
-	var errs []error
+func AddToParser(p Parser) error {
+	var err error
 	for _, f := range _flags {
-		err := p.AddFlagGroup(f.shortDescription, f.longDescription, f.data)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("adding %v to parser: %v", f.shortDescription, err))
+		flagErr := p.AddFlagGroup(f.shortDescription, f.longDescription, f.data)
+		if flagErr != nil {
+			err = multierr.Append(err, fmt.Errorf("adding %v to parser: %v", f.shortDescription, flagErr))
 		}
 	}
-	return errs
+	return err
 }
 
 // stores the list of currently registered flags

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -6,6 +6,15 @@ import (
 	"go.uber.org/multierr"
 )
 
+type flag struct {
+	groupName       string
+	longDescription string
+	data            interface{}
+}
+
+// stores the list of currently registered flags
+var _flags []*flag
+
 // AddFlags should be used by embedded modules to inject custom flags into `yab`.
 // It adds a set of custom flags with heading `groupName`.
 //
@@ -53,13 +62,4 @@ func AddToParser(p Parser) error {
 		}
 	}
 	return err
-}
-
-// stores the list of currently registered flags
-var _flags []*flag
-
-type flag struct {
-	groupName       string
-	longDescription string
-	data            interface{}
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -7,7 +7,7 @@ import (
 )
 
 // AddFlags should be used by embedded modules to inject custom flags into `yab`.
-// It adds a set of custom flags with heading `shortDescription`.
+// It adds a set of custom flags with heading `groupName`.
 //
 // The `data` argument should be a pointer to a struct with one field for each
 // command line flag. Each field should use tags like `description` to inform
@@ -27,18 +27,18 @@ import (
 //
 // In order to retrieve the mutated results of the set flag, users of AddFlags() should
 // retain a reference to the `data` object and check its values after parsing is complete.
-func AddFlags(shortDescription string, longDescription string, data interface{}) {
+func AddFlags(groupName string, longDescription string, data interface{}) {
 	_flags = append(_flags, &flag{
-		shortDescription: shortDescription,
-		longDescription:  longDescription,
-		data:             data,
+		groupName:       groupName,
+		longDescription: longDescription,
+		data:            data,
 	})
 }
 
 // Parser is any object that can add flag groups to itself before performing its parse.
 type Parser interface {
 	// AddFlagGroup adds an additional flag group to process during parsing.
-	AddFlagGroup(shortDescription, longDescription string, data interface{}) error
+	AddFlagGroup(groupName, longDescription string, data interface{}) error
 }
 
 // AddToParser adds all registered flags to the passed Parser.
@@ -47,9 +47,9 @@ type Parser interface {
 func AddToParser(p Parser) error {
 	var err error
 	for _, f := range _flags {
-		flagErr := p.AddFlagGroup(f.shortDescription, f.longDescription, f.data)
+		flagErr := p.AddFlagGroup(f.groupName, f.longDescription, f.data)
 		if flagErr != nil {
-			err = multierr.Append(err, fmt.Errorf("adding %v to parser: %v", f.shortDescription, flagErr))
+			err = multierr.Append(err, fmt.Errorf("adding %v to parser: %v", f.groupName, flagErr))
 		}
 	}
 	return err
@@ -59,7 +59,7 @@ func AddToParser(p Parser) error {
 var _flags []*flag
 
 type flag struct {
-	shortDescription string
-	longDescription  string
-	data             interface{}
+	groupName       string
+	longDescription string
+	data            interface{}
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -24,7 +24,7 @@ import "fmt"
 // In order to retrieve the mutated results of the set flag, users of AddFlags() should
 // retain a reference to the `data` object and check its values after parsing is complete.
 func AddFlags(shortDescription string, longDescription string, data interface{}) {
-	flags = append(flags, &flag{
+	_flags = append(_flags, &flag{
 		shortDescription: shortDescription,
 		longDescription:  longDescription,
 		data:             data,
@@ -42,7 +42,7 @@ type Parser interface {
 // Returns a slice of errors indicating which flags groups failed to be added.
 func AddToParser(p Parser) []error {
 	var errs []error
-	for _, f := range flags {
+	for _, f := range _flags {
 		err := p.AddFlagGroup(f.shortDescription, f.longDescription, f.data)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("adding %v to parser: %v", f.shortDescription, err))
@@ -52,7 +52,7 @@ func AddToParser(p Parser) []error {
 }
 
 // stores the list of currently registered flags
-var flags []*flag
+var _flags []*flag
 
 type flag struct {
 	shortDescription string

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,61 @@
+package plugin
+
+import "fmt"
+
+// AddFlags should be used by embedded modules to inject custom flags into `yab`.
+// It adds a set of custom flags with heading `shortDescription`.
+//
+// The `data` argument should be a pointer to a struct with one field for each
+// command line flag. Each field should use tags like `description` to inform
+// the parser of metadata about the flag. (tags are the same as supported by
+// github.com/jessevdk/go-flags)
+//
+// 	type foo struct {
+// 		Bar string `long:"bar" description:"Sets the 'bar' value."`
+// 	}
+//
+//	AddFlags("Foo Options", "", &foo{})
+//
+// This would inject a custom flag group that looks like:
+//
+//	Foo Options
+// 		--bar	Sets the 'bar' value.
+//
+// In order to retrieve the mutated results of the set flag, users of AddFlags() should
+// retain a reference to the `data` object and check its values after parsing is complete.
+func AddFlags(shortDescription string, longDescription string, data interface{}) {
+	flags = append(flags, &flag{
+		shortDescription: shortDescription,
+		longDescription:  longDescription,
+		data:             data,
+	})
+}
+
+// Parser is any object that can add flag groups to itself before performing its parse.
+type Parser interface {
+	// AddFlagGroup adds an additional flag group to process during parsing.
+	AddFlagGroup(shortDescription, longDescription string, data interface{}) error
+}
+
+// AddToParser adds all registered flags to the passed Parser.
+// This operation is not atomic, flags are applied on a best-effort basis (not "all-or-nothing")
+// Returns a slice of errors indicating which flags groups failed to be added.
+func AddToParser(p Parser) []error {
+	var errs []error
+	for _, f := range flags {
+		err := p.AddFlagGroup(f.shortDescription, f.longDescription, f.data)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("adding %v to parser: %v", f.shortDescription, err))
+		}
+	}
+	return errs
+}
+
+// stores the list of currently registered flags
+var flags []*flag
+
+type flag struct {
+	shortDescription string
+	longDescription  string
+	data             interface{}
+}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -66,9 +66,9 @@ func TestAddToParser(t *testing.T) {
 
 		err := AddToParser(p)
 		if tt.shouldErr {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		} else {
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		}
 
 		errs := multierr.Errors(err)
@@ -89,7 +89,7 @@ func TestAddToParserMany(t *testing.T) {
 	p := &mockParser{}
 
 	errs := AddToParser(p)
-	assert.Nil(t, errs)
+	assert.NoError(t, errs)
 	assert.Equal(t, numFlags, p.addFlagGroupCallCount)
 	assert.Equal(t, numFlags, len(p.flags))
 
@@ -122,7 +122,7 @@ func TestAddedFlagsArePassedToParser(t *testing.T) {
 	p := &mockParser{}
 	AddFlags(short, long, foo)
 	errs := AddToParser(p)
-	assert.Nil(t, errs)
+	assert.NoError(t, errs)
 
 	assert.Equal(t, 1, p.addFlagGroupCallCount)
 	assert.Equal(t, 1, len(p.flags))

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -22,9 +22,9 @@ func (p *mockParser) AddFlagGroup(short, long string, data interface{}) error {
 		return errors.New("bad")
 	}
 	p.flags = append(p.flags, &flag{
-		shortDescription: short,
-		longDescription:  long,
-		data:             data,
+		groupName:       short,
+		longDescription: long,
+		data:            data,
 	})
 	p.addFlagGroupCallCount++
 	return nil
@@ -82,7 +82,7 @@ func TestAddToParserMany(t *testing.T) {
 	numFlags := 100
 	mockFlags := make([]*flag, numFlags)
 	for i := range mockFlags {
-		mockFlags[i] = &flag{shortDescription: fmt.Sprintf("foo-%d", i)}
+		mockFlags[i] = &flag{groupName: fmt.Sprintf("foo-%d", i)}
 	}
 	defer setFlags(mockFlags)()
 
@@ -108,7 +108,7 @@ func TestAddFlags(t *testing.T) {
 	assert.Equal(t, 1, len(_flags))
 
 	setFlag := _flags[0]
-	assert.Equal(t, short, setFlag.shortDescription)
+	assert.Equal(t, short, setFlag.groupName)
 	assert.Equal(t, long, setFlag.longDescription)
 	assert.Equal(t, foo, setFlag.data)
 }
@@ -128,7 +128,7 @@ func TestAddedFlagsArePassedToParser(t *testing.T) {
 	assert.Equal(t, 1, len(p.flags))
 
 	setFlag := p.flags[0]
-	assert.Equal(t, short, setFlag.shortDescription)
+	assert.Equal(t, short, setFlag.groupName)
 	assert.Equal(t, long, setFlag.longDescription)
 	assert.Equal(t, foo, setFlag.data)
 }

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1,0 +1,130 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockParser struct {
+	flags                 []*flag
+	shouldErr             bool
+	errOnCallCount        int
+	addFlagGroupCallCount int
+}
+
+func (p *mockParser) AddFlagGroup(short, long string, data interface{}) error {
+	if p.shouldErr && p.errOnCallCount == p.addFlagGroupCallCount {
+		return errors.New("bad")
+	}
+	p.flags = append(p.flags, &flag{
+		shortDescription: short,
+		longDescription:  long,
+		data:             data,
+	})
+	p.addFlagGroupCallCount++
+	return nil
+}
+
+type fooFlags struct {
+	Bar string `long:"bar" description:"Sets the 'bar' value."`
+}
+
+// defer-able test cleanup for global state
+func resetFlags(_flags []*flag) func() {
+	flags = _flags
+	return func() {
+		flags = nil
+	}
+}
+
+func TestAddToParser(t *testing.T) {
+	tests := []struct {
+		shouldErr                 bool
+		errOnCallCount            int
+		numErrs                   int
+		numAddFlagGroupCallCounts int
+		numParserFlags            int
+	}{
+		{numErrs: 0, numAddFlagGroupCallCounts: 3, numParserFlags: 3},
+		{shouldErr: true, numErrs: 3},
+		{shouldErr: true, errOnCallCount: 2, numErrs: 1, numAddFlagGroupCallCounts: 2, numParserFlags: 2},
+	}
+
+	threeFlags := []*flag{{}, {}, {}}
+	defer resetFlags(threeFlags)()
+
+	for _, tt := range tests {
+		p := &mockParser{
+			shouldErr:      tt.shouldErr,
+			errOnCallCount: tt.errOnCallCount,
+		}
+
+		errs := AddToParser(p)
+		if tt.shouldErr {
+			assert.NotNil(t, errs)
+		} else {
+			assert.Nil(t, errs)
+		}
+		assert.Equal(t, tt.numErrs, len(errs))
+		assert.Equal(t, tt.numAddFlagGroupCallCounts, p.addFlagGroupCallCount)
+		assert.Equal(t, tt.numParserFlags, len(p.flags))
+	}
+}
+
+func TestAddToParserMany(t *testing.T) {
+	numFlags := 100
+	mockFlags := make([]*flag, numFlags)
+	for i := range mockFlags {
+		mockFlags[i] = &flag{shortDescription: fmt.Sprintf("foo-%d", i)}
+	}
+	defer resetFlags(mockFlags)()
+
+	p := &mockParser{}
+
+	errs := AddToParser(p)
+	assert.Nil(t, errs)
+	assert.Equal(t, numFlags, p.addFlagGroupCallCount)
+	assert.Equal(t, numFlags, len(p.flags))
+
+	for i := range mockFlags {
+		assert.Equal(t, mockFlags[i], p.flags[i])
+	}
+}
+
+func TestAddFlags(t *testing.T) {
+	defer resetFlags(nil)()
+	short := "Foo Options"
+	long := "This is a lot of usage information about Foo"
+	foo := &fooFlags{}
+
+	AddFlags(short, long, foo)
+	assert.Equal(t, 1, len(flags))
+
+	setFlag := flags[0]
+	assert.Equal(t, short, setFlag.shortDescription)
+	assert.Equal(t, long, setFlag.longDescription)
+	assert.Equal(t, foo, setFlag.data)
+}
+
+func TestAddedFlagsArePassedToParser(t *testing.T) {
+	defer resetFlags(nil)()
+	short := "Foo Options"
+	long := "This is a lot of usage information about Foo"
+	foo := &fooFlags{}
+
+	p := &mockParser{}
+	AddFlags(short, long, foo)
+	errs := AddToParser(p)
+	assert.Nil(t, errs)
+
+	assert.Equal(t, 1, p.addFlagGroupCallCount)
+	assert.Equal(t, 1, len(p.flags))
+
+	setFlag := p.flags[0]
+	assert.Equal(t, short, setFlag.shortDescription)
+	assert.Equal(t, long, setFlag.longDescription)
+	assert.Equal(t, foo, setFlag.data)
+}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -33,10 +33,10 @@ type fooFlags struct {
 }
 
 // defer-able test cleanup for global state
-func resetFlags(_flags []*flag) func() {
-	flags = _flags
+func resetFlags(flags []*flag) func() {
+	_flags = flags
 	return func() {
-		flags = nil
+		_flags = nil
 	}
 }
 
@@ -101,9 +101,9 @@ func TestAddFlags(t *testing.T) {
 	foo := &fooFlags{}
 
 	AddFlags(short, long, foo)
-	assert.Equal(t, 1, len(flags))
+	assert.Equal(t, 1, len(_flags))
 
-	setFlag := flags[0]
+	setFlag := _flags[0]
 	assert.Equal(t, short, setFlag.shortDescription)
 	assert.Equal(t, long, setFlag.longDescription)
 	assert.Equal(t, foo, setFlag.data)

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -48,7 +48,7 @@ func TestAddToParser(t *testing.T) {
 		numAddFlagGroupCallCounts int
 		numParserFlags            int
 	}{
-		{numErrs: 0, numAddFlagGroupCallCounts: 3, numParserFlags: 3},
+		{numAddFlagGroupCallCounts: 3, numParserFlags: 3},
 		{shouldErr: true, numErrs: 3},
 		{shouldErr: true, errOnCallCount: 2, numErrs: 1, numAddFlagGroupCallCounts: 2, numParserFlags: 2},
 	}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"go.uber.org/multierr"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -62,12 +64,14 @@ func TestAddToParser(t *testing.T) {
 			errOnCallCount: tt.errOnCallCount,
 		}
 
-		errs := AddToParser(p)
+		err := AddToParser(p)
 		if tt.shouldErr {
-			assert.NotNil(t, errs)
+			assert.NotNil(t, err)
 		} else {
-			assert.Nil(t, errs)
+			assert.Nil(t, err)
 		}
+
+		errs := multierr.Errors(err)
 		assert.Equal(t, tt.numErrs, len(errs))
 		assert.Equal(t, tt.numAddFlagGroupCallCounts, p.addFlagGroupCallCount)
 		assert.Equal(t, tt.numParserFlags, len(p.flags))

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -33,7 +33,7 @@ type fooFlags struct {
 }
 
 // defer-able test cleanup for global state
-func resetFlags(flags []*flag) func() {
+func setFlags(flags []*flag) (restore func()) {
 	_flags = flags
 	return func() {
 		_flags = nil
@@ -54,7 +54,7 @@ func TestAddToParser(t *testing.T) {
 	}
 
 	threeFlags := []*flag{{}, {}, {}}
-	defer resetFlags(threeFlags)()
+	defer setFlags(threeFlags)()
 
 	for _, tt := range tests {
 		p := &mockParser{
@@ -80,7 +80,7 @@ func TestAddToParserMany(t *testing.T) {
 	for i := range mockFlags {
 		mockFlags[i] = &flag{shortDescription: fmt.Sprintf("foo-%d", i)}
 	}
-	defer resetFlags(mockFlags)()
+	defer setFlags(mockFlags)()
 
 	p := &mockParser{}
 
@@ -95,7 +95,7 @@ func TestAddToParserMany(t *testing.T) {
 }
 
 func TestAddFlags(t *testing.T) {
-	defer resetFlags(nil)()
+	defer setFlags(nil)()
 	short := "Foo Options"
 	long := "This is a lot of usage information about Foo"
 	foo := &fooFlags{}
@@ -110,7 +110,7 @@ func TestAddFlags(t *testing.T) {
 }
 
 func TestAddedFlagsArePassedToParser(t *testing.T) {
-	defer resetFlags(nil)()
+	defer setFlags(nil)()
 	short := "Foo Options"
 	long := "This is a lot of usage information about Foo"
 	foo := &fooFlags{}


### PR DESCRIPTION
Following #220, we should create a way for plugins to specify custom flags to `yab` invocations.