### PR TITLE
Introduce yamlalias to simplify aliases in templates

### DIFF
--- a/internal/yamlalias/wrap.go
+++ b/internal/yamlalias/wrap.go
@@ -37,8 +37,8 @@ func UnmarshalStrict(in []byte, out interface{}) error {
 	return yaml.UnmarshalStrict(in, addAliases(out))
 }
 
-// addAliases generates a new struct that contains all exported fields
-// from the passed in struct, but adds additional fields for any
+// addAliases generates a new struct for unmarshalling that contains all exported
+// fields from the passed in struct, but also adds additional fields for any
 // aliases.
 //
 // Given a struct such as:
@@ -65,12 +65,13 @@ func UnmarshalStrict(in []byte, out interface{}) error {
 // out.UserNameYamlAlias1 = &dest.UserName
 // out.UserNameYamlAlias2 = &dest.UserName
 // out.TTL = &dest.TTL
+// return out
 //
 // The YAML library respects existing pointers when unmarshalling, and
 // does not replace them:
 // https://gist.github.com/prashantv/fa4f92b4b95f936d68495be250ed3506
-func addAliases(v interface{}) interface{} {
-	rv := reflect.ValueOf(v).Elem()
+func addAliases(dest interface{}) interface{} {
+	rv := reflect.ValueOf(dest).Elem()
 	rt := rv.Type()
 
 	fields := make([]reflect.StructField, 0, rt.NumField())
@@ -113,10 +114,10 @@ func addAliases(v interface{}) interface{} {
 	// The struct we generated has pointers to the original fields.
 	// Set all the pointers to the fields in the original struct.
 	generated := reflect.StructOf(fields)
-	generatedV := reflect.New(generated)
+	out := reflect.New(generated)
 	for i, dest := range dests {
-		generatedV.Elem().Field(i).Set(dest)
+		out.Elem().Field(i).Set(dest)
 	}
 
-	return generatedV.Interface()
+	return out.Interface()
 }

--- a/internal/yamlalias/wrap.go
+++ b/internal/yamlalias/wrap.go
@@ -52,7 +52,7 @@ func UnmarshalStrict(in []byte, out interface{}) error {
 // original struct and a new field for each alias.
 //
 //   struct {
-//     UserName string `yaml:"username" yaml-aliases:"userName,user-name"`
+//     UserName *string `yaml:"username" yaml-aliases:"userName,user-name"`
 //     UserNameYamlAlias1 *string `yaml:"userName"`
 //     UserNameYamlAlias2 *string `yaml:"user-name"`
 //     TTL *time.Duration `yaml:"ttl"`

--- a/internal/yamlalias/wrap.go
+++ b/internal/yamlalias/wrap.go
@@ -1,0 +1,93 @@
+// Package yamlalias adds support for aliases when parsing YAML.
+//
+// Aliases are specified as a comma-separated list specified via
+// "yaml-aliases" struct tag.
+//
+// Example:
+//
+//   type Config struct {
+//     UserName string `yaml:"username" yaml-aliases:"userName,user-name"`
+//   }
+//
+// This will parse the following YAML examples in the same way:
+//   {"username": "John Doe"}
+//   {"userName": "John Doe"}
+//   {"user-name": "John Doe"}
+//
+// Note: It only adds aliases for top-level fields in the struct.
+package yamlalias
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Unmarshal is a wrapper for yaml.Unmarshal but adds
+// support for any yaml-aliases specified in out.
+func Unmarshal(in []byte, out interface{}) error {
+	return yaml.Unmarshal(in, addAliases(out))
+}
+
+// UnmarshalStrict is a wrapper for yaml.UnmarshalStrict but adds
+// support for any yaml-aliases specified in out.
+func UnmarshalStrict(in []byte, out interface{}) error {
+	return yaml.UnmarshalStrict(in, addAliases(out))
+}
+
+// addAliases generates a new struct that contains all exported fields
+// from the passed in struct, but adds additional fields for any
+// aliases.
+func addAliases(v interface{}) interface{} {
+	rv := reflect.ValueOf(v).Elem()
+	rt := rv.Type()
+
+	fields := make([]reflect.StructField, 0, rt.NumField())
+	dests := make([]reflect.Value, 0, rt.NumField())
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+
+		// Ignore unexported fields.
+		if f.PkgPath != "" {
+			continue
+		}
+
+		// Add a pointer field that matches the original field in the struct.
+		fields = append(fields, reflect.StructField{
+			Name: f.Name,
+			Type: reflect.PtrTo(f.Type),
+			Tag:  f.Tag,
+		})
+		dests = append(dests, rv.Field(i).Addr())
+
+		allAliases, ok := f.Tag.Lookup("yaml-aliases")
+		if !ok {
+			// No aliases specified. No other fields to add.
+			continue
+		}
+
+		aliases := strings.Split(allAliases, ",")
+		for j, alias := range aliases {
+			// Add a new field that is a pointer to the original field.
+			// We generate a name that is unlikely to clash. Clashes will cause panics.
+			fields = append(fields, reflect.StructField{
+				Name: fmt.Sprintf("%vYamlAlias%v", f.Name, j),
+				Type: reflect.PtrTo(f.Type),
+				Tag:  reflect.StructTag(fmt.Sprintf(`yaml:%q`, alias)),
+			})
+			dests = append(dests, rv.Field(i).Addr())
+		}
+	}
+
+	// The struct we generated has pointers to the original fields.
+	// Set all the pointers to the fields in the original struct.
+	generated := reflect.StructOf(fields)
+	generatedV := reflect.New(generated)
+	for i := range fields {
+		generatedV.Elem().Field(i).Set(dests[i])
+	}
+
+	return generatedV.Interface()
+}

--- a/internal/yamlalias/wrap.go
+++ b/internal/yamlalias/wrap.go
@@ -40,6 +40,30 @@ func UnmarshalStrict(in []byte, out interface{}) error {
 // addAliases generates a new struct that contains all exported fields
 // from the passed in struct, but adds additional fields for any
 // aliases.
+//
+// Given a struct such as:
+//
+//   type Config struct {
+//     UserName string `yaml:"username" yaml-aliases:"userName,user-name"`
+//   }
+//
+// It will create a new struct with fields for each alias:
+//
+//   struct {
+//     UserName string `yaml:"username" yaml-aliases:"userName,user-name"`
+//     UserNameYamlAlias1 *string `yaml:"userName"`
+//     UserNameYamlAlias2 *string `yaml:"user-name"`
+//   }
+//
+// A value of that struct is returned, with the new pointer fields pointing
+// to the original field that defined the aliases:
+//
+// s.UserNameYamlAlias1 = &UserName
+// s.UserNameYamlAlias2 = &UserName
+//
+// The YAML library respects existing pointers when unmarshalling, and
+// does not replace them:
+// https://gist.github.com/prashantv/fa4f92b4b95f936d68495be250ed3506
 func addAliases(v interface{}) interface{} {
 	rv := reflect.ValueOf(v).Elem()
 	rt := rv.Type()

--- a/internal/yamlalias/wrap_test.go
+++ b/internal/yamlalias/wrap_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 func stringPtr(s string) *string {
@@ -116,6 +117,20 @@ func TestWrap(t *testing.T) {
 			assert.Equal(t, tt.want, v)
 		})
 	}
+}
+
+func TestWrapPointerField(t *testing.T) {
+	var dest string
+	type StructWithPointer struct {
+		Foo *string `yaml:"foo" yaml-aliases:"bar"`
+	}
+
+	s := StructWithPointer{Foo: &dest}
+	require.NoError(t, yaml.Unmarshal([]byte(`{"foo": "initial"}`), &s), "failed to unmarshal")
+	assert.Equal(t, "initial", dest, "dest expected to be updated")
+
+	require.NoError(t, Unmarshal([]byte(`{"bar": "updated"}`), &s), "failed to unmarshal with alias")
+	assert.Equal(t, "updated", dest, "expected dest to be updated via alias")
 }
 
 func TestWrapInvalid(t *testing.T) {

--- a/internal/yamlalias/wrap_test.go
+++ b/internal/yamlalias/wrap_test.go
@@ -1,0 +1,149 @@
+package yamlalias
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func TestWrap(t *testing.T) {
+	type Simple struct {
+		Foo string `yaml:"foo" yaml-aliases:"bar,baz"`
+	}
+
+	type ManyTypes struct {
+		Str   string            `yaml-aliases:"string"`
+		Int   int               `yaml-aliases:"Int"`
+		Slice []string          `yaml-aliases:"list"`
+		Map   map[string]string `yaml-aliases:"dict"`
+	}
+
+	type AliasToPtr struct {
+		Foo *string `yaml:"foo" yaml-aliases:"bar"`
+	}
+
+	tests := []struct {
+		msg  string
+		data string
+		want interface{}
+	}{
+		{
+			msg:  "No aliases",
+			data: `{"foo": "foo", "bar": "bar"}`,
+			want: &struct {
+				Foo string
+				Bar string
+			}{"foo", "bar"},
+		},
+		{
+			msg:  "set field by normal name",
+			data: `{"foo": "foo"}`,
+			want: &Simple{"foo"},
+		},
+		{
+			msg:  "set field by first alias",
+			data: `{"bar": "bar"}`,
+			want: &Simple{"bar"},
+		},
+		{
+			msg:  "set field by second alias",
+			data: `{"baz": "baz"}`,
+			want: &Simple{"baz"},
+		},
+		{
+			msg:  "set field with multiple aliases, last one wins",
+			data: `{"bar": "bar", "foo": "foo", "baz": "baz"}`,
+			want: &Simple{"baz"},
+		},
+		{
+			msg:  "pointer field that is not set",
+			data: `{}`,
+			want: &AliasToPtr{},
+		},
+		{
+			msg:  "pointer field set directly",
+			data: `{"foo": "foo"}`,
+			want: &AliasToPtr{stringPtr("foo")},
+		},
+		{
+			msg:  "pointer field that is set by alias",
+			data: `{"bar": "bar"}`,
+			want: &AliasToPtr{stringPtr("bar")},
+		},
+		{
+			msg: "Unexported fields are ignored",
+			want: &struct {
+				Foo string `yaml:"foo" yaml-aliases:"bar"`
+				bar string `yaml:"bar" yaml-aliases:"baz"`
+			}{
+				Foo: "bar",
+				bar: "",
+			},
+			data: `{"bar": "bar"}`,
+		},
+		{
+			msg: "Alias with different case",
+			want: &struct {
+				Foo string `yaml:"foo" yaml-aliases:"Foo"`
+			}{
+				Foo: "Foo",
+			},
+			data: `{"Foo": "Foo"}`,
+		},
+		{
+			msg: "Alias with dashes",
+			want: &struct {
+				Foo string `yaml:"foo" yaml-aliases:"foo-bar"`
+			}{
+				Foo: "foo-bar",
+			},
+			data: `{"foo-bar": "foo-bar"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			// To allow use of anonymous structs, we use reflection to create
+			// a new empty struct.
+			v := reflect.New(reflect.TypeOf(tt.want).Elem()).Interface()
+			require.NoError(t, Unmarshal([]byte(tt.data), v))
+			assert.Equal(t, tt.want, v)
+		})
+	}
+}
+
+func TestWrapInvalid(t *testing.T) {
+	tests := []struct {
+		msg string
+		t   interface{}
+	}{
+		{
+			msg: "Alias clashes with other field",
+			t: &struct {
+				Foo string `yaml:"foo" yaml-aliases:"bar,baz"`
+				Bar string `yaml:"bar"`
+			}{},
+		},
+		{
+			msg: "Alias clashes with another alias",
+			t: &struct {
+				Foo string `yaml:"foo" yaml-aliases:"baz"`
+				Bar string `yaml:"bar" yaml-aliases:"baz"`
+			}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			assert.Panics(t, func() {
+				Unmarshal([]byte(`{}`), &tt.t)
+			})
+		})
+	}
+}

--- a/options.go
+++ b/options.go
@@ -174,10 +174,6 @@ func (s *stringAlias) UnmarshalFlag(value string) error {
 	return nil
 }
 
-func (s *stringAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	return unmarshal(s.dest)
-}
-
 func setEncodingOptions(opts *Options) {
 	if opts.ROpts.Aliases.JSON {
 		opts.ROpts.Encoding = encoding.JSON

--- a/template.go
+++ b/template.go
@@ -27,41 +27,25 @@ import (
 	"strings"
 	"time"
 
+	"github.com/yarpc/yab/internal/yamlalias"
 	"github.com/yarpc/yab/templateargs"
 
 	"gopkg.in/yaml.v2"
 )
 
 type template struct {
-	Peers                     []string    `yaml:"peers"`
-	Peer                      string      `yaml:"peer"`
-	PeerList                  string      `yaml:"peerList"`
-	Peerlist                  stringAlias `yaml:"peerlist"`
-	PeerDashList              stringAlias `yaml:"peer-list"`
-	Caller                    string      `yaml:"caller"`
-	Service                   string      `yaml:"service"`
-	Thrift                    string      `yaml:"thrift"`
-	Procedure                 string      `yaml:"procedure"`
-	Method                    stringAlias `yaml:"method"`
-	DisableThriftEnvelope     *bool       `yaml:"disableThriftEnvelope"`
-	DisableDashThriftEnvelope **bool      `yaml:"disable-thrift-envelope"`
-	Disablethriftenvelope     **bool      `yaml:"disablethriftenvelope"`
+	Peers                 []string `yaml:"peers"`
+	Peer                  string   `yaml:"peer"`
+	PeerList              string   `yaml:"peerList" yaml-aliases:"peerlist,peer-list"`
+	Caller                string   `yaml:"caller"`
+	Service               string   `yaml:"service"`
+	Thrift                string   `yaml:"thrift"`
+	Procedure             string   `yaml:"procedure" yaml-aliases:"method"`
+	DisableThriftEnvelope *bool    `yaml:"disableThriftEnvelope" yaml-aliases:"disablethriftenvelope,disable-thrift-envelope"`
 
-	ShardKey        string `yaml:"shardKey"`
-	RoutingKey      string `yaml:"routingKey"`
-	RoutingDelegate string `yaml:"routingDelegate"`
-
-	Shardkey        stringAlias `yaml:"shardkey"`
-	Routingkey      stringAlias `yaml:"routingkey"`
-	Routingdelegate stringAlias `yaml:"routingdelegate"`
-
-	ShardDashKey        stringAlias `yaml:"shard-key"`
-	RoutingDashKey      stringAlias `yaml:"routing-key"`
-	RoutingDashDelegate stringAlias `yaml:"routing-delegate"`
-
-	SK stringAlias `yaml:"sk"`
-	RK stringAlias `yaml:"rk"`
-	RD stringAlias `yaml:"rd"`
+	ShardKey        string `yaml:"shardKey" yaml-aliases:"shardkey,shard-key,sk"`
+	RoutingKey      string `yaml:"routingKey" yaml-aliases:"routingkey,routing-key,rk"`
+	RoutingDelegate string `yaml:"routingDelegate" yaml-aliases:"routingdelegate,routing-delegate,rd"`
 
 	Headers map[string]string           `yaml:"headers"`
 	Baggage map[string]string           `yaml:"baggage"`
@@ -96,11 +80,12 @@ func readYAMLFile(yamlTemplate string, templateArgs map[string]string, opts *Opt
 }
 
 func readYAMLRequest(base string, contents []byte, templateArgs map[string]string, opts *Options) error {
-	t, err := unmarshalTemplate(contents)
-	if err != nil {
+	var t template
+	if err := yamlalias.UnmarshalStrict(contents, &t); err != nil {
 		return err
 	}
 
+	var err error
 	t.Request, err = templateargs.ProcessMap(t.Request, templateArgs)
 	if err != nil {
 		return err
@@ -164,33 +149,6 @@ func overrideParam(s *string, newS string) {
 	if newS != "" {
 		*s = newS
 	}
-}
-
-func unmarshalTemplate(bytes []byte) (*template, error) {
-	t := &template{}
-
-	t.Method.dest = &t.Procedure
-
-	t.Peerlist.dest = &t.PeerList
-	t.PeerDashList.dest = &t.PeerList
-
-	t.Shardkey.dest = &t.ShardKey
-	t.Routingkey.dest = &t.RoutingKey
-	t.Routingdelegate.dest = &t.RoutingDelegate
-
-	t.ShardDashKey.dest = &t.ShardKey
-	t.RoutingDashKey.dest = &t.RoutingKey
-	t.RoutingDashDelegate.dest = &t.RoutingDelegate
-
-	t.SK.dest = &t.ShardKey
-	t.RK.dest = &t.RoutingKey
-	t.RD.dest = &t.RoutingDelegate
-
-	t.Disablethriftenvelope = &t.DisableThriftEnvelope
-	t.DisableDashThriftEnvelope = &t.DisableThriftEnvelope
-
-	err := yaml.Unmarshal(bytes, &t)
-	return t, err
 }
 
 type headers map[string]string

--- a/template_test.go
+++ b/template_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/yarpc/yab/internal/yamlalias"
 )
 
 func mustReadYAMLFile(t *testing.T, yamlTemplate string, opts *Options) {
@@ -292,9 +293,10 @@ func TestTemplateAlias(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		for _, template := range tt.templates {
-			t.Run(template, func(t *testing.T) {
-				templ, err := unmarshalTemplate([]byte(template))
+		for _, in := range tt.templates {
+			t.Run(in, func(t *testing.T) {
+				var templ template
+				err := yamlalias.Unmarshal([]byte(in), &templ)
 				require.NoError(t, err)
 				assert.Equal(t, tt.wantShardKey, templ.ShardKey, "shard key aliases expanded")
 				assert.Equal(t, tt.wantRoutingKey, templ.RoutingKey, "routing key aliases expanded")
@@ -312,23 +314,23 @@ func TestDisableThriftEnvelopeOverride(t *testing.T) {
 		wantDisableThriftEnvelope bool
 	}{
 		{
-			initial: false,
-			yaml:    "method: foo",
+			initial:                   false,
+			yaml:                      "method: foo",
 			wantDisableThriftEnvelope: false,
 		},
 		{
-			initial: true,
-			yaml:    "method: foo",
+			initial:                   true,
+			yaml:                      "method: foo",
 			wantDisableThriftEnvelope: true,
 		},
 		{
-			initial: false,
-			yaml:    "disable-thrift-envelope: true",
+			initial:                   false,
+			yaml:                      "disable-thrift-envelope: true",
 			wantDisableThriftEnvelope: true,
 		},
 		{
-			initial: true,
-			yaml:    "disable-thrift-envelope: true",
+			initial:                   true,
+			yaml:                      "disable-thrift-envelope: true",
 			wantDisableThriftEnvelope: true,
 		},
 	}


### PR DESCRIPTION
For yab templates, we support a few aliases to simplify
usage for users. E.g., we support shardKey, shardkey, shard-key or sk.

This requires a lot of manual wiring up to work. Instead, introduce
a yamlalias package which will use reflection to generate a new struct
that contains additional fields for each alias.