### PR TITLE
Use helper library for yaml to json conversion

### DIFF
--- a/encoding/protobuf.go
+++ b/encoding/protobuf.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/yarpc/yab/protobuf"
 	"github.com/yarpc/yab/transport"
-	"github.com/yarpc/yab/unmarshal"
 
+	"github.com/ghodss/yaml"
 	"github.com/golang/protobuf/proto"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/dynamic"
@@ -55,12 +55,7 @@ func (p protoSerializer) Encoding() Encoding {
 }
 
 func (p protoSerializer) Request(body []byte) (*transport.Request, error) {
-	m, err := unmarshal.YAML(body)
-	if err != nil {
-		return nil, err
-	}
-
-	json, err := json.Marshal(m)
+	json, err := yaml.YAMLToJSON(body)
 	if err != nil {
 		return nil, err
 	}

--- a/encoding/protobuf_test.go
+++ b/encoding/protobuf_test.go
@@ -104,9 +104,14 @@ func TestProtobufRequest(t *testing.T) {
 			bsOut: []byte{0x8, 0xA},
 		},
 		{
-			desc:   "fail with unsupported yaml",
-			bsIn:   []byte(`yaml: {1: x, 2: y}`),
-			errMsg: "json: unsupported type",
+			desc:  "nested yaml",
+			bsIn:  []byte(`{test: 1, nested: {value: 1}}`),
+			bsOut: []byte{0x8, 0x1, 0x12, 0x2, 0x8, 0x1},
+		},
+		{
+			desc:  "nested json",
+			bsIn:  []byte(`{"test": 1, "nested": {"value": 1}}`),
+			bsOut: []byte{0x8, 0x1, 0x12, 0x2, 0x8, 0x1},
 		},
 	}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f1a5f79e8de2c3e4cd01e48162825138799f83c93a456ea094b3423c89e20d7f
-updated: 2019-09-27T14:57:18.093679-07:00
+hash: 60f9b79605ed609f618305e67a3341e31c61df272871525e566f0c6dfaaeb062
+updated: 2019-09-27T16:38:16.846409-07:00
 imports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -26,6 +26,8 @@ imports:
   - spew
 - name: github.com/fatih/structtag
   version: 76ae1d6d2117609598c7d4e8f3e938145f204e8f
+- name: github.com/ghodss/yaml
+  version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/gogo/googleapis
   version: b8d18e97a9a193c846d32143391f6033a9d69849
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,6 +27,8 @@ import:
 - package: github.com/prometheus/procfs
   version: '>=0.0.1'
 - package: golang.org/x/sys
+- package: github.com/ghodss/yaml
+  version: ^1.0.0
 testImport:
 - package: github.com/apache/thrift
   version: '>=0.9.3, <0.11.0'

--- a/testdata/protobuf/simple/simple.proto
+++ b/testdata/protobuf/simple/simple.proto
@@ -1,7 +1,12 @@
 syntax = "proto3";
 
+message Nested {
+    int32 value = 1;
+}
+
 message Foo {
     int32 test = 1;
+    Nested nested = 2;
 }
 
 service Bar{

--- a/testdata/protobuf/simple/simple.proto.bin
+++ b/testdata/protobuf/simple/simple.proto.bin
@@ -1,7 +1,10 @@
 
-K
-simple.proto"
+Œ
+simple.proto"
+Nested
+value (Rvalue":
 Foo
-test (Rtest2
+test (Rtest
+nested (2.NestedRnested2
 Bar
 Baz.Foo.Foobproto3


### PR DESCRIPTION
#271 introduced an issue where we cannot parse nested json structs, as yaml unmarshalls into `map[struct{}]struct{}` even if all keys are strings.

Import a helper library to help with the conversion. Depends on #277.