### PR TITLE
benchmark: Add per-peer stats

### DIFF
--- a/bench_method.go
+++ b/bench_method.go
@@ -31,6 +31,11 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
+type peerTransport struct {
+	transport.Transport
+	peerID int
+}
+
 type benchmarkMethod struct {
 	serializer encoding.Serializer
 	req        *transport.Request
@@ -65,25 +70,25 @@ func (m benchmarkMethod) call(t transport.Transport) (time.Duration, error) {
 	return duration, err
 }
 
-func peerBalancer(peers []string) func(i int) string {
+func peerBalancer(peers []string) func(i int) (string, int) {
 	numPeers := len(peers)
 	startOffset := rand.Intn(numPeers)
-	return func(i int) string {
+	return func(i int) (string, int) {
 		offset := (startOffset + i) % numPeers
-		return peers[offset]
+		return peers[offset], offset
 	}
 }
 
 // WarmTransports returns n transports that have been warmed up.
 // No requests may fail during the warmup period.
-func (m benchmarkMethod) WarmTransports(n int, tOpts TransportOptions, warmupRequests int) ([]transport.Transport, error) {
+func (m benchmarkMethod) WarmTransports(n int, tOpts TransportOptions, warmupRequests int) ([]peerTransport, error) {
 	tOpts, err := loadTransportPeers(tOpts)
 	if err != nil {
 		return nil, err
 	}
 
 	peerFor := peerBalancer(tOpts.Peers)
-	transports := make([]transport.Transport, n)
+	transports := make([]peerTransport, n)
 	errs := make([]error, n)
 
 	var wg sync.WaitGroup
@@ -91,8 +96,13 @@ func (m benchmarkMethod) WarmTransports(n int, tOpts TransportOptions, warmupReq
 		wg.Add(1)
 		go func(i int, tOpts TransportOptions) {
 			defer wg.Done()
-			tOpts.Peers = []string{peerFor(i)}
-			transports[i], errs[i] = m.WarmTransport(tOpts, warmupRequests)
+
+			peerHostPort, peerIndex := peerFor(i)
+			tOpts.Peers = []string{peerHostPort}
+
+			tp, err := m.WarmTransport(tOpts, warmupRequests)
+			transports[i] = peerTransport{tp, peerIndex}
+			errs[i] = err
 		}(i, tOpts)
 	}
 

--- a/bench_method_test.go
+++ b/bench_method_test.go
@@ -197,8 +197,9 @@ func TestPeerBalancer(t *testing.T) {
 		rand.Seed(tt.seed)
 		peerFor := peerBalancer(tt.peers)
 		for i, want := range tt.want {
-			got := peerFor(i)
+			got, index := peerFor(i)
 			assert.Equal(t, want, got, "peerBalancer(%v) seed %v i %v failed", tt.peers, tt.seed, i)
+			assert.Equal(t, want, tt.peers[index], "peerBalancer(%v) seed %v i %v unexpected index %v", tt.peers, tt.seed, i, index)
 		}
 	}
 }

--- a/benchmark.go
+++ b/benchmark.go
@@ -142,10 +142,10 @@ func runBenchmark(out output, logger *zap.Logger, allOpts Options, m benchmarkMe
 			// If per-peer stats are enabled, dual emit metrics to the original value
 			// and the per-peer value.
 			prefix := fmt.Sprintf("peer.%v.", c.peerID)
-			statter = statsd.MultiClient{
-				globalStatter,
-				statsd.NewPrefixedClient(globalStatter, prefix),
-			}
+			statter = statsd.MultiClient(
+				statter,
+				statsd.NewPrefixedClient(statter, prefix),
+			)
 		}
 
 		for j := 0; j < opts.Concurrency; j++ {

--- a/benchmark.go
+++ b/benchmark.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"runtime"
@@ -126,15 +127,30 @@ func runBenchmark(out output, logger *zap.Logger, allOpts Options, m benchmarkMe
 		out.Fatalf("Failed to warmup connections for benchmark: %v", err)
 	}
 
-	statter, err := statsd.NewClient(logger, opts.StatsdHostPort, allOpts.TOpts.ServiceName, allOpts.ROpts.Procedure)
+	globalStatter, err := statsd.NewClient(logger, opts.StatsdHostPort, allOpts.TOpts.ServiceName, allOpts.ROpts.Procedure)
 	if err != nil {
 		out.Fatalf("Failed to create statsd client for benchmark: %v", err)
 	}
 
 	var wg sync.WaitGroup
 	states := make([]*benchmarkState, len(connections)*opts.Concurrency)
-	for i := range states {
-		states[i] = newBenchmarkState(statter)
+
+	for i, c := range connections {
+		statter := globalStatter
+
+		if opts.PerPeerStats {
+			// If per-peer stats are enabled, dual emit metrics to the original value
+			// and the per-peer value.
+			prefix := fmt.Sprintf("peer.%v.", c.peerID)
+			statter = statsd.MultiClient{
+				globalStatter,
+				statsd.NewPrefixedClient(globalStatter, prefix),
+			}
+		}
+
+		for j := 0; j < opts.Concurrency; j++ {
+			states[i*opts.Concurrency+j] = newBenchmarkState(statter)
+		}
 	}
 
 	run := limiter.New(opts.MaxRequests, opts.RPS, opts.MaxDuration)
@@ -155,6 +171,7 @@ func runBenchmark(out output, logger *zap.Logger, allOpts Options, m benchmarkMe
 	}
 
 	// TODO: Support streaming updates.
+	// TOOD: Aggregate per-backend state for JSON output in future.
 
 	// Wait for all the worker goroutines to end.
 	wg.Wait()

--- a/options.go
+++ b/options.go
@@ -108,6 +108,7 @@ type BenchmarkOptions struct {
 
 	// Benchmark metrics can optionally be reported via statsd.
 	StatsdHostPort string `long:"statsd" description:"Optional host:port of a StatsD server to report metrics"`
+	PerPeerStats   bool   `long:"per-peer-stats" description:"Whether to emit stats by peer rather than aggregated"`
 }
 
 func newOptions() *Options {

--- a/statsd/dual.go
+++ b/statsd/dual.go
@@ -2,20 +2,20 @@ package statsd
 
 import "time"
 
-// MultiClient is a client that emits to multiple underlying clients.
-type MultiClient []Client
+type multiClient []Client
 
-var _ Client = MultiClient(nil)
+// MultiClient combines multiple Clients into a single Client.
+func MultiClient(clients ...Client) Client {
+	return multiClient(clients)
+}
 
-// Inc imlements Client.Inc.
-func (mc MultiClient) Inc(stat string) {
+func (mc multiClient) Inc(stat string) {
 	for _, c := range mc {
 		c.Inc(stat)
 	}
 }
 
-// Timing imlements Client.Timing.
-func (mc MultiClient) Timing(stat string, d time.Duration) {
+func (mc multiClient) Timing(stat string, d time.Duration) {
 	for _, c := range mc {
 		c.Timing(stat, d)
 	}

--- a/statsd/dual.go
+++ b/statsd/dual.go
@@ -1,0 +1,22 @@
+package statsd
+
+import "time"
+
+// MultiClient is a client that emits to multiple underlying clients.
+type MultiClient []Client
+
+var _ Client = MultiClient(nil)
+
+// Inc imlements Client.Inc.
+func (mc MultiClient) Inc(stat string) {
+	for _, c := range mc {
+		c.Inc(stat)
+	}
+}
+
+// Timing imlements Client.Timing.
+func (mc MultiClient) Timing(stat string, d time.Duration) {
+	for _, c := range mc {
+		c.Timing(stat, d)
+	}
+}

--- a/statsd/dual_test.go
+++ b/statsd/dual_test.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestDual(t *testing.T) {
+func TestMulti(t *testing.T) {
 	origUserEnv := os.Getenv("USER")
 	defer os.Setenv("USER", origUserEnv)
 	os.Setenv("USER", "tester")
@@ -26,7 +26,7 @@ func TestDual(t *testing.T) {
 	c2, err := NewClient(zap.NewNop(), s.Addr().String(), "c2", "foo")
 	require.NoError(t, err, "Failed to create client")
 
-	mc := MultiClient{c1, c2}
+	mc := MultiClient(c1, c2)
 	mc.Inc("c")
 	mc.Timing("t", time.Millisecond)
 

--- a/statsd/dual_test.go
+++ b/statsd/dual_test.go
@@ -1,0 +1,46 @@
+package statsd
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go/testutils"
+	"github.com/yarpc/yab/statsd/statsdtest"
+	"go.uber.org/zap"
+)
+
+func TestDual(t *testing.T) {
+	origUserEnv := os.Getenv("USER")
+	defer os.Setenv("USER", origUserEnv)
+	os.Setenv("USER", "tester")
+
+	s := statsdtest.NewServer(t)
+	defer s.Close()
+
+	c1, err := NewClient(zap.NewNop(), s.Addr().String(), "c1", "foo")
+	require.NoError(t, err, "Failed to create client")
+
+	c2, err := NewClient(zap.NewNop(), s.Addr().String(), "c2", "foo")
+	require.NoError(t, err, "Failed to create client")
+
+	mc := MultiClient{c1, c2}
+	mc.Inc("c")
+	mc.Timing("t", time.Millisecond)
+
+	want := map[string]int{
+		"yab.tester.c1.foo.c": 1,
+		"yab.tester.c2.foo.c": 1,
+
+		"yab.tester.c1.foo.t": 1,
+		"yab.tester.c2.foo.t": 1,
+	}
+
+	require.True(t, testutils.WaitFor(time.Second, func() bool {
+		return len(s.Aggregated()) >= len(want)
+	}), "did not receive expected stats")
+
+	assert.Equal(t, want, s.Aggregated(), "unexpected stats")
+}

--- a/statsd/prefix.go
+++ b/statsd/prefix.go
@@ -1,0 +1,24 @@
+package statsd
+
+import "time"
+
+type prefixClient struct {
+	client Client
+	prefix string
+}
+
+// NewPrefixedClient wraps the provided client to add a prefix to all calls.
+func NewPrefixedClient(client Client, prefix string) Client {
+	return &prefixClient{
+		client: client,
+		prefix: prefix,
+	}
+}
+
+func (pc prefixClient) Inc(stat string) {
+	pc.client.Inc(pc.prefix + stat)
+}
+
+func (pc prefixClient) Timing(stat string, d time.Duration) {
+	pc.client.Timing(pc.prefix+stat, d)
+}

--- a/statsd/prefix_test.go
+++ b/statsd/prefix_test.go
@@ -1,0 +1,47 @@
+package statsd
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go/testutils"
+	"github.com/yarpc/yab/statsd/statsdtest"
+	"go.uber.org/zap"
+)
+
+func TestPrefixClient(t *testing.T) {
+	origUserEnv := os.Getenv("USER")
+	defer os.Setenv("USER", origUserEnv)
+	os.Setenv("USER", "tester")
+
+	s := statsdtest.NewServer(t)
+	defer s.Close()
+
+	c1, err := NewClient(zap.NewNop(), s.Addr().String(), "c1", "foo")
+	require.NoError(t, err, "Failed to create client")
+
+	c2 := NewPrefixedClient(c1, "prefix.")
+
+	c1.Inc("c")
+	c2.Inc("c")
+
+	c1.Timing("t", time.Millisecond)
+	c2.Timing("t", time.Millisecond)
+
+	want := map[string]int{
+		"yab.tester.c1.foo.c":        1,
+		"yab.tester.c1.foo.prefix.c": 1,
+
+		"yab.tester.c1.foo.t":        1,
+		"yab.tester.c1.foo.prefix.t": 1,
+	}
+
+	require.True(t, testutils.WaitFor(time.Second, func() bool {
+		return len(s.Aggregated()) >= len(want)
+	}), "did not receive expected stats")
+
+	assert.Equal(t, want, s.Aggregated(), "unexpected stats")
+}

--- a/statsd/statsdtest/server.go
+++ b/statsd/statsdtest/server.go
@@ -1,0 +1,103 @@
+package statsdtest
+
+import (
+	"math"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/cactus/go-statsd-client/statsd/statsdtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Server represents an in-memory statsd server for testing.
+type Server struct {
+	t       *testing.T
+	ln      net.PacketConn
+	sender  *statsdtest.RecordingSender
+	running sync.WaitGroup
+}
+
+// NewServer creates a new in-memory statsd server for testing.
+func NewServer(t *testing.T) *Server {
+	sender := statsdtest.NewRecordingSender()
+
+	ln, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err, "Failed to create UDP listener")
+
+	s := &Server{
+		t:      t,
+		ln:     ln,
+		sender: sender,
+	}
+
+	s.running.Add(1)
+	go s.run()
+	return s
+}
+
+func (s *Server) run() {
+	defer s.running.Done()
+
+	// UDP uses 16 bits for the length, so this is the max packet size.
+	buf := make([]byte, math.MaxUint16)
+
+	for {
+		n, _, err := s.ln.ReadFrom(buf)
+		if nerr, ok := err.(net.Error); ok && !nerr.Temporary() {
+			return
+		}
+
+		_, err = s.sender.Send(buf[:n])
+		assert.NoError(s.t, err, "Failed to Send to recording sender")
+	}
+}
+
+// Addr returns the net.Addr that the UDP server is listening on.
+func (s *Server) Addr() net.Addr {
+	return s.ln.LocalAddr()
+}
+
+// Close stops the listener.
+func (s *Server) Close() {
+	s.ln.Close()
+	s.running.Wait()
+}
+
+// Stats returns all stats that have been received by this server, keeping only Stat and Value.
+func (s *Server) Stats() statsdtest.Stats {
+	rawStats := s.sender.GetSent()
+	stats := make(statsdtest.Stats, len(rawStats))
+	for i, s := range rawStats {
+		stats[i] = statsdtest.Stat{
+			Stat:  s.Stat,
+			Value: s.Value,
+		}
+	}
+	return stats
+}
+
+// Aggregated returns an aggregated stats value.
+func (s *Server) Aggregated() map[string]int {
+	aggregated := make(map[string]int)
+	for _, stat := range s.sender.GetSent() {
+
+		switch stat.Tag {
+		case "c", "g":
+			v, err := strconv.Atoi(stat.Value)
+			require.NoError(s.t, err, "failed to convert %v: %v", stat.Stat, stat.Value)
+
+			if stat.Tag == "c" {
+				aggregated[stat.Stat] += v
+			} else {
+				aggregated[stat.Stat] = v
+			}
+		case "ms":
+			aggregated[stat.Stat]++
+		}
+	}
+
+	return aggregated
+}

--- a/statsd/statsdtest/server_test.go
+++ b/statsd/statsdtest/server_test.go
@@ -1,0 +1,54 @@
+package statsdtest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/cactus/go-statsd-client/statsd"
+	"github.com/cactus/go-statsd-client/statsd/statsdtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
+)
+
+func TestServer(t *testing.T) {
+	server := NewServer(t)
+	defer server.Close()
+
+	client, err := statsd.NewClient(server.Addr().String(), "client")
+	require.NoError(t, err, "failed to create client")
+
+	err = multierr.Combine(
+		client.Inc("counter", 1, 1.0),
+		client.Inc("counter", 2, 1.0),
+		client.Gauge("gauge", 3, 1.0),
+		client.Gauge("gauge", 5, 1.0),
+		client.Timing("timer", 100, 1.0),
+		client.Timing("timer", 150, 1.0),
+	)
+	require.NoError(t, err, "failed to emit metrics")
+
+	want := statsdtest.Stats{
+		{Stat: "client.counter", Value: "1"},
+		{Stat: "client.counter", Value: "2"},
+		{Stat: "client.gauge", Value: "3"},
+		{Stat: "client.gauge", Value: "5"},
+		{Stat: "client.timer", Value: "100"},
+		{Stat: "client.timer", Value: "150"},
+	}
+	aggregated := map[string]int{
+		"client.counter": 3, // counters should be summed
+		"client.gauge":   5, // last gauge wins
+		"client.timer":   2, // timers only store counts
+	}
+
+	// Wait for the server to receive all the stats.
+	require.True(t, testutils.WaitFor(time.Second, func() bool {
+		return len(server.Stats()) == len(want)
+	}), "did not receive expected stats")
+
+	assert.Equal(t, want, server.Stats(), "unexpected stats")
+	assert.Equal(t, aggregated, server.Aggregated(), "unexpected aggregated stats")
+}


### PR DESCRIPTION
When a list of backends is slow, it's hard to figure out which backend is
slow when using the current metrics (which are aggregates).

Add a per-peer-stats option that will track metrics by peer rather than
aggregated together. This makes it significantly easier to find a single
slow peer.

This adds a few statsd utilities to add prefixes, dual emit, and to
simplify testing.