### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+# Unreleased
+* Support grpc/proto for `--health`.
+
 # 0.15.0 (2019-07-07)
 * Allow `null` in request templates to imply skipping the field.
 * Allow specifying HTTP method for HTTP requests using `--http-method`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 Changelog
 =========
 
-# Unreleased
-* Support grpc/proto for `--health`.
+# 0.16.0 (2019-09-09)
+* Add support for grpc/proto when using `--health`.
+* Fix bug that prevented yab templates to work with proto. Simple YAML yab
+  templates now work with proto, though not all template substitutions are
+  supported yet.
 
 # 0.15.0 (2019-07-07)
 * Allow `null` in request templates to imply skipping the field.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,16 @@ Application Options:
 
 Request Options:
   -e, --encoding=                The encoding of the data, options are: Thrift,
-                                 JSON, raw. Defaults to Thrift if the method
-                                 contains '::' or a Thrift file is specified
+                                 proto, JSON, raw. Defaults to Thrift if the
+                                 method contains '::' or a Thrift file is
+                                 specified. Defaults to proto if the method
+                                 contains '/' or a proto filedescriptorset is
+                                 specified
   -t, --thrift=                  Path of the .thrift file
-      --procedure=               The full Thrift method name (Svc::Method) to
-                                 invoke
+  -F, --file-descriptor-set-bin= A binary file containing a compiled protobuf
+                                 FileDescriptorSet.
+      --procedure=               The full method name to invoke (Thrift:
+                                 Svc::Method, Proto: package.Service/Method).
   -m, --method=                  Alias for procedure
   -r, --request=                 The request body, in JSON or YAML format
   -f, --file=                    Path of a file containing the request body in
@@ -64,7 +69,7 @@ Request Options:
   -A, --arg=                     A list of key-value template arguments,
                                  specified as -A foo:bar -A user:me
       --disable-thrift-envelope  Disables Thrift envelopes (disabled by default
-                                 for TChannel)
+                                 for TChannel and gRPC)
       --multiplexed-thrift       Enables the Thrift TMultiplexedProtocol used
                                  by services that host multiple Thrift services
                                  on a single endpoint.
@@ -88,6 +93,7 @@ Transport Options:
                                  style traces and baggage headers
   -T, --topt=                    Transport options for TChannel, protocol
                                  headers for HTTP
+      --http-method=             The HTTP method to use (default: POST)
 
 Benchmark Options:
   -n, --max-requests=            The maximum number of requests to make. 0
@@ -105,6 +111,8 @@ Benchmark Options:
                                  The default (0) is no limit. (default: 0)
       --statsd=                  Optional host:port of a StatsD server to
                                  report metrics
+      --per-peer-stats           Whether to emit stats by peer rather than
+                                 aggregated
 
 Help Options:
   -h, --help                     Show this help message

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -85,10 +85,11 @@ func TestEncodingGetHealth(t *testing.T) {
 		{Thrift, true},
 		{Raw, false},
 		{JSON, false},
+		{Protobuf, true},
 	}
 
 	for _, tt := range tests {
-		health, err := tt.encoding.GetHealth()
+		health, err := tt.encoding.GetHealth("")
 		if tt.success {
 			assert.NoError(t, err, "%v.GetHealth should succeed", tt.encoding)
 			assert.NotNil(t, health, "%v.GetHealth should succeed")
@@ -188,4 +189,17 @@ func TestJSONEncodingResponse(t *testing.T) {
 			assert.Nil(t, got, "Failed response should not return result")
 		}
 	}
+}
+
+func TestUnspecifiedHealthSerializer(t *testing.T) {
+	s := unspecifiedHealthSerializer{}
+	assert.Equal(t, UnspecifiedEncoding, s.Encoding())
+	bytes, err := s.Request(nil)
+	assert.Nil(t, bytes)
+	assert.Error(t, err, errUnspecifiedHealthSerializer.Error())
+	obj, err := s.Response(nil)
+	assert.Nil(t, obj)
+	assert.Error(t, err, errUnspecifiedHealthSerializer.Error())
+	err = s.CheckSuccess(nil)
+	assert.Error(t, err, errUnspecifiedHealthSerializer.Error())
 }

--- a/encoding/protobuf_health.go
+++ b/encoding/protobuf_health.go
@@ -1,0 +1,56 @@
+package encoding
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/yarpc/yab/transport"
+	"go.uber.org/yarpc/pkg/procedure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+type protoHealthSerializer struct {
+	serviceName string
+}
+
+func (p protoHealthSerializer) Encoding() Encoding {
+	return Protobuf
+}
+
+func (p protoHealthSerializer) Request(body []byte) (*transport.Request, error) {
+	if len(body) > 0 {
+		return nil, errors.New("cannot specify --health and a request body")
+	}
+	bytes, err := proto.Marshal(&grpc_health_v1.HealthCheckRequest{Service: p.serviceName})
+	if err != nil {
+		return nil, err
+	}
+	return &transport.Request{
+		Method: procedure.ToName("grpc.health.v1.Health", "Check"),
+		Body:   bytes,
+	}, nil
+}
+
+func (p protoHealthSerializer) Response(body *transport.Response) (interface{}, error) {
+	var msg grpc_health_v1.HealthCheckResponse
+	if err := proto.Unmarshal(body.Body, &msg); err != nil {
+		return nil, err
+	}
+	m := jsonpb.Marshaler{}
+	str, err := m.MarshalToString(&msg)
+	if err != nil {
+		return nil, err
+	}
+	var unmarshaledJSON json.RawMessage
+	if err = json.Unmarshal([]byte(str), &unmarshaledJSON); err != nil {
+		return nil, err
+	}
+	return unmarshaledJSON, nil
+}
+
+func (p protoHealthSerializer) CheckSuccess(body *transport.Response) error {
+	_, err := p.Response(body)
+	return err
+}

--- a/encoding/protobuf_health_test.go
+++ b/encoding/protobuf_health_test.go
@@ -1,0 +1,106 @@
+package encoding
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yarpc/yab/transport"
+)
+
+func TestProtobufHealth(t *testing.T) {
+	s := &protoHealthSerializer{}
+	assert.Equal(t, Protobuf, s.Encoding())
+}
+
+func TestProtobufHealthRequest(t *testing.T) {
+	tests := []struct {
+		desc        string
+		serviceName string
+		reqBody     []byte
+		bsOut       []byte
+		errMsg      string
+	}{
+		{
+			desc:  "empty",
+			bsOut: []byte{},
+		},
+		{
+			desc:        "no input",
+			serviceName: "x",
+			reqBody:     []byte("x"),
+			errMsg:      "cannot specify --health and a request body",
+		},
+		{
+			desc:        "pass",
+			serviceName: "x",
+			bsOut:       []byte{0xa, 0x1, 0x78},
+		},
+		{
+			desc:        "fail",
+			serviceName: string([]byte{0xc3, 0x28}),
+			errMsg:      "proto: invalid UTF-8 string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			serializer := &protoHealthSerializer{serviceName: tt.serviceName}
+			got, err := serializer.Request(tt.reqBody)
+			if tt.errMsg == "" {
+				assert.NoError(t, err, "%v", tt.desc)
+				require.NotNil(t, got, "%v: Invalid request")
+				assert.Equal(t, tt.bsOut, got.Body)
+			} else {
+				assert.Nil(t, got, "%v: Error cases should not return any bytes", tt.desc)
+				require.Error(t, err, "%v", tt.desc)
+				assert.Contains(t, err.Error(), tt.errMsg, "%v: invalid error", tt.desc)
+			}
+		})
+	}
+}
+
+func TestProtobufHealthResponse(t *testing.T) {
+	tests := []struct {
+		desc      string
+		reqBody   []byte
+		outAsJSON string
+		errMsg    string
+	}{
+		{
+			desc:      "pass",
+			reqBody:   nil,
+			outAsJSON: "{}",
+		},
+		{
+			desc:    "fail",
+			reqBody: []byte{0x1, 0x2},
+			errMsg:  "illegal tag",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			serializer := &protoHealthSerializer{}
+			response := &transport.Response{
+				Body: tt.reqBody,
+			}
+			got, err := serializer.Response(response)
+			if tt.errMsg == "" {
+				assert.NoError(t, err, "%v", tt.desc)
+				assert.NotNil(t, got, "%v: Invalid request")
+				r, err := json.Marshal(got)
+				assert.NoError(t, err)
+				assert.JSONEq(t, tt.outAsJSON, string(r))
+
+				err = serializer.CheckSuccess(response)
+				assert.NoError(t, err)
+			} else {
+				assert.Nil(t, got, "%v: Error cases should not return any bytes", tt.desc)
+				require.Error(t, err, "%v", tt.desc)
+				assert.Contains(t, err.Error(), tt.errMsg, "%v: invalid error", tt.desc)
+			}
+		})
+	}
+}

--- a/encoding/protobuf_test.go
+++ b/encoding/protobuf_test.go
@@ -76,7 +76,7 @@ func TestProtobufRequest(t *testing.T) {
 		{
 			desc:   "invalid json",
 			bsIn:   []byte("{"),
-			errMsg: `could not parse given request body as message of type "Foo"`,
+			errMsg: `did not find expected node content`,
 		},
 		{
 			desc:   "invalid field in request input",
@@ -97,6 +97,16 @@ func TestProtobufRequest(t *testing.T) {
 			desc:  "pass with field",
 			bsIn:  []byte(`{"test":10}`),
 			bsOut: []byte{0x8, 0xA},
+		},
+		{
+			desc:  "pass with yaml",
+			bsIn:  []byte(`test: 10`),
+			bsOut: []byte{0x8, 0xA},
+		},
+		{
+			desc:   "fail with unsupported yaml",
+			bsIn:   []byte(`yaml: {1: x, 2: y}`),
+			errMsg: "json: unsupported type",
 		},
 	}
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,6 +22,8 @@ import:
   version: ^1.21
 - package: github.com/jhump/protoreflect
   version: a84568470d8add1307a0f1d8a3afcc4dfe7c4dd0
+- package: google.golang.org/grpc
+  version: ^1.14
 - package: golang.org/x/sys
 testImport:
 - package: github.com/apache/thrift

--- a/grpc_server_util_test.go
+++ b/grpc_server_util_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+const _grpcService = "yab-grpc-test"
+
+type grpcServer struct {
+	ln            net.Listener
+	server        *grpc.Server
+	healthHandler *health.Server
+}
+
+func newGRPCServer(t *testing.T) *grpcServer {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "Failed to create TCP listener")
+
+	server := grpc.NewServer()
+	healthHandler := health.NewServer()
+
+	grpc_health_v1.RegisterHealthServer(server, healthHandler)
+	reflection.Register(server)
+	s := &grpcServer{ln, server, healthHandler}
+	s.SetHealth(true /* serving */)
+
+	go server.Serve(ln)
+	return s
+}
+
+func (s *grpcServer) HostPort() string {
+	return s.ln.Addr().String()
+}
+
+func (s *grpcServer) SetHealth(serving bool) {
+	status := grpc_health_v1.HealthCheckResponse_NOT_SERVING
+	if serving {
+		status = grpc_health_v1.HealthCheckResponse_SERVING
+	}
+
+	s.healthHandler.SetServingStatus(_grpcService, status)
+}
+
+func (s *grpcServer) Stop() {
+	s.server.Stop()
+}

--- a/main_test.go
+++ b/main_test.go
@@ -349,6 +349,46 @@ func TestGRPCHealthReflection(t *testing.T) {
 	main()
 }
 
+func TestHealthIntegrationProtobuf(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	// Create a server with the Meta::health endpoint.
+	server := newGRPCServer(t)
+	defer server.Stop()
+
+	os.Args = []string{
+		"yab",
+		"-p",
+		"grpc://" + server.HostPort(),
+		_grpcService,
+		"--health",
+	}
+
+	main()
+}
+
+func TestHealthIntegrationProtobufExplicitProtocol(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	// Create a server with the Meta::health endpoint.
+	server := newGRPCServer(t)
+	defer server.Stop()
+
+	os.Args = []string{
+		"yab",
+		"-e",
+		"proto",
+		"-p",
+		server.HostPort(),
+		_grpcService,
+		"--health",
+	}
+
+	main()
+}
+
 func TestBenchmarkIntegration(t *testing.T) {
 	origArgs := os.Args
 	defer func() { os.Args = origArgs }()

--- a/main_test.go
+++ b/main_test.go
@@ -299,6 +299,56 @@ func TestHealthIntegration(t *testing.T) {
 	main()
 }
 
+func TestGRPCHealthReflectionWithTemplate(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	// Create a server with the Meta::health endpoint.
+	server := newGRPCServer(t)
+	defer server.Stop()
+
+	templateContents, err := ioutil.ReadFile("./testdata/grpc_health.yab")
+	require.NoError(t, err, "failed to read template file")
+
+	templateContents = bytes.Replace(templateContents, []byte("PEERHOSTPORT"), []byte(server.HostPort()), -1)
+
+	templateFile, err := ioutil.TempFile("" /* dir */, "grpc_*_health.yab")
+	require.NoError(t, err, "Failed to create a temp file")
+
+	_, err = templateFile.Write(templateContents)
+	require.NoError(t, err, "failed to write replaced template")
+	require.NoError(t, templateFile.Close(), "failed to close template file")
+
+	os.Args = []string{
+		"yab",
+		"-y",
+		templateFile.Name(),
+	}
+
+	main()
+}
+
+func TestGRPCHealthReflection(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	// Create a server with the Meta::health endpoint.
+	server := newGRPCServer(t)
+	defer server.Stop()
+
+	os.Args = []string{
+		"yab",
+		"-p",
+		server.HostPort(),
+		_grpcService,
+		"grpc.health.v1.Health/Check",
+		"-r",
+		`{"service": "` + _grpcService + `"}`,
+	}
+
+	main()
+}
+
 func TestBenchmarkIntegration(t *testing.T) {
 	origArgs := os.Args
 	defer func() { os.Args = origArgs }()

--- a/man/yab.1
+++ b/man/yab.1
@@ -1,4 +1,4 @@
-.TH yab 1 "6 September 2017"
+.TH yab 1 "5 September 2019"
 .SH NAME
 yab \- yet another benchmarker
 .SH SYNOPSIS
@@ -119,6 +119,23 @@ Or it can be loaded from a file using -f or --file:
 $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Get --file req.yaml
 .RE
 .fi
+.PP
+To make a proto requrest, specify a compiled FileDescriptorSet and pass the
+fully qualified service an method name as procedure.
+.PP
+.nf
+.RS
+$ yab -p localhost:5435 --file-descriptor-set-bin proto.bin \\
+.RE
+.fi
+.nf
+.RS
+    service package.Service/Method -r '{"key": "value"}'
+.RE
+.fi
+.PP
+A FileDescriptorSet can be generated using the --descriptor_set_out= flag
+in protoc.
 .PP
 Request options can also be specified in a YAML file, e.g., get.yab:
 .PP
@@ -290,13 +307,16 @@ $ yab -p localhost:9787 -t kv.thrift kv KeyValue::Set \\
 
 .TP
 \fB\fB\-e\fR, \fB\-\-encoding\fR\fP
-The encoding of the data, options are: Thrift, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified
+The encoding of the data, options are: Thrift, proto, JSON, raw. Defaults to Thrift if the method contains '::' or a Thrift file is specified. Defaults to proto if the method contains '/' or a proto filedescriptorset is specified
 .TP
 \fB\fB\-t\fR, \fB\-\-thrift\fR\fP
 Path of the .thrift file
 .TP
+\fB\fB\-F\fR, \fB\-\-file-descriptor-set-bin\fR\fP
+A binary file containing a compiled protobuf FileDescriptorSet.
+.TP
 \fB\fB\-\-procedure\fR\fP
-The full Thrift method name (Svc::Method) to invoke
+The full method name to invoke (Thrift: Svc::Method, Proto: package.Service/Method).
 .TP
 \fB\fB\-m\fR, \fB\-\-method\fR\fP
 Alias for procedure
@@ -332,7 +352,7 @@ Send a tchannel request specified by a YAML template
 A list of key-value template arguments, specified as -A foo:bar -A user:me
 .TP
 \fB\fB\-\-disable-thrift-envelope\fR\fP
-Disables Thrift envelopes (disabled by default for TChannel)
+Disables Thrift envelopes (disabled by default for TChannel and gRPC)
 .TP
 \fB\fB\-\-multiplexed-thrift\fR\fP
 Enables the Thrift TMultiplexedProtocol used by services that host multiple Thrift services on a single endpoint.
@@ -404,6 +424,9 @@ Use the Jaeger tracing client to send Uber style traces and baggage headers
 .TP
 \fB\fB\-T\fR, \fB\-\-topt\fR\fP
 Transport options for TChannel, protocol headers for HTTP
+.TP
+\fB\fB\-\-http-method\fR\fP
+The HTTP method to use
 .SS Benchmark Options
 Configures benchmarking, which is disabled by default.
 .PP
@@ -455,6 +478,9 @@ Limit on the number of requests per second. The default (0) is no limit.
 .TP
 \fB\fB\-\-statsd\fR\fP
 Optional host:port of a StatsD server to report metrics
+.TP
+\fB\fB\-\-per-peer-stats\fR\fP
+Whether to emit stats by peer rather than aggregated
 .SS Help Options
 .TP
 \fB\fB\-h\fR, \fB\-\-help\fR\fP

--- a/man/yab.html
+++ b/man/yab.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.19.2 -->
-<!-- CreationDate: Wed Sep  6 07:19:56 2017 -->
+<!-- CreationDate: Thu Sep  5 16:51:11 2019 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -156,6 +156,19 @@ loaded from a file using -f or --file:</p>
 localhost:9787 -t kv.thrift kv KeyValue::Get --file
 req.yaml</p>
 
+<p style="margin-left:11%; margin-top: 1em">To make a proto
+requrest, specify a compiled FileDescriptorSet and pass the
+fully qualified service an method name as procedure.</p>
+
+<p style="margin-left:22%; margin-top: 1em">$ yab -p
+localhost:5435 --file-descriptor-set-bin proto.bin \ <br>
+service package.Service/Method -r &rsquo;{&quot;key&quot;:
+&quot;value&quot;}&rsquo;</p>
+
+<p style="margin-left:11%; margin-top: 1em">A
+FileDescriptorSet can be generated using the
+--descriptor_set_out= flag in protoc.</p>
+
 <p style="margin-left:11%; margin-top: 1em">Request options
 can also be specified in a YAML file, e.g., get.yab:</p>
 
@@ -279,8 +292,10 @@ localhost:9787 -t kv.thrift kv KeyValue::Set \ <br>
 <b>&minus;&minus;encoding</b></p>
 
 <p style="margin-left:22%;">The encoding of the data,
-options are: Thrift, JSON, raw. Defaults to Thrift if the
-method contains &rsquo;::&rsquo; or a Thrift file is
+options are: Thrift, proto, JSON, raw. Defaults to Thrift if
+the method contains &rsquo;::&rsquo; or a Thrift file is
+specified. Defaults to proto if the method contains
+&rsquo;/&rsquo; or a proto filedescriptorset is
 specified</p>
 
 <p style="margin-left:11%;"><b>&minus;t</b>,
@@ -288,11 +303,17 @@ specified</p>
 
 <p style="margin-left:22%;">Path of the .thrift file</p>
 
+<p style="margin-left:11%;"><b>&minus;F</b>,
+<b>&minus;&minus;file-descriptor-set-bin</b></p>
+
+<p style="margin-left:22%;">A binary file containing a
+compiled protobuf FileDescriptorSet.</p>
+
 
 <p style="margin-left:11%;"><b>&minus;&minus;procedure</b></p>
 
-<p style="margin-left:22%;">The full Thrift method name
-(Svc::Method) to invoke</p>
+<p style="margin-left:22%;">The full method name to invoke
+(Thrift: Svc::Method, Proto: package.Service/Method).</p>
 
 <p style="margin-left:11%;"><b>&minus;m</b>,
 <b>&minus;&minus;method</b></p>
@@ -364,7 +385,7 @@ arguments, specified as -A foo:bar -A user:me</p>
 <p style="margin-left:11%;"><b>&minus;&minus;disable-thrift-envelope</b></p>
 
 <p style="margin-left:22%;">Disables Thrift envelopes
-(disabled by default for TChannel)</p>
+(disabled by default for TChannel and gRPC)</p>
 
 
 <p style="margin-left:11%;"><b>&minus;&minus;multiplexed-thrift</b></p>
@@ -490,6 +511,11 @@ to send Uber style traces and baggage headers</p>
 <p style="margin-left:22%;">Transport options for TChannel,
 protocol headers for HTTP</p>
 
+
+<p style="margin-left:11%;"><b>&minus;&minus;http-method</b></p>
+
+<p style="margin-left:22%;">The HTTP method to use</p>
+
 <p style="margin-left:11%; margin-top: 1em"><b>Benchmark
 Options</b> <br>
 Configures benchmarking, which is disabled by default.</p>
@@ -586,6 +612,12 @@ per second. The default (0) is no limit.</p>
 
 <p style="margin-left:22%;">Optional host:port of a StatsD
 server to report metrics</p>
+
+
+<p style="margin-left:11%;"><b>&minus;&minus;per-peer-stats</b></p>
+
+<p style="margin-left:22%;">Whether to emit stats by peer
+rather than aggregated</p>
 
 <p style="margin-left:11%; margin-top: 1em"><b>Help Options
 <br>

--- a/request.go
+++ b/request.go
@@ -92,7 +92,7 @@ func NewSerializer(opts Options) (encoding.Serializer, error) {
 			return nil, errHealthAndProcedure
 		}
 
-		return opts.ROpts.Encoding.GetHealth()
+		return opts.ROpts.Encoding.GetHealth(opts.TOpts.ServiceName)
 	}
 
 	// Thrift returns available methods if one is not specified, while the other

--- a/request_test.go
+++ b/request_test.go
@@ -204,17 +204,22 @@ func TestNewSerializer(t *testing.T) {
 		{
 			encoding: encoding.JSON,
 			opts:     RequestOptions{Health: true},
-			wantErr:  encoding.ErrHealthThriftOnly.Error(),
+			wantErr:  `--health not supported with encoding "json"`,
 		},
 		{
 			encoding: encoding.Raw,
 			opts:     RequestOptions{Health: true},
-			wantErr:  encoding.ErrHealthThriftOnly.Error(),
+			wantErr:  `--health not supported with encoding "raw"`,
 		},
 		{
 			encoding: encoding.Thrift,
 			opts:     RequestOptions{Health: true},
 			want:     encoding.Thrift,
+		},
+		{
+			encoding: encoding.Protobuf,
+			opts:     RequestOptions{Health: true},
+			want:     encoding.Protobuf,
 		},
 		{
 			encoding: encoding.Thrift,
@@ -232,7 +237,7 @@ func TestNewSerializer(t *testing.T) {
 		{
 			encoding: encoding.UnspecifiedEncoding,
 			opts:     RequestOptions{Health: true},
-			want:     encoding.Thrift,
+			want:     encoding.UnspecifiedEncoding,
 		},
 		{
 			encoding: encoding.UnspecifiedEncoding,

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euo pipefail -o errtrace -o functrace
 IFS=$'\n\t'
 
 die() {
@@ -24,6 +24,15 @@ if [ -z "$VERSION" ]; then
   die "USAGE: $0 VERSION"
 fi
 
+# Make it easier to debug failures
+failure() {
+  local lineno=$1
+  local msg=$2
+  echo "Failed at $lineno: $msg"
+}
+trap 'failure ${LINENO} "$BASH_COMMAND"' ERR
+
+
 ./scripts/cross_build.sh "$VERSION"
 
 CHANGELOG=$(go run scripts/extract_changelog.go "$VERSION")
@@ -34,8 +43,7 @@ echo "CHANGELOG:"
 echo "$CHANGELOG"
 echo ""
 
-UPLOADS_URL=$( \
-  echo '{}' | \
+RELEASE_ARGS=$(echo '{}' | \
     jq -Mr \
       --arg version "$VERSION" \
       --arg changelog "$CHANGELOG" \
@@ -43,9 +51,15 @@ UPLOADS_URL=$( \
         tag_name: $version,
         name: $version,
         body: $changelog,
-      }' | \
-    curl --user "$GITHUB_USER:$GITHUB_TOKEN" -X POST --data @- \
-      "https://api.github.com/repos/$GITHUB_REPO/releases" | \
+      }')
+
+RELEASE_URL="https://api.github.com/repos/$GITHUB_REPO/releases"
+RELEASE_OUT=$(echo "$RELEASE_ARGS" | curl --user "$GITHUB_USER:$GITHUB_TOKEN" -X POST --data @- "$RELEASE_URL")
+
+echo "Release to $RELEASE_URL got:"
+echo "  $RELEASE_OUT"
+
+UPLOADS_URL=$(echo "$RELEASE_OUT" | \
     jq -e -r '.upload_url' | \
 
     # The UPLOADS_URL has a strange {?name,label} as a suffix that we need to remove.

--- a/testdata/grpc_health.yab
+++ b/testdata/grpc_health.yab
@@ -1,0 +1,5 @@
+service: yab-grpc-test
+peer: PEERHOSTPORT
+method: "grpc.health.v1.Health/Check"
+request:
+  service: yab-grpc-test

--- a/transport/grpc.go
+++ b/transport/grpc.go
@@ -42,7 +42,6 @@ var (
 	errGRPCNoTracer    = errors.New("must specify grpc tracer")
 	errGRPCNoCaller    = errors.New("must specify grpc caller")
 	errGRPCNoService   = errors.New("must specify grpc service")
-	errGRPCNoEncoding  = errors.New("must specify grpc encoding")
 	errGRPCNoProcedure = errors.New("must specify grpc procedure")
 )
 
@@ -80,9 +79,6 @@ func newGRPC(options GRPCOptions) (*grpcTransport, error) {
 	}
 	if options.Caller == "" {
 		return nil, errGRPCNoCaller
-	}
-	if options.Encoding == "" {
-		return nil, errGRPCNoEncoding
 	}
 
 	transport := grpc.NewTransport(grpc.Tracer(options.Tracer))

--- a/transport/grpc_test.go
+++ b/transport/grpc_test.go
@@ -81,16 +81,6 @@ func TestGRPCConstructor(t *testing.T) {
 			},
 			wantErr: errGRPCNoCaller,
 		},
-		{
-			options: GRPCOptions{
-				Addresses: []string{
-					"1:1:1:1:2345",
-				},
-				Tracer: opentracing.NoopTracer{},
-				Caller: "example-caller",
-			},
-			wantErr: errGRPCNoEncoding,
-		},
 	}
 	for _, tt := range tests {
 		_, err := NewGRPC(tt.options)

--- a/version.go
+++ b/version.go
@@ -22,4 +22,4 @@ package main
 
 // versionString is the sem-ver version string for yab.
 // It will be bumped explicitly on releases.
-var versionString = "0.15.0"
+var versionString = "0.16.0"


### PR DESCRIPTION
* Add support for grpc/proto when using `--health`.
* Fix bug that prevented yab templates to work with proto. Simple YAML yab
  templates now work with proto, though not all template substitutions are
  supported yet.