### PR TITLE
Add option to specify HTTP method

### DIFF
--- a/options.go
+++ b/options.go
@@ -83,6 +83,7 @@ type TransportOptions struct {
 	ShardKey         string            `long:"sk" description:"The shard key is a transport header that clues where to send a request within a clustered traffic group."`
 	Jaeger           bool              `long:"jaeger" description:"Use the Jaeger tracing client to send Uber style traces and baggage headers"`
 	TransportHeaders map[string]string `short:"T" long:"topt" description:"Transport options for TChannel, protocol headers for HTTP"`
+	HTTPMethod       string            `long:"http-method" description:"The HTTP method to use"`
 
 	// This is a hack to work around go-flags not allowing disabling flags:
 	// https://github.com/jessevdk/go-flags/issues/191
@@ -114,6 +115,7 @@ func newOptions() *Options {
 
 	// Defaults
 	opts.ROpts.Timeout = timeMillisFlag(time.Second)
+	opts.TOpts.HTTPMethod = "POST"
 
 	// Set flag aliases
 	opts.ROpts.MethodName.dest = &opts.ROpts.Procedure

--- a/transport.go
+++ b/transport.go
@@ -190,6 +190,7 @@ func getTransport(opts TransportOptions, enc encoding.Encoding, tracer opentraci
 	}
 
 	hopts := transport.HTTPOptions{
+		Method:          opts.HTTPMethod,
 		SourceService:   opts.CallerName,
 		TargetService:   opts.ServiceName,
 		RoutingDelegate: opts.RoutingDelegate,

--- a/transport/http.go
+++ b/transport/http.go
@@ -42,6 +42,7 @@ type httpTransport struct {
 
 // HTTPOptions are used to create a HTTP transport.
 type HTTPOptions struct {
+	Method          string
 	URLs            []string
 	SourceService   string
 	TargetService   string
@@ -65,6 +66,9 @@ func NewHTTP(opts HTTPOptions) (Transport, error) {
 	if opts.TargetService == "" {
 		return nil, errMissingTarget
 	}
+	if opts.Method == "" {
+		opts.Method = "POST"
+	}
 
 	return &httpTransport{
 		opts: opts,
@@ -83,8 +87,8 @@ func (h *httpTransport) Tracer() opentracing.Tracer {
 func (h *httpTransport) newReq(ctx context.Context, r *Request) (*http.Request, error) {
 	url := h.opts.URLs[rand.Intn(len(h.opts.URLs))]
 
-	// TODO: We should envelope Thrift paylods here.
-	req, err := http.NewRequest("POST", url, bytes.NewReader(r.Body))
+	// TODO: We should envelope Thrift payloads here.
+	req, err := http.NewRequest(h.opts.Method, url, bytes.NewReader(r.Body))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Yab supports "raw" requests to HTTP for REST servers, but it only uses
POST requests. Add a flag to control the HTTP method used to make the
request.

Fixes #252