### PR TITLE
Add gRPC transport.Transport

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,16 @@
-hash: 90be37e72b4e67ea34ac1c36382d4f78f3c75826e225fc201864f4b064313ffc
-updated: 2017-08-29T10:46:15.625926737-07:00
+hash: 8971e7137ab1629451c94430d3aadccf4d28491647569b9a6180a4f87a27c58d
+updated: 2017-10-27T14:48:17.144866+02:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
 - name: github.com/cactus/go-statsd-client
-  version: ad551ee7f9f3465fb1ce1695899c612f7808a06a
+  version: ce77ca9ecdee1c3ffd097e32f9bb832825ccb203
   subpackages:
   - statsd
 - name: github.com/casimir/xdg-go
@@ -14,15 +18,29 @@ imports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/davecgh/go-spew
-  version: adab96458c51a58dc1783b3335dcce5461522e75
+  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
   subpackages:
   - spew
+- name: github.com/facebookgo/clock
+  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/gogo/protobuf
-  version: 9319258ff0eab7faf2eaca190ef9dff2b9603ead
+  version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
   subpackages:
   - proto
+- name: github.com/golang/protobuf
+  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
+  subpackages:
+  - proto
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/timestamp
 - name: github.com/jessevdk/go-flags
-  version: 6cf8f02b4ae8ba723ddc64dcfd403e530c06d927
+  version: f88afde2fa19a30cf50ba4b05b3d13bc6bae3079
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/opentracing/opentracing-go
   version: 1949ddbfd147afd4d964a9f00b24eb291e0e7c38
   subpackages:
@@ -32,13 +50,38 @@ imports:
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- name: github.com/prometheus/client_model
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 1bab55dd05dbff384524a6a1c99006d9eb5f139b
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
+  subpackages:
+  - xfs
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - require
 - name: github.com/uber-go/atomic
-  version: 70bd1261d36be490ebd22a62b385a3c5d23b6240
+  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
+- name: github.com/uber-go/mapdecode
+  version: 718b4994083e432669f44a00174c5f1bcdb1434d
+  subpackages:
+  - internal/mapstructure
+- name: github.com/uber-go/tally
+  version: 95078a8f10668bd1fa73ae46761cdc58d25436b8
 - name: github.com/uber/jaeger-client-go
   version: 3e3870040def0ebdaf65a003863fa64f5cb26139
   subpackages:
@@ -50,7 +93,7 @@ imports:
   - thrift-gen/zipkincore
   - utils
 - name: github.com/uber/jaeger-lib
-  version: 575c678b2873b62aaadd0fa5817a2aeb3155dc4d
+  version: bc381f836083a0f7d5778d4216022388c4aeaf46
   subpackages:
   - metrics
 - name: github.com/uber/tchannel-go
@@ -74,7 +117,7 @@ imports:
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/thriftrw
-  version: 8bbe12f61b982c30be95f88bfe62cade3d470e08
+  version: bce7fd589d505915f56a7901d8c143e1625e085c
   subpackages:
   - ast
   - compile
@@ -88,67 +131,8 @@ imports:
   - thriftreflect
   - version
   - wire
-- name: go.uber.org/zap
-  version: 9d9d6135afe89b6fc4a05e9a8552526caba38048
-  subpackages:
-  - buffer
-  - internal/bufferpool
-  - internal/color
-  - internal/exit
-  - zapcore
-- name: golang.org/x/net
-  version: 66aacef3dd8a676686c7ae3716979581e8b03c47
-  subpackages:
-  - bpf
-  - context
-  - internal/iana
-  - internal/socket
-  - ipv4
-  - ipv6
-- name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
-testImports:
-- name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-  subpackages:
-  - quantile
-- name: github.com/facebookgo/clock
-  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
-- name: github.com/golang/protobuf
-  version: ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
-  subpackages:
-  - proto
-- name: github.com/matttproud/golang_protobuf_extensions
-  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
-  subpackages:
-  - pbutil
-- name: github.com/prometheus/client_golang
-  version: c5b7fccd204277076155f10851dad72b76a49317
-  subpackages:
-  - prometheus
-  - prometheus/promhttp
-- name: github.com/prometheus/client_model
-  version: 6f3806018612930941127f2a7c6c453ba2c527d2
-  subpackages:
-  - go
-- name: github.com/prometheus/common
-  version: 61f87aac8082fa8c3c5655c7608d7478d46ac2ad
-  subpackages:
-  - expfmt
-  - internal/bitbucket.org/ww/goautoneg
-  - model
-- name: github.com/prometheus/procfs
-  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
-  subpackages:
-  - xfs
-- name: github.com/uber-go/mapdecode
-  version: 2d8ecd5e64c88634bd7dfcbc9fd2a9e813830e8d
-  subpackages:
-  - internal/mapstructure
-- name: github.com/uber-go/tally
-  version: 2605c407d7d219644d03a3680ad7df4779017782
 - name: go.uber.org/yarpc
-  version: df6f636a8ec8a0f7e90ab431ede56b9371159a9e
+  version: 56c8cccbfd1aab4a314c900cafcbf879b515181f
   subpackages:
   - api/backoff
   - api/encoding
@@ -162,6 +146,7 @@ testImports:
   - internal/bufferpool
   - internal/clientconfig
   - internal/config
+  - internal/digester
   - internal/errorsync
   - internal/humanize
   - internal/inboundmiddleware
@@ -175,12 +160,71 @@ testImports:
   - internal/request
   - peer
   - peer/hostport
+  - peer/roundrobin
   - pkg/encoding
   - pkg/errors
   - pkg/lifecycle
   - pkg/procedure
+  - transport/grpc
   - transport/http
   - transport/tchannel
   - transport/tchannel/internal
   - yarpcconfig
   - yarpcerrors
+- name: go.uber.org/zap
+  version: 35aad584952c3e7020db7b839f6b102de6271f89
+  subpackages:
+  - buffer
+  - internal/bufferpool
+  - internal/color
+  - internal/exit
+  - zapcore
+- name: golang.org/x/net
+  version: c73622c77280266305273cb545f54516ced95b93
+  subpackages:
+  - bpf
+  - context
+  - http2
+  - http2/hpack
+  - idna
+  - internal/iana
+  - internal/socket
+  - internal/timeseries
+  - ipv4
+  - ipv6
+  - lex/httplex
+  - trace
+- name: golang.org/x/text
+  version: 6eab0e8f74e86c598ec3b6fad4888e0c11482d48
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
+- name: google.golang.org/genproto
+  version: f676e0f3ac6395ff1a529ae59a6670878a8371a6
+  subpackages:
+  - googleapis/rpc/status
+- name: google.golang.org/grpc
+  version: 61d37c5d657a47e4404fd6823bd598341a2595de
+  repo: https://github.com/grpc/grpc-go
+  subpackages:
+  - balancer
+  - codes
+  - connectivity
+  - credentials
+  - grpclb/grpc_lb_v1/messages
+  - grpclog
+  - internal
+  - keepalive
+  - metadata
+  - naming
+  - peer
+  - resolver
+  - stats
+  - status
+  - tap
+  - transport
+- name: gopkg.in/yaml.v2
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -18,8 +18,8 @@ import:
   version: ^1
 - package: github.com/uber/jaeger-client-go
   version: ^2.9
+- package: go.uber.org/yarpc
+  version: ^1.21
 testImport:
 - package: github.com/apache/thrift
   version: ">=0.9.3, <0.11.0"
-- package: go.uber.org/yarpc
-  version: ^1

--- a/transport/grpc.go
+++ b/transport/grpc.go
@@ -132,11 +132,7 @@ func (t *grpcTransport) Call(ctx context.Context, request *Request) (*Response, 
 	if err != nil {
 		return nil, err
 	}
-	response, err := transportResponseToResponse(transportResponse)
-	if err != nil {
-		return nil, err
-	}
-	return response, nil
+	return transportResponseToResponse(transportResponse)
 }
 
 func (t *grpcTransport) Close() error {

--- a/transport/grpc.go
+++ b/transport/grpc.go
@@ -124,18 +124,18 @@ func (t *grpcTransport) Call(ctx context.Context, request *Request) (*Response, 
 
 	ctx, cancel := requestContextWithTimeout(ctx, request)
 	defer cancel()
-	transportResponse, err := t.Outbound.Call(ctx, t.requestToTransportRequest(request))
+	transportResponse, err := t.Outbound.Call(ctx, t.requestToYARPCRequest(request))
 	if err != nil {
 		return nil, err
 	}
-	return transportResponseToResponse(transportResponse)
+	return yarpcResponseToResponse(transportResponse)
 }
 
 func (t *grpcTransport) Close() error {
 	return multierr.Combine(t.Transport.Stop(), t.Outbound.Stop())
 }
 
-func (t *grpcTransport) requestToTransportRequest(request *Request) *transport.Request {
+func (t *grpcTransport) requestToYARPCRequest(request *Request) *transport.Request {
 	return &transport.Request{
 		Caller:          t.Caller,
 		Service:         request.TargetService,
@@ -160,7 +160,7 @@ func requestContextWithTimeout(ctx context.Context, request *Request) (context.C
 	return context.WithTimeout(ctx, timeout)
 }
 
-func transportResponseToResponse(transportResponse *transport.Response) (*Response, error) {
+func yarpcResponseToResponse(transportResponse *transport.Response) (*Response, error) {
 	response := &Response{
 		Headers: transportResponse.Headers.Items(),
 	}

--- a/transport/grpc.go
+++ b/transport/grpc.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transport
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/ioutil"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"go.uber.org/multierr"
+	apipeer "go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/peer"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/peer/roundrobin"
+	"go.uber.org/yarpc/transport/grpc"
+)
+
+var (
+	errGRPCNoAddresses = errors.New("must specify at least one grpc address")
+	errGRPCNoTracer    = errors.New("must specify grpc tracer")
+	errGRPCNoCaller    = errors.New("must specify grpc caller")
+	errGRPCNoService   = errors.New("must specify grpc service")
+	errGRPCNoEncoding  = errors.New("must specify grpc encoding")
+	errGRPCNoProcedure = errors.New("must specify grpc procedure")
+)
+
+// GRPCOptions are used to create a GRPC transport.
+type GRPCOptions struct {
+	Addresses       []string
+	Tracer          opentracing.Tracer
+	Caller          string
+	Encoding        string
+	RoutingKey      string
+	RoutingDelegate string
+}
+
+// NewGRPC returns a transport that calls a GRPC service.
+func NewGRPC(options GRPCOptions) (TransportCloser, error) {
+	return newGRPC(options)
+}
+
+type grpcTransport struct {
+	Transport       transport.Transport
+	Outbound        transport.UnaryOutbound
+	Caller          string
+	Encoding        string
+	RoutingKey      string
+	RoutingDelegate string
+	tracer          opentracing.Tracer
+}
+
+func newGRPC(options GRPCOptions) (*grpcTransport, error) {
+	if len(options.Addresses) == 0 {
+		return nil, errGRPCNoAddresses
+	}
+	if options.Tracer == nil {
+		return nil, errGRPCNoTracer
+	}
+	if options.Caller == "" {
+		return nil, errGRPCNoCaller
+	}
+	if options.Encoding == "" {
+		return nil, errGRPCNoEncoding
+	}
+
+	identifiers := make([]apipeer.Identifier, len(options.Addresses))
+	for i, address := range options.Addresses {
+		identifiers[i] = hostport.Identify(address)
+	}
+	transport := grpc.NewTransport(grpc.Tracer(options.Tracer))
+	outbound := transport.NewOutbound(peer.Bind(roundrobin.New(transport), peer.BindPeers(identifiers)))
+	if err := transport.Start(); err != nil {
+		return nil, err
+	}
+	if err := outbound.Start(); err != nil {
+		_ = transport.Stop()
+		return nil, err
+	}
+
+	return &grpcTransport{
+		Transport:       transport,
+		Outbound:        outbound,
+		Caller:          options.Caller,
+		Encoding:        options.Encoding,
+		RoutingKey:      options.RoutingKey,
+		RoutingDelegate: options.RoutingDelegate,
+		tracer:          options.Tracer,
+	}, nil
+}
+
+func (t *grpcTransport) Tracer() opentracing.Tracer {
+	return t.tracer
+}
+
+func (t *grpcTransport) Protocol() Protocol {
+	return GRPC
+}
+
+func (t *grpcTransport) Call(ctx context.Context, request *Request) (*Response, error) {
+	if request.TargetService == "" {
+		return nil, errGRPCNoService
+	}
+	if request.Method == "" {
+		return nil, errGRPCNoProcedure
+	}
+
+	ctx, cancel := requestContextWithTimeout(ctx, request)
+	defer cancel()
+	transportResponse, err := t.Outbound.Call(ctx, t.requestToTransportRequest(request))
+	if err != nil {
+		return nil, err
+	}
+	response, err := transportResponseToResponse(transportResponse)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (t *grpcTransport) Close() error {
+	return multierr.Combine(t.Transport.Stop(), t.Outbound.Stop())
+}
+
+func (t *grpcTransport) requestToTransportRequest(request *Request) *transport.Request {
+	return &transport.Request{
+		Caller:          t.Caller,
+		Service:         request.TargetService,
+		Encoding:        transport.Encoding(t.Encoding),
+		Procedure:       request.Method,
+		Headers:         transport.HeadersFromMap(request.Headers),
+		ShardKey:        request.ShardKey,
+		RoutingKey:      t.RoutingKey,
+		RoutingDelegate: t.RoutingDelegate,
+		Body:            bytes.NewReader(request.Body),
+	}
+}
+
+func requestContextWithTimeout(ctx context.Context, request *Request) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, noop
+	}
+	timeout := time.Second
+	if request.Timeout > 0 {
+		timeout = request.Timeout
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+func transportResponseToResponse(transportResponse *transport.Response) (*Response, error) {
+	response := &Response{
+		Headers: transportResponse.Headers.Items(),
+	}
+	if transportResponse.Body != nil {
+		body, err := ioutil.ReadAll(transportResponse.Body)
+		if err != nil {
+			return nil, err
+		}
+		if err := transportResponse.Body.Close(); err != nil {
+			return nil, err
+		}
+		response.Body = body
+	}
+	return response, nil
+}
+
+func noop() {}

--- a/transport/grpc.go
+++ b/transport/grpc.go
@@ -22,7 +22,6 @@ package transport
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"io/ioutil"
 	"time"
@@ -35,6 +34,7 @@ import (
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/peer/roundrobin"
 	"go.uber.org/yarpc/transport/grpc"
+	"golang.org/x/net/context"
 )
 
 var (

--- a/transport/grpc_test.go
+++ b/transport/grpc_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/transport"
+	yarpcjson "go.uber.org/yarpc/encoding/json"
+	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func TestGRPCSuccess(t *testing.T) {
+	doWithTestEnv(t, "example-caller", 5, []transport.Procedure{
+		newTestJSONProcedure("example", "Foo::Bar", testBar),
+	}, func(t *testing.T, testEnv *testEnv) {
+		request, err := newTestJSONRequest("example", "Foo::Bar", &testBarRequest{One: "hello"})
+		require.NoError(t, err)
+		response, err := testEnv.Transport.Call(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		testBarResponse := &testBarResponse{}
+		require.NoError(t, json.Unmarshal(response.Body, testBarResponse))
+		require.Equal(t, "hello", testBarResponse.One)
+	})
+}
+
+func TestGRPCError(t *testing.T) {
+	doWithTestEnv(t, "example-caller", 5, []transport.Procedure{
+		newTestJSONProcedure("example", "Foo::Bar", testBar),
+	}, func(t *testing.T, testEnv *testEnv) {
+		request, err := newTestJSONRequest("example", "Foo::Bar", &testBarRequest{Error: "hello"})
+		require.NoError(t, err)
+		_, err = testEnv.Transport.Call(context.Background(), request)
+		require.Equal(t, yarpcerrors.UnknownErrorf("hello"), err)
+	})
+}
+
+type testBarRequest struct {
+	One   string
+	Error string
+}
+
+type testBarResponse struct {
+	One string
+}
+
+func testBar(ctx context.Context, request *testBarRequest) (*testBarResponse, error) {
+	if request == nil {
+		return nil, nil
+	}
+	if request.Error != "" {
+		return nil, errors.New(request.Error)
+	}
+	return &testBarResponse{
+		One: request.One,
+	}, nil
+}
+
+func newTestJSONRequest(service string, method string, request interface{}) (*Request, error) {
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	return &Request{
+		TargetService: service,
+		Method:        method,
+		Body:          body,
+	}, nil
+}
+
+func newTestJSONProcedure(service string, name string, handler interface{}) transport.Procedure {
+	procedure := yarpcjson.Procedure(name, handler)[0]
+	procedure.Service = service
+	return procedure
+}
+
+func doWithTestEnv(
+	t *testing.T,
+	caller string,
+	numInbounds int,
+	procedures []transport.Procedure,
+	f func(*testing.T, *testEnv),
+) {
+	testEnv, err := newTestEnv(caller, numInbounds, procedures)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Close())
+	}()
+	f(t, testEnv)
+}
+
+type testEnv struct {
+	Caller         string
+	Transport      *grpcTransport
+	YARPCTransport *grpc.Transport
+	YARPCInbounds  []*grpc.Inbound
+}
+
+func newTestEnv(
+	caller string,
+	numInbounds int,
+	procedures []transport.Procedure,
+) (_ *testEnv, err error) {
+	yarpcTransport := grpc.NewTransport()
+	if err := yarpcTransport.Start(); err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			err = multierr.Append(err, yarpcTransport.Stop())
+		}
+	}()
+
+	addresses := make([]string, numInbounds)
+	yarpcInbounds := make([]*grpc.Inbound, numInbounds)
+	for i := 0; i < numInbounds; i++ {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return nil, err
+		}
+		addresses[i] = listener.Addr().String()
+		yarpcInbound := yarpcTransport.NewInbound(listener)
+		yarpcInbound.SetRouter(newTestRouter(procedures))
+		if err := yarpcInbound.Start(); err != nil {
+			return nil, err
+		}
+		defer func() {
+			if err != nil {
+				err = multierr.Append(err, yarpcInbound.Stop())
+			}
+		}()
+		yarpcInbounds[i] = yarpcInbound
+	}
+
+	transport, err := newGRPC(GRPCOptions{
+		Addresses: addresses,
+		Tracer:    opentracing.NoopTracer{},
+		Caller:    caller,
+		Encoding:  "json",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &testEnv{
+		caller,
+		transport,
+		yarpcTransport,
+		yarpcInbounds,
+	}, nil
+}
+
+func (e *testEnv) Close() error {
+	err := e.Transport.Close()
+	for _, yarpcInbound := range e.YARPCInbounds {
+		err = multierr.Combine(err, yarpcInbound.Stop())
+	}
+	return multierr.Combine(err, e.YARPCTransport.Stop())
+}
+
+type testRouter struct {
+	procedures []transport.Procedure
+}
+
+func newTestRouter(procedures []transport.Procedure) *testRouter {
+	return &testRouter{procedures}
+}
+
+func (r *testRouter) Procedures() []transport.Procedure {
+	return r.procedures
+}
+
+func (r *testRouter) Choose(_ context.Context, request *transport.Request) (transport.HandlerSpec, error) {
+	for _, procedure := range r.procedures {
+		if procedure.Service == request.Service && procedure.Name == request.Procedure {
+			return procedure.HandlerSpec, nil
+		}
+	}
+	return transport.HandlerSpec{}, fmt.Errorf("no procedure for service %s and name %s", request.Service, request.Procedure)
+}

--- a/transport/grpc_test.go
+++ b/transport/grpc_test.go
@@ -21,6 +21,7 @@
 package transport
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -35,7 +36,6 @@ import (
 	yarpcjson "go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/yarpc/yarpcerrors"
-	"golang.org/x/net/context"
 )
 
 func TestGRPCSuccess(t *testing.T) {

--- a/transport/grpc_test.go
+++ b/transport/grpc_test.go
@@ -21,7 +21,6 @@
 package transport
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,6 +35,7 @@ import (
 	yarpcjson "go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/yarpc/yarpcerrors"
+	"golang.org/x/net/context"
 )
 
 func TestGRPCSuccess(t *testing.T) {

--- a/transport/interface.go
+++ b/transport/interface.go
@@ -21,6 +21,7 @@
 package transport
 
 import (
+	"io"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -55,6 +56,7 @@ type Protocol int
 const (
 	TChannel Protocol = iota + 1
 	HTTP
+	GRPC
 )
 
 // Transport defines the interface for the underlying transport over which
@@ -63,4 +65,10 @@ type Transport interface {
 	Call(ctx context.Context, request *Request) (*Response, error)
 	Protocol() Protocol
 	Tracer() opentracing.Tracer
+}
+
+// TransportCloser is a Transport that can be closed.
+type TransportCloser interface {
+	Transport
+	io.Closer
 }


### PR DESCRIPTION
This adds a grpc `transport.Transport` based on yarpc-go's `*grpc.Outbound`, as well as integration testing using JSON. The work to actually add gRPC to yab will come afterwards as this is more complicated - yab assumes there will only be tchannel and http, so there's a lot of this:

```go
if something {
  return "tchannel"
}
return "http"
```

That I'll need to refactor to assume >2 transports.