### PR TITLE
thrift: Treat null map values as ignore field/key

### DIFF
--- a/thrift/fields.go
+++ b/thrift/fields.go
@@ -91,6 +91,11 @@ func fieldGroupToValue(fieldsList compile.FieldGroup, request map[string]interfa
 			continue
 		}
 
+		if v == nil {
+			// If no value is provided, then ignore this field.
+			continue
+		}
+
 		userFields[field.ThriftName()] = v
 	}
 

--- a/thrift/parse_test.go
+++ b/thrift/parse_test.go
@@ -481,6 +481,35 @@ func TestParseRequest(t *testing.T) {
 			},
 			errMsg: `unrecognized enum "Op(NaN)"`,
 		},
+		{
+			// nil field means ignore the field or map value.
+			request: map[string]interface{}{
+				"s": map[string]interface{}{
+					"f1": "f1v",
+					"ns": nil,
+				},
+				"s_i_map": map[string]interface{}{
+					"a": 1,
+					"b": nil,
+					"c": 3,
+				},
+			},
+			want: []wire.Field{
+				{ID: 5, Value: wire.NewValueStruct(wire.Struct{
+					Fields: []wire.Field{
+						{ID: 1, Value: wire.NewValueString("f1v")},
+					},
+				})},
+				{ID: 15, Value: wire.NewValueMap(wire.MapItemListFromSlice(
+					wire.TBinary,
+					wire.TI32,
+					[]wire.MapItem{
+						{wire.NewValueString("a"), wire.NewValueI32(1)},
+						{wire.NewValueString("c"), wire.NewValueI32(3)},
+					},
+				))},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/thrift/to_wire.go
+++ b/thrift/to_wire.go
@@ -137,6 +137,11 @@ func mapToValue(keySpec, valueSpec compile.TypeSpec, value interface{}) (wire.Ma
 
 	items := make([]wire.MapItem, 0, len(valueMap))
 	for k, v := range valueMap {
+		if v == nil {
+			// If no value is provided, then ignore this key.
+			continue
+		}
+
 		keyValue := convertMapKey(keySpec, k)
 		kw, err := toWireValue(keySpec, keyValue)
 		if err != nil {


### PR DESCRIPTION
Currently, if a value is specified as null, it causes an error
parsing (e.g., cannot parse null as i32). This limits how useful
yab templates can be, as any specified field must always be set to
a value.

However, what we'd like is a YAML template with something like:

```
request:
  minVersion: ${minVersion:null}
  maxVersion: ${maxVersion:null}
```

We may only want to specify one or the other condition, but today this
template would cause errors and it would try to parse "null". Instead we
should ignore null, as null is not a value we can propagate on the wire.