### PR TITLE
Add error tracing to release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,7 +56,8 @@ RELEASE_ARGS=$(echo '{}' | \
 RELEASE_URL="https://api.github.com/repos/$GITHUB_REPO/releases"
 RELEASE_OUT=$(echo "$RELEASE_ARGS" | curl --user "$GITHUB_USER:$GITHUB_TOKEN" -X POST --data @- "$RELEASE_URL")
 
-echo "Release to $RELEASE_URL got:\n$RELEASE_OUT"
+echo "Release to $RELEASE_URL got:"
+echo "  $RELEASE_OUT"
 
 UPLOADS_URL=$(echo "$RELEASE_OUT" | \
     jq -e -r '.upload_url' | \


### PR DESCRIPTION
The release script failed again:
https://travis-ci.com/yarpc/yab/jobs/214229866

It's not clear why it failed, since the error doesn't have much
information:
"Script failed with status 1"

I tried to reproduce locally but the release succeeded. Separate the
commands and use error tracing to better understand the error. Error
tracing from:
https://unix.stackexchange.com/questions/462156/how-do-i-find-the-line-number-in-bash-when-an-error-occured