### PR TITLE
Remove unused fields Request.TargetService and Request.ShardKey

### DIFF
--- a/request.go
+++ b/request.go
@@ -141,9 +141,6 @@ func prepareRequest(req *transport.Request, headers map[string]string, opts Opti
 	req.Baggage = opts.ROpts.Baggage
 	req.Timeout = timeout
 
-	// Add request metadata
-	req.TargetService = opts.TOpts.ServiceName
-
 	// Apply middleware
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/request_test.go
+++ b/request_test.go
@@ -317,7 +317,6 @@ func TestNewRequestWithMetadata(t *testing.T) {
 	req, err := prepareRequest(req, nil /* headers */, Options{TOpts: topts})
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", req.Method)
-	assert.Equal(t, "bar", req.TargetService)
 }
 
 func TestNewRequestWithTransportMiddleware(t *testing.T) {
@@ -328,7 +327,6 @@ func TestNewRequestWithTransportMiddleware(t *testing.T) {
 	req, err := prepareRequest(req, nil /* headers */, Options{TOpts: topts})
 	assert.NoError(t, err)
 	assert.Equal(t, "baz", req.Method)
-	assert.Equal(t, "bar", req.TargetService)
 }
 
 type mockRequestInterceptor struct {
@@ -388,7 +386,6 @@ func TestPrepareRequest(t *testing.T) {
 	req, err := prepareRequest(rawReq, nil /* headers */, opts)
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", req.Method)
-	assert.Equal(t, "baz", req.TargetService)
 	assert.Equal(t, "medium", req.Baggage["size"])
 }
 

--- a/transport/interface.go
+++ b/transport/interface.go
@@ -29,13 +29,11 @@ import (
 
 // Request is the fields used to make an RPC.
 type Request struct {
-	TargetService    string
 	Method           string
 	Timeout          time.Duration
 	Headers          map[string]string
 	Baggage          map[string]string
 	TransportHeaders map[string]string
-	ShardKey         string
 	Body             []byte
 }
 


### PR DESCRIPTION
In both the HTTP and TChannel transport implementations, these values are passed as options when constructing new Transports, and these fields are never used from the request.