### PR TITLE
benchmark: Fix empty procedure for `--health`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+# Unreleased
+* Fix bug where benchmark stats were missing procedure if `--health` was used.
+
 # 0.14.3 (2019-04-16)
 * Fix bug where values specified in templates as `"y"` were being
   converted to true.

--- a/bench_method.go
+++ b/bench_method.go
@@ -70,6 +70,10 @@ func (m benchmarkMethod) call(t transport.Transport) (time.Duration, error) {
 	return duration, err
 }
 
+func (m benchmarkMethod) Method() string {
+	return m.req.Method
+}
+
 func peerBalancer(peers []string) func(i int) (string, int) {
 	numPeers := len(peers)
 	startOffset := rand.Intn(numPeers)

--- a/bench_method_test.go
+++ b/bench_method_test.go
@@ -37,11 +37,14 @@ import (
 )
 
 func benchmarkMethodForTest(t *testing.T, procedure string, p transport.Protocol) benchmarkMethod {
-	rOpts := RequestOptions{
+	return benchmarkMethodForROpts(t, RequestOptions{
 		Encoding:   encoding.Thrift,
 		ThriftFile: validThrift,
 		Procedure:  procedure,
-	}
+	}, p)
+}
+
+func benchmarkMethodForROpts(t *testing.T, rOpts RequestOptions, p transport.Protocol) benchmarkMethod {
 	serializer, err := NewSerializer(Options{ROpts: rOpts})
 	require.NoError(t, err, "Failed to create Thrift serializer")
 
@@ -292,4 +295,12 @@ func TestBenchmarkMethodWarmTransportsError(t *testing.T) {
 			assert.NoError(t, err, "%v: WarmTransports should succeed", msg)
 		}
 	}
+}
+
+func TestBenchmarkMethodHealth(t *testing.T) {
+	m := benchmarkMethodForROpts(t, RequestOptions{
+		Encoding: encoding.Thrift,
+		Health:   true,
+	}, transport.TChannel)
+	assert.Equal(t, "Meta::health", m.Method())
 }

--- a/benchmark.go
+++ b/benchmark.go
@@ -127,7 +127,7 @@ func runBenchmark(out output, logger *zap.Logger, allOpts Options, m benchmarkMe
 		out.Fatalf("Failed to warmup connections for benchmark: %v", err)
 	}
 
-	globalStatter, err := statsd.NewClient(logger, opts.StatsdHostPort, allOpts.TOpts.ServiceName, allOpts.ROpts.Procedure)
+	globalStatter, err := statsd.NewClient(logger, opts.StatsdHostPort, allOpts.TOpts.ServiceName, m.Method())
 	if err != nil {
 		out.Fatalf("Failed to create statsd client for benchmark: %v", err)
 	}


### PR DESCRIPTION
Currently, we use the passed in procedure name for stats. Instead, use
the method name on the created transport.Request object rather than
the flag.