### PR TITLE
Bash autocomplete script

### DIFF
--- a/etc/bash_completion.d/yab
+++ b/etc/bash_completion.d/yab
@@ -1,4 +1,8 @@
 # bash completion for yab executable
+# based on https://godoc.org/github.com/jessevdk/go-flags#hdr-Completion
+# depends on https://salsa.debian.org/debian/bash-completion
+
+
 have yab &&
 _yab()
 {

--- a/etc/bash_completion.d/yab
+++ b/etc/bash_completion.d/yab
@@ -1,0 +1,16 @@
+# bash completion for yab executable
+have yab &&
+_yab()
+{
+    # All arguments except the first one
+    args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+
+    # Only split on newlines
+    local IFS=$'\n'
+
+    # Call completion (note that the first element of COMP_WORDS is
+    # the executable itself)
+    COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
+    return 0
+} &&
+complete -F _yab yab


### PR DESCRIPTION
It relies on:
  * autocomplete functionality from go-flags package
    https://godoc.org/github.com/jessevdk/go-flags#hdr-Completion
  * functions ('have') from bash-completion in order to allow
    user to explicitly opt in
    https://salsa.debian.org/debian/bash-completion
  * script being placed in the etc/bash_completion.d directory belonging
    to bash-completion - this is similar to the man page in share

Packaging will need to properly place files