### PR TITLE
WIP: Add gRPC to main

### DIFF
--- a/main.go
+++ b/main.go
@@ -368,10 +368,10 @@ func getTracer(opts Options, out output) (opentracing.Tracer, io.Closer) {
 }
 
 // withTransportSerializer may modify the serializer for the transport used.
-// E.g. Thrift payloads are not enveloped when used with TChannel.
+// E.g. Thrift payloads are not enveloped when used with TChannel or gRPC.
 func withTransportSerializer(p transport.Protocol, s encoding.Serializer, rOpts RequestOptions) encoding.Serializer {
 	switch {
-	case p == transport.TChannel && s.Encoding() == encoding.Thrift,
+	case (p == transport.TChannel || p == transport.GRPC) && s.Encoding() == encoding.Thrift,
 		rOpts.ThriftDisableEnvelopes:
 		s = s.(noEnveloper).WithoutEnvelopes()
 	}

--- a/options.go
+++ b/options.go
@@ -56,7 +56,7 @@ type RequestOptions struct {
 	TemplateArgs map[string]string `short:"A" long:"arg" description:"A list of key-value template arguments, specified as -A foo:bar -A user:me"`
 
 	// Thrift options
-	ThriftDisableEnvelopes bool `long:"disable-thrift-envelope" description:"Disables Thrift envelopes (disabled by default for TChannel)"`
+	ThriftDisableEnvelopes bool `long:"disable-thrift-envelope" description:"Disables Thrift envelopes (disabled by default for TChannel and gRPC)"`
 	ThriftMultiplexed      bool `long:"multiplexed-thrift" description:"Enables the Thrift TMultiplexedProtocol used by services that host multiple Thrift services on a single endpoint."`
 
 	// These are aliases for tcurl compatibility.

--- a/options.go
+++ b/options.go
@@ -73,6 +73,7 @@ type RequestOptions struct {
 
 // TransportOptions are transport related options.
 type TransportOptions struct {
+	Protocol         string            `long:"protocol" description:"The protocol to use, either tchannel, http, https, ftp, or grpc. Overrides all implicit protocol settings."`
 	ServiceName      string            `short:"s" long:"service" description:"The TChannel/Hyperbahn service name"`
 	Peers            []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
 	PeerList         string            `short:"P" long:"peer-list" description:"Path or URL of a JSON, YAML, or flat file containing a list of host:ports. -P? for supported protocols."`

--- a/request.go
+++ b/request.go
@@ -143,6 +143,7 @@ func prepareRequest(req *transport.Request, headers map[string]string, opts Opti
 
 	// Add request metadata
 	req.TargetService = opts.TOpts.ServiceName
+	req.ShardKey = opts.TOpts.ShardKey
 
 	// Apply middleware
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/transport.go
+++ b/transport.go
@@ -73,7 +73,7 @@ func parsePeer(explicitProtocol string, peer string) (protocol, host string, val
 			return "tchannel", peer, true
 		}
 		switch explicitProtocol {
-		case "tchannel", "grpc":
+		case "http", "https", "ftp", "tchannel", "grpc":
 			return explicitProtocol, peer, true
 		default:
 			return "", "", false
@@ -222,7 +222,7 @@ func getTransport(opts TransportOptions, encoding encoding.Encoding, tracer open
 			Encoding:        encoding.String(),
 			RoutingKey:      opts.RoutingKey,
 			RoutingDelegate: opts.RoutingDelegate,
-			// TODO(pedge): ignored: opts.ShardKey, opts.TransportHeader, opts.ServiceName
+			// TODO(pedge): ignored: opts.ShardKey, opts.TransportHeaders, opts.ServiceName
 		})
 	}
 


### PR DESCRIPTION
This builds on the previous PR to actually add grpc into the main. This adds a `--protocol` flag, which upon further review we probably do not want.

I want this as a discussion point to figure out how we want to do this, either to require explicitly setting `grpc://` as a prefix, or to add the `--protocol` flag before further testing. Both work as of now, ie you can either do `--peer 0.0.0.0:8088 --protocol grpc` or `--peer grpc://0.0.0.0:8088`

Tested working locally (some internal naming changed):

```
$ yab --thrift=idl/uber/infra/lottery/lottery.thrift --service lottery --procedure Lottery::play --peer 0.0.0.0:8088 --request '{"request":{"number":10}}' --protocol grpc -d 10s
{
  "body": {
    "result": {
      "won": true
    }
  }
}

Benchmark parameters:
  CPUs:            8
  Connections:     16
  Concurrency:     1
  Max requests:    0
  Max duration:    10s
  Max RPS:         0
Latencies:
  0.5000: 1.481367ms
  0.9000: 4.120448ms
  0.9500: 4.978417ms
  0.9900: 7.441082ms
  0.9990: 27.914933ms
  0.9995: 36.157199ms
  1.0000: 91.973059ms
Elapsed time:      10.001s
Total requests:    77744
RPS:               7773.27
$ yab --thrift=idl/uber/infra/lottery/lottery.thrift --service lottery --procedure Lottery::play --peer 0.0.0.0:8087 --request '{"request":{"number":10}}' --protocol tchannel -d 10s
{
  "body": {
    "result": {
      "won": true
    }
  },
  "ok": true,
  "trace": "0"
}

Benchmark parameters:
  CPUs:            8
  Connections:     16
  Concurrency:     1
  Max requests:    0
  Max duration:    10s
  Max RPS:         0
Latencies:
  0.5000: 1.200049ms
  0.9000: 3.444818ms
  0.9500: 4.577865ms
  0.9900: 8.301695ms
  0.9990: 25.494045ms
  0.9995: 42.75586ms
  1.0000: 50.849356ms
Elapsed time:      10.001s
Total requests:    96247
RPS:               9623.46
```