### PR TITLE
Print available proto methods for unrecognized arg

### DIFF
--- a/encoding/protobuf.go
+++ b/encoding/protobuf.go
@@ -108,7 +108,10 @@ func findProtoMethodDescriptor(s *desc.ServiceDescriptor, m string) (*desc.Metho
 		for i, method := range s.GetMethods() {
 			available[i] = s.GetFullyQualifiedName() + "/" + method.GetName()
 		}
-		errMsg := fmt.Sprintf("service %q does not include a method named %q", s.GetFullyQualifiedName(), m)
+		errMsg := "no proto method specified, specify --method package.Service/Method"
+		if m != "" {
+			errMsg = fmt.Sprintf("service %q does not include a method named %q", s.GetFullyQualifiedName(), m)
+		}
 		return nil, notFoundError{errMsg + ", available methods:", available}
 	}
 	return methodDescriptor, nil

--- a/encoding/protobuf_test.go
+++ b/encoding/protobuf_test.go
@@ -2,12 +2,14 @@ package encoding
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
+
+	"github.com/yarpc/yab/protobuf"
+	"github.com/yarpc/yab/transport"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yarpc/yab/protobuf"
-	"github.com/yarpc/yab/transport"
 )
 
 func TestNewProtobuf(t *testing.T) {
@@ -23,12 +25,12 @@ func TestNewProtobuf(t *testing.T) {
 		{
 			desc:   "no method",
 			method: "Bar",
-			errMsg: "service \"Bar\" does not include a method named \"\", available methods:\n\tBar/Baz",
+			errMsg: "no proto method specified, specify --method package.Service/Method, available methods:\n\tBar/Baz",
 		},
 		{
 			desc:   "missing method for service",
 			method: "Bar/baq",
-			errMsg: "service \"Bar\" does not include a method named \"baq\", available methods:\n\tBar/Baz",
+			errMsg: fmt.Sprintf("service %q does not include a method named %q, available methods:\n\tBar/Baz", "Bar", "baq"),
 		},
 		{
 			desc:   "invalid method format",


### PR DESCRIPTION
Thrift currently has a feature that if the method specified in the
procedure is not present (or not available on the server), it prints the
available methods as a hint to the user. This brings the proto
implementation to feature parity.

Example:
```
$ ./yab --file-descriptor-set-bin=/Users/robbert/health.bin raffle grpc.health.v1.Health -r '{"service": "raffle"}' -p localhost:8000
Failed while parsing input: service "grpc.health.v1.Health" does not include a method named "", available methods:
	grpc.health.v1.Health/Check
```