### PR TITLE
templateargs: Deal with YAML's handling of "y" as boolean

### DIFF
--- a/templateargs/process.go
+++ b/templateargs/process.go
@@ -41,9 +41,9 @@ func processString(v string, args map[string]string) (interface{}, error) {
 	err = yaml.Unmarshal([]byte(rendered), &unmarshalled)
 
 	if _, isBool := unmarshalled.(bool); isBool {
-		// The Go YAML parser has some unfortunate handling of bools:
-		// https://github.com/go-yaml/yaml/issues/214
-		// Let's use a more strict-definition for booleans:
+		// The Go YAML parser has some unfortunate handling of strings that look
+		// like booleans: https://github.com/go-yaml/yaml/issues/214
+		// Let's use a more strict definition for booleans.
 		if _, err := strconv.ParseBool(rendered); err != nil {
 			// Go doesn't think this is a boolean, so use the value as a string
 			return rendered, nil

--- a/templateargs/process_test.go
+++ b/templateargs/process_test.go
@@ -16,8 +16,11 @@ type (
 
 func TestProcessString(t *testing.T) {
 	args := map[string]string{
-		"user":  "prashant",
-		"count": "10",
+		"user":     "prashant",
+		"count":    "10",
+		"y":        "y",
+		"t":        "true",
+		"t_quoted": `"true"`,
 	}
 	tests := []struct {
 		v       string
@@ -27,6 +30,22 @@ func TestProcessString(t *testing.T) {
 		{
 			v:    "s",
 			want: "s",
+		},
+		{
+			v:    "y",
+			want: "y",
+		},
+		{
+			v:    "${y}",
+			want: "y",
+		},
+		{
+			v:    "${t}",
+			want: true,
+		},
+		{
+			v:    "${t_quoted}",
+			want: "true",
 		},
 		{
 			v:       "${unknown}",


### PR DESCRIPTION
When using yab templates and a key is specified as `"y"` (with quoting),
the template parsing ends up converting this to `y`, which then gets
unmarshalled as a boolean. The underlying cause is:
https://github.com/go-yaml/yaml/issues/214

This is caused by template rendering's use of `yaml.Unmarshal` on all
string values which can lose the type.

This change restricts the `Unmarshal` to values that were modified
as part of the rendering step. It also adds special logic to protect
against YAML's boolean handling, by only using the boolean value
if strconv.ParseBool would parse the value. This means if a value
was rendered as `y`, we would still not treat it as a boolean.

Fixes #253