### PR TITLE
Add gRPC transport to main

### DIFF
--- a/main.go
+++ b/main.go
@@ -368,10 +368,10 @@ func getTracer(opts Options, out output) (opentracing.Tracer, io.Closer) {
 }
 
 // withTransportSerializer may modify the serializer for the transport used.
-// E.g. Thrift payloads are not enveloped when used with TChannel.
+// E.g. Thrift payloads are not enveloped when used with TChannel or gRPC.
 func withTransportSerializer(p transport.Protocol, s encoding.Serializer, rOpts RequestOptions) encoding.Serializer {
 	switch {
-	case p == transport.TChannel && s.Encoding() == encoding.Thrift,
+	case (p == transport.TChannel || p == transport.GRPC) && s.Encoding() == encoding.Thrift,
 		rOpts.ThriftDisableEnvelopes:
 		s = s.(noEnveloper).WithoutEnvelopes()
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -839,6 +839,16 @@ func TestWithTransportSerializer(t *testing.T) {
 			rOpts:    noEnvelopeOpts,
 			want:     []byte{0},
 		},
+		{
+			protocol: transport.GRPC,
+			rOpts:    validRequestOpts,
+			want:     []byte{0},
+		},
+		{
+			protocol: transport.GRPC,
+			rOpts:    noEnvelopeOpts,
+			want:     []byte{0},
+		},
 	}
 
 	for _, tt := range tests {

--- a/options.go
+++ b/options.go
@@ -56,7 +56,7 @@ type RequestOptions struct {
 	TemplateArgs map[string]string `short:"A" long:"arg" description:"A list of key-value template arguments, specified as -A foo:bar -A user:me"`
 
 	// Thrift options
-	ThriftDisableEnvelopes bool `long:"disable-thrift-envelope" description:"Disables Thrift envelopes (disabled by default for TChannel)"`
+	ThriftDisableEnvelopes bool `long:"disable-thrift-envelope" description:"Disables Thrift envelopes (disabled by default for TChannel and gRPC)"`
 	ThriftMultiplexed      bool `long:"multiplexed-thrift" description:"Enables the Thrift TMultiplexedProtocol used by services that host multiple Thrift services on a single endpoint."`
 
 	// These are aliases for tcurl compatibility.

--- a/request.go
+++ b/request.go
@@ -143,6 +143,7 @@ func prepareRequest(req *transport.Request, headers map[string]string, opts Opti
 
 	// Add request metadata
 	req.TargetService = opts.TOpts.ServiceName
+	req.ShardKey = opts.TOpts.ShardKey
 
 	// Apply middleware
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/request_test.go
+++ b/request_test.go
@@ -313,11 +313,12 @@ func TestDetectEncoding(t *testing.T) {
 
 func TestNewRequestWithMetadata(t *testing.T) {
 	req := &transport.Request{Method: "foo"}
-	topts := TransportOptions{ServiceName: "bar"}
+	topts := TransportOptions{ServiceName: "bar", ShardKey: "baz"}
 	req, err := prepareRequest(req, nil /* headers */, Options{TOpts: topts})
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", req.Method)
 	assert.Equal(t, "bar", req.TargetService)
+	assert.Equal(t, "baz", req.ShardKey)
 }
 
 func TestNewRequestWithTransportMiddleware(t *testing.T) {

--- a/transport.go
+++ b/transport.go
@@ -166,6 +166,17 @@ func getTransport(opts TransportOptions, encoding encoding.Encoding, tracer open
 		return transport.NewTChannel(topts)
 	}
 
+	if protocol == "grpc" {
+		return transport.NewGRPC(transport.GRPCOptions{
+			Addresses:       getHosts(opts.Peers),
+			Tracer:          tracer,
+			Caller:          opts.CallerName,
+			Encoding:        encoding.String(),
+			RoutingKey:      opts.RoutingKey,
+			RoutingDelegate: opts.RoutingDelegate,
+		})
+	}
+
 	hopts := transport.HTTPOptions{
 		SourceService:   opts.CallerName,
 		TargetService:   opts.ServiceName,

--- a/transport_test.go
+++ b/transport_test.go
@@ -51,6 +51,7 @@ func TestParsePeer(t *testing.T) {
 		{"http://1.1.1.1", "http", "1.1.1.1"},
 		{"https://1.1.1.1", "https", "1.1.1.1"},
 		{"http://1.1.1.1:8080", "http", "1.1.1.1:8080"},
+		{"grpc://1.1.1.1:8080", "grpc", "1.1.1.1:8080"},
 		{"://asd", "unknown", ""},
 	}
 
@@ -79,6 +80,10 @@ func TestEnsureSameProtocol(t *testing.T) {
 		{
 			peers: []string{"http://1.1.1.1", "http://2.2.2.2:8080"},
 			want:  "http",
+		},
+		{
+			peers: []string{"grpc://1.1.1.1", "grpc://2.2.2.2:8080"},
+			want:  "grpc",
 		},
 		{
 			// mix of http and https


### PR DESCRIPTION
This is a redo of the https://github.com/yarpc/yab/pull/228 PR. This was tested locally:

```
$ yab --thrift=idl/uber/infra/lottery/lottery.thrift --service lottery --procedure Lottery::play --peer grpc://0.0.0.0:8088 --request '{"request":{"number":10}}' -d 10s
{
  "body": {
    "result": {
      "won": true
    }
  }
}

Benchmark parameters:
  CPUs:            8
  Connections:     16
  Concurrency:     1
  Max requests:    0
  Max duration:    10s
  Max RPS:         0
Latencies:
  0.5000: 1.381652ms
  0.9000: 3.368971ms
  0.9500: 4.186062ms
  0.9900: 20.716951ms
  0.9990: 26.317353ms
  0.9995: 27.576483ms
  1.0000: 46.746371ms
Elapsed time:      10.001s
Total requests:    83230
RPS:               8321.80
$ yab --thrift=idl/uber/infra/lottery/lottery.thrift --service lottery --procedure Lottery::play --peer tchannel://0.0.0.0:8087 --request '{"request":{"number":10}}' -d 10s
{
  "body": {
    "result": {
      "won": true
    }
  },
  "ok": true,
  "trace": "0"
}

Benchmark parameters:
  CPUs:            8
  Connections:     16
  Concurrency:     1
  Max requests:    0
  Max duration:    10s
  Max RPS:         0
Latencies:
  0.5000: 1.248132ms
  0.9000: 3.031068ms
  0.9500: 3.730443ms
  0.9900: 5.544837ms
  0.9990: 24.617576ms
  0.9995: 35.931727ms
  1.0000: 105.118904ms
Elapsed time:      10.003s
Total requests:    100522
RPS:               10048.26
```