### PR TITLE
Fix the release script, use curl instead of ghr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ go:
 env:
     global:
         - TEST_TIMEOUT_SCALE=10
+        - GITHUB_USER=prashantv
         - secure: paMlkVWaAi0NACXU2oAcSZQugszfb8sALV/FrtXmWtCen42n/6JXLHU4EHNwnLUDo7ZtgTniEPzBXW4GPSMJyyjyk55T4mWmbeMrELfNpHATmIhTRA6xP8AVHwph14i9jDXNLfiGsCZEkpyBfEOsUHc2jS7wSCA2yXBD6OFSoFGWwrpHMrUO0UHXyKGTGKsQrSQMkIaZ9WOXW0S6FRxjfUTLG9oCFfTxM7LGsz26YYI61nRSPnecitmoKVOCj3toMmg8vG6EwsBwDLggLblc70Fw5fggWeTUpvFUrczzqiWq2Sv61FIhMaT1OsO990w5B5BAODoa/L/G0OExd66GSBGHeu7vudIncKoE2jWxinFQzrJ21cEIyT+1LE0ABC4Zcb51KMzm/Alkn4oaSH2X9al/xQjTrVYGaEJdUu62JzkV5SuUrR+3ZzSy9MaUP8CAaP2W7MlyrjNewoO53BkkDtfh0/EbQFWGgE6lULkWwL4JX9qDkJWB5O7aHCM/fjfVRxODsgUfKksabeycabp1mqLQovQhVLLkk/DH66HKFIAO+EHg+EEQA3Z0PJuOf6zqDgHYxj9fXGvega1Yhuecnkej02iEBsuFM+WMDvAXMj5kWwMy5XhFc57ZJtVoFFA0HEjWJessbQNX3ci919wJQuSwI/5HG5ATg2o3Pb5KtD4=
 
 cache:
@@ -25,7 +26,7 @@ after_success:
 
 deploy:
     - provider: script
-      script: scripts/release.sh $TRAVIS_TAG
+      script: GITHUB_REPO=$TRAVIS_REPO_SLUG scripts/release.sh $TRAVIS_TAG
       skip_cleanup: true
       on:
           go: 1.9

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ install_ci: install
 		go get github.com/wadey/gocovmerge
 		go get github.com/mattn/goveralls
 		go get golang.org/x/tools/cmd/cover
-		go get github.com/tcnksm/ghr
 
 
 .PHONY: docs

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,14 +1,27 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
 
-if [ -z "$GITHUB_TOKEN" ]; then
-  echo "GITHUB_TOKEN is not set"
-  exit 1
+die() {
+    echo "$@" >&2
+    exit 1
+}
+
+if [ -z "${GITHUB_USER:-}" ]; then
+  die "GITHUB_USER is not set."
 fi
 
-VERSION="$1"
+if [ -z "${GITHUB_REPO:-}" ]; then
+  die "GITHUB_REPO is not set."
+fi
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  die "GITHUB_TOKEN is not set."
+fi
+
+VERSION="${1:-}"
 if [ -z "$VERSION" ]; then
-  echo "USAGE: $0 VERSION"
-  exit 1
+  die "USAGE: $0 VERSION"
 fi
 
 ./scripts/cross_build.sh "$VERSION"
@@ -21,15 +34,36 @@ echo "CHANGELOG:"
 echo "$CHANGELOG"
 echo ""
 
-# ghr needs either a directory or a single file so we'll move the files we
-# want to release into their own folder.
-RELEASEDIR="release-$VERSION"
-mkdir -p "$RELEASEDIR"
-mv build/yab-"$VERSION"-*.zip "$RELEASEDIR"
+UPLOADS_URL=$( \
+  echo '{}' | \
+    jq -Mr \
+      --arg version "$VERSION" \
+      --arg changelog "$CHANGELOG" \
+      '. + {
+        tag_name: $version,
+        name: $version,
+        body: $changelog,
+      }' | \
+    curl --user "$GITHUB_USER:$GITHUB_TOKEN" -X POST --data @- \
+      "https://api.github.com/repos/$GITHUB_REPO/releases" | \
+    jq -e -r '.upload_url' | \
 
-ghr \
-  -owner yarpc \
-  -token "$GITHUB_TOKEN" \
-  -body "$CHANGELOG" \
-  "$VERSION" "$RELEASEDIR"
-rm -r "$RELEASEDIR"
+    # The UPLOADS_URL has a strange {?name,label} as a suffix that we need to remove.
+    # E.g., https://uploads.github.com/repos/yarpc/yab/releases/11488347/assets{?name,label}
+    cut -d '{' -f1)
+
+# Upon creating a release, we get back the URL to which assets should be
+# uploaded under .uploads_url.
+#
+# See https://developer.github.com/v3/repos/releases/#create-a-release for
+# more information.
+
+for FILE in build/yab-"$VERSION"-*.zip; do
+  echo "Uploading $FILE"
+
+  # See https://developer.github.com/v3/repos/releases/#upload-a-release-asset
+  UPLOAD_URL="${UPLOADS_URL}?name=$(basename "$FILE")"
+  curl --user "$GITHUB_USER:$GITHUB_TOKEN" -X POST \
+    --data-binary @"$FILE" -H 'Content-Type: application/zip' \
+    "$UPLOAD_URL"
+done


### PR DESCRIPTION
Use curl directly instead to cut releases and upload releases.

This fixes the release issues (401s) we observed when cutting the latest
release.