### PR TITLE
Fix proto serialization from yaml templates

### DIFF
--- a/encoding/protobuf_test.go
+++ b/encoding/protobuf_test.go
@@ -103,6 +103,11 @@ func TestProtobufRequest(t *testing.T) {
 			bsIn:  []byte(`test: 10`),
 			bsOut: []byte{0x8, 0xA},
 		},
+		{
+			desc:   "fail with unsupported yaml",
+			bsIn:   []byte(`yaml: {1: x, 2: y}`),
+			errMsg: "json: unsupported type",
+		},
 	}
 
 	source, err := protobuf.NewDescriptorProviderFileDescriptorSetBins("../testdata/protobuf/simple/simple.proto.bin")

--- a/encoding/protobuf_test.go
+++ b/encoding/protobuf_test.go
@@ -76,7 +76,7 @@ func TestProtobufRequest(t *testing.T) {
 		{
 			desc:   "invalid json",
 			bsIn:   []byte("{"),
-			errMsg: `could not parse given request body as message of type "Foo"`,
+			errMsg: `did not find expected node content`,
 		},
 		{
 			desc:   "invalid field in request input",
@@ -96,6 +96,11 @@ func TestProtobufRequest(t *testing.T) {
 		{
 			desc:  "pass with field",
 			bsIn:  []byte(`{"test":10}`),
+			bsOut: []byte{0x8, 0xA},
+		},
+		{
+			desc:  "pass with yaml",
+			bsIn:  []byte(`test: 10`),
 			bsOut: []byte{0x8, 0xA},
 		},
 	}

--- a/grpc_server_util_test.go
+++ b/grpc_server_util_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+const _grpcService = "yab-grpc-test"
+
+type grpcServer struct {
+	ln            net.Listener
+	server        *grpc.Server
+	healthHandler *health.Server
+}
+
+func newGRPCServer(t *testing.T) *grpcServer {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "Failed to create TCP listener")
+
+	server := grpc.NewServer()
+	healthHandler := health.NewServer()
+
+	grpc_health_v1.RegisterHealthServer(server, healthHandler)
+	reflection.Register(server)
+	s := &grpcServer{ln, server, healthHandler}
+	s.SetHealth(true /* serving */)
+
+	go server.Serve(ln)
+	return s
+}
+
+func (s *grpcServer) HostPort() string {
+	return s.ln.Addr().String()
+}
+
+func (s *grpcServer) SetHealth(serving bool) {
+	status := grpc_health_v1.HealthCheckResponse_NOT_SERVING
+	if serving {
+		status = grpc_health_v1.HealthCheckResponse_SERVING
+	}
+
+	s.healthHandler.SetServingStatus(_grpcService, status)
+}
+
+func (s *grpcServer) Stop() {
+	s.server.Stop()
+}

--- a/main_test.go
+++ b/main_test.go
@@ -299,6 +299,56 @@ func TestHealthIntegration(t *testing.T) {
 	main()
 }
 
+func TestGRPCHealthReflectionWithTemplate(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	// Create a server with the Meta::health endpoint.
+	server := newGRPCServer(t)
+	defer server.Stop()
+
+	templateContents, err := ioutil.ReadFile("./testdata/grpc_health.yab")
+	require.NoError(t, err, "failed to read template file")
+
+	templateContents = bytes.Replace(templateContents, []byte("PEERHOSTPORT"), []byte(server.HostPort()), -1)
+
+	templateFile, err := ioutil.TempFile("" /* dir */, "grpc_*_health.yab")
+	require.NoError(t, err, "Failed to create a temp file")
+
+	_, err = templateFile.Write(templateContents)
+	require.NoError(t, err, "failed to write replaced template")
+	require.NoError(t, templateFile.Close(), "failed to close template file")
+
+	os.Args = []string{
+		"yab",
+		"-y",
+		templateFile.Name(),
+	}
+
+	main()
+}
+
+func TestGRPCHealthReflection(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	// Create a server with the Meta::health endpoint.
+	server := newGRPCServer(t)
+	defer server.Stop()
+
+	os.Args = []string{
+		"yab",
+		"-p",
+		server.HostPort(),
+		_grpcService,
+		"grpc.health.v1.Health/Check",
+		"-r",
+		`{"service": "` + _grpcService + `"}`,
+	}
+
+	main()
+}
+
 func TestBenchmarkIntegration(t *testing.T) {
 	origArgs := os.Args
 	defer func() { os.Args = origArgs }()

--- a/testdata/grpc_health.yab
+++ b/testdata/grpc_health.yab
@@ -1,4 +1,5 @@
 service: yab-grpc-test
 peer: PEERHOSTPORT
 method: "grpc.health.v1.Health/Check"
-request: {"service": "yab-grpc-test"}
+request:
+  service: yab-grpc-test

--- a/testdata/grpc_health.yab
+++ b/testdata/grpc_health.yab
@@ -1,0 +1,4 @@
+service: yab-grpc-test
+peer: PEERHOSTPORT
+method: "grpc.health.v1.Health/Check"
+request: {"service": "yab-grpc-test"}


### PR DESCRIPTION
Previously we were interpreting the input to `Request(body []byte)` as
json, whereas it should be interpreted as Yaml. As proto  reflection only works on json, convert the yaml to json first and attempt to construct the proto payload from that.
