### PR TITLE
Support grpc reflection when using proto encoding

### DIFF
--- a/bench_method_test.go
+++ b/bench_method_test.go
@@ -42,7 +42,7 @@ func benchmarkMethodForTest(t *testing.T, procedure string, p transport.Protocol
 		ThriftFile: validThrift,
 		Procedure:  procedure,
 	}
-	serializer, err := NewSerializer(rOpts)
+	serializer, err := NewSerializer(Options{ROpts: rOpts})
 	require.NoError(t, err, "Failed to create Thrift serializer")
 
 	serializer = withTransportSerializer(p, serializer, rOpts)

--- a/main.go
+++ b/main.go
@@ -297,7 +297,7 @@ func runWithOptions(opts Options, out output, logger *zap.Logger) {
 		out.Fatalf("Failed while loading headers input: %v\n", err)
 	}
 
-	serializer, err := NewSerializer(opts.ROpts)
+	serializer, err := NewSerializer(opts)
 	if err != nil {
 		out.Fatalf("Failed while parsing input: %v\n", err)
 	}

--- a/main.go
+++ b/main.go
@@ -297,11 +297,6 @@ func runWithOptions(opts Options, out output, logger *zap.Logger) {
 		out.Fatalf("Failed while loading headers input: %v\n", err)
 	}
 
-	serializer, err := NewSerializer(opts)
-	if err != nil {
-		out.Fatalf("Failed while parsing input: %v\n", err)
-	}
-
 	if opts.TOpts.CallerName != "" {
 		if _, ok := warningCallerNames[opts.TOpts.CallerName]; ok {
 			// TODO: when logger is hooked up this should use the WARN level message
@@ -315,6 +310,11 @@ func runWithOptions(opts Options, out output, logger *zap.Logger) {
 		}
 	} else {
 		opts.TOpts.CallerName = "yab-" + os.Getenv("USER")
+	}
+
+	serializer, err := NewSerializer(opts)
+	if err != nil {
+		out.Fatalf("Failed while parsing input: %v\n", err)
 	}
 
 	tracer, closer := getTracer(opts, out)

--- a/main_test.go
+++ b/main_test.go
@@ -852,7 +852,7 @@ func TestWithTransportSerializer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		serializer, err := NewSerializer(tt.rOpts)
+		serializer, err := NewSerializer(Options{ROpts: tt.rOpts})
 		require.NoError(t, err, "Failed to create serializer for %+v", tt.rOpts)
 
 		serializer = withTransportSerializer(tt.protocol, serializer, tt.rOpts)

--- a/protobuf/source_reflection.go
+++ b/protobuf/source_reflection.go
@@ -1,0 +1,71 @@
+package protobuf
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/grpcreflect"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+)
+
+var (
+	// ErrorCouldNotDialReflectionServer is an error for when the reflection server could not be reached.
+	ErrorCouldNotDialReflectionServer = errors.New("could not reach reflection server")
+)
+
+// ReflectionArgs are args for constructing a DescriptorProvider that reaches out to a reflection server.
+type ReflectionArgs struct {
+	Caller  string
+	Service string
+	Peers   []string
+	Timeout time.Duration
+}
+
+// NewDescriptorProviderReflection returns a DescriptorProvider DescriptorProvider that reaches out to
+// a reflection server to access filedescriptors.
+func NewDescriptorProviderReflection(args ReflectionArgs) (DescriptorProvider, error) {
+	metadataContext := metadata.NewOutgoingContext(context.Background(),
+		map[string][]string{
+			"rpc-caller":   []string{args.Caller},
+			"rpc-service":  []string{args.Service},
+			"rpc-encoding": []string{"proto"},
+		})
+	r, deregisterScheme := manual.GenerateAndRegisterManualResolver()
+	defer deregisterScheme()
+	peers := make([]resolver.Address, len(args.Peers))
+	for i, p := range args.Peers {
+		peers[i] = resolver.Address{Addr: p, Type: resolver.Backend}
+	}
+	r.InitialAddrs(peers)
+
+	conn, err := grpc.DialContext(context.Background(),
+		r.Scheme()+":///any.peers.registered.for.this.scheme",
+		grpc.WithTimeout(args.Timeout),
+		grpc.WithBlock(),
+		grpc.WithInsecure())
+	if err != nil {
+		return nil, ErrorCouldNotDialReflectionServer
+	}
+	pbClient := rpb.NewServerReflectionClient(conn)
+	return &grpcreflectSource{
+		client: grpcreflect.NewClient(metadataContext, pbClient),
+	}, nil
+}
+
+type grpcreflectSource struct {
+	client *grpcreflect.Client
+}
+
+func (s *grpcreflectSource) FindSymbol(fullyQualifiedName string) (desc.Descriptor, error) {
+	file, err := s.client.FileContainingSymbol(fullyQualifiedName)
+	if err != nil {
+		return nil, err
+	}
+	return file.FindSymbol(fullyQualifiedName), nil
+}

--- a/protobuf/source_reflection_test.go
+++ b/protobuf/source_reflection_test.go
@@ -13,8 +13,9 @@ import (
 
 func TestReflection(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	defer ln.Close()
 	require.NoError(t, err)
+	defer ln.Close()
+
 	s := grpc.NewServer()
 	reflection.Register(s)
 	go s.Serve(ln)
@@ -24,7 +25,7 @@ func TestReflection(t *testing.T) {
 		Peers:   []string{ln.Addr().String()},
 	})
 	assert.NoError(t, err)
-	assert.NotNil(t, source)
+	require.NotNil(t, source)
 
 	result, err := source.FindSymbol("grpc.reflection.v1alpha.ServerReflectionRequest")
 	assert.NoError(t, err)
@@ -39,6 +40,8 @@ func TestReflection(t *testing.T) {
 func TestReflectionMultiplePeers(t *testing.T) {
 	listenRefuser, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err, "failed to listen on a port")
+	defer listenRefuser.Close()
+
 	noListen, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err, "failed to listen on a port")
 	noListen.Close()
@@ -69,6 +72,6 @@ func TestReflectionClosedPort(t *testing.T) {
 		Peers:   []string{ln.Addr().String()},
 	})
 
-	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "could not reach reflection server")
 	assert.Nil(t, got)
 }

--- a/protobuf/source_reflection_test.go
+++ b/protobuf/source_reflection_test.go
@@ -1,0 +1,74 @@
+package protobuf
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+)
+
+func TestReflection(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	defer ln.Close()
+	require.NoError(t, err)
+	s := grpc.NewServer()
+	reflection.Register(s)
+	go s.Serve(ln)
+
+	source, err := NewDescriptorProviderReflection(ReflectionArgs{
+		Timeout: time.Second,
+		Peers:   []string{ln.Addr().String()},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, source)
+
+	result, err := source.FindSymbol("grpc.reflection.v1alpha.ServerReflectionRequest")
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+
+	result, err = source.FindSymbol("wat")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Symbol not found: wat")
+	assert.Nil(t, result)
+}
+
+func TestReflectionMultiplePeers(t *testing.T) {
+	listenRefuser, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to listen on a port")
+	noListen, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to listen on a port")
+	noListen.Close()
+
+	got, err := NewDescriptorProviderReflection(ReflectionArgs{
+		Timeout: time.Second,
+		Peers:   []string{noListen.Addr().String(), listenRefuser.Addr().String()},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	go func() {
+		conn, _ := listenRefuser.Accept()
+		conn.Close()
+	}()
+	_, err = got.FindSymbol("some-symbol")
+	require.Error(t, err)
+}
+
+func TestReflectionClosedPort(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to listen on a port")
+	ln.Close()
+
+	got, err := NewDescriptorProviderReflection(ReflectionArgs{
+		Timeout: time.Second,
+		Peers:   []string{ln.Addr().String()},
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, got)
+}

--- a/request.go
+++ b/request.go
@@ -86,39 +86,39 @@ func getHeaders(inline, file string, override map[string]string) (map[string]str
 }
 
 // NewSerializer creates a Serializer for the specific encoding.
-func NewSerializer(opts RequestOptions) (encoding.Serializer, error) {
-	if opts.Health {
-		if opts.Procedure != "" {
+func NewSerializer(opts Options) (encoding.Serializer, error) {
+	if opts.ROpts.Health {
+		if opts.ROpts.Procedure != "" {
 			return nil, errHealthAndProcedure
 		}
 
-		return opts.Encoding.GetHealth()
+		return opts.ROpts.Encoding.GetHealth()
 	}
 
 	// Thrift returns available methods if one is not specified, while the other
 	// encodings will just return an error, so only do the empty procedure check
 	// for non-Thrift encodings.
-	e := detectEncoding(opts)
+	e := detectEncoding(opts.ROpts)
 	switch e {
 	case encoding.Thrift:
-		return encoding.NewThrift(opts.ThriftFile, opts.Procedure, opts.ThriftMultiplexed)
+		return encoding.NewThrift(opts.ROpts.ThriftFile, opts.ROpts.Procedure, opts.ROpts.ThriftMultiplexed)
 	case encoding.Protobuf:
-		descSource, err := protobuf.NewDescriptorProviderFileDescriptorSetBins(opts.FileDescriptorSet...)
+		descSource, err := protobuf.NewDescriptorProviderFileDescriptorSetBins(opts.ROpts.FileDescriptorSet...)
 		if err != nil {
 			return nil, err
 		}
-		return encoding.NewProtobuf(opts.Procedure, descSource)
+		return encoding.NewProtobuf(opts.ROpts.Procedure, descSource)
 	}
 
-	if opts.Procedure == "" {
+	if opts.ROpts.Procedure == "" {
 		return nil, errMissingProcedure
 	}
 
 	switch e {
 	case encoding.JSON:
-		return encoding.NewJSON(opts.Procedure), nil
+		return encoding.NewJSON(opts.ROpts.Procedure), nil
 	case encoding.Raw:
-		return encoding.NewRaw(opts.Procedure), nil
+		return encoding.NewRaw(opts.ROpts.Procedure), nil
 	}
 
 	return nil, errUnrecognizedEncoding

--- a/request.go
+++ b/request.go
@@ -124,19 +124,19 @@ func NewSerializer(opts Options) (encoding.Serializer, error) {
 	return nil, errUnrecognizedEncoding
 }
 
-func newProtoDescriptorProvider(ROpts RequestOptions, TOpts TransportOptions) (protobuf.DescriptorProvider, error) {
-	if len(ROpts.FileDescriptorSet) > 0 {
-		return protobuf.NewDescriptorProviderFileDescriptorSetBins(ROpts.FileDescriptorSet...)
+func newProtoDescriptorProvider(ropts RequestOptions, topts TransportOptions) (protobuf.DescriptorProvider, error) {
+	if len(ropts.FileDescriptorSet) > 0 {
+		return protobuf.NewDescriptorProviderFileDescriptorSetBins(ropts.FileDescriptorSet...)
 	}
-	TOpts, err := loadTransportPeers(TOpts)
+	topts, err := loadTransportPeers(topts)
 	if err != nil {
 		return nil, err
 	}
 	return protobuf.NewDescriptorProviderReflection(protobuf.ReflectionArgs{
-		Caller:  TOpts.CallerName,
-		Service: TOpts.ServiceName,
-		Peers:   TOpts.Peers,
-		Timeout: ROpts.Timeout.Duration(),
+		Caller:  topts.CallerName,
+		Service: topts.ServiceName,
+		Peers:   topts.Peers,
+		Timeout: ropts.Timeout.Duration(),
 	})
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/yarpc/yab/encoding"
-	"github.com/yarpc/yab/protobuf"
 	"github.com/yarpc/yab/transport"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -291,7 +290,7 @@ func TestNewSerializer(t *testing.T) {
 				Timeout:   timeMillisFlag(time.Millisecond),
 			},
 			topts:   TransportOptions{Peers: []string{"127.0.0.1:0"}},
-			wantErr: protobuf.ErrorCouldNotDialReflectionServer.Error(),
+			wantErr: "could not reach reflection server:",
 		},
 		{
 			encoding: encoding.Protobuf,
@@ -320,8 +319,9 @@ func TestNewSerializer(t *testing.T) {
 }
 func TestNewSerializerProtobufReflection(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	defer ln.Close()
 	require.NoError(t, err)
+	defer ln.Close()
+
 	s := grpc.NewServer()
 	reflection.Register(s)
 	go s.Serve(ln)

--- a/request_test.go
+++ b/request_test.go
@@ -185,6 +185,7 @@ func TestNewSerializer(t *testing.T) {
 	tests := []struct {
 		encoding encoding.Encoding
 		opts     RequestOptions
+		topts    TransportOptions
 		want     encoding.Encoding
 		wantErr  string
 	}{
@@ -284,7 +285,7 @@ func TestNewSerializer(t *testing.T) {
 	for _, tt := range tests {
 		tt.opts.Encoding = tt.encoding
 		t.Run(fmt.Sprintf("%+v", tt.opts), func(t *testing.T) {
-			got, err := NewSerializer(tt.opts)
+			got, err := NewSerializer(Options{ROpts: tt.opts, TOpts: tt.topts})
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr, "unexpected error")


### PR DESCRIPTION
When using the proto encoding, instead of requiring the user to supply a precompiled filedescriptorset with `--file-descriptor-set-bin` support using the [grpc server reflection](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) api to retrieve the required filedescriptors from the server.