### PR TITLE
Refactor transport & encoding detection

### DIFF
--- a/benchmark.go
+++ b/benchmark.go
@@ -92,7 +92,7 @@ func runWorker(t transport.Transport, m benchmarkMethod, s *benchmarkState, run 
 	}
 }
 
-func runBenchmark(out output, logger *zap.Logger, allOpts Options, m benchmarkMethod) {
+func runBenchmark(out output, logger *zap.Logger, allOpts Options, resolved resolvedProtocolEncoding, m benchmarkMethod) {
 	opts := allOpts.BOpts
 
 	if err := opts.validate(); err != nil {
@@ -122,7 +122,7 @@ func runBenchmark(out output, logger *zap.Logger, allOpts Options, m benchmarkMe
 
 	// Warm up number of connections.
 	logger.Debug("Warming up connections.", zap.Int("numConns", numConns))
-	connections, err := m.WarmTransports(numConns, allOpts.TOpts, opts.WarmupRequests)
+	connections, err := m.WarmTransports(numConns, allOpts.TOpts, resolved, opts.WarmupRequests)
 	if err != nil {
 		out.Fatalf("Failed to warmup connections for benchmark: %v", err)
 	}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -88,7 +88,7 @@ func TestBenchmark(t *testing.T) {
 				Concurrency: 2,
 			},
 			TOpts: s.transportOpts(),
-		}, m)
+		}, _resolvedTChannelThrift, m)
 
 		bufStr := buf.String()
 		assert.Contains(t, bufStr, "Max RPS")
@@ -144,7 +144,7 @@ func TestRunBenchmarkErrors(t *testing.T) {
 		// need to run the benchmark in a separate goroutine.
 		go func() {
 			defer wg.Done()
-			runBenchmark(out, _testLogger, opts, m)
+			runBenchmark(out, _testLogger, opts, _resolvedTChannelThrift, m)
 		}()
 
 		wg.Wait()
@@ -196,7 +196,7 @@ func TestBenchmarkStatsPerPeer(t *testing.T) {
 		ROpts: RequestOptions{
 			Procedure: fooMethod,
 		},
-	}, m)
+	}, _resolvedTChannelThrift, m)
 
 	// Ensure one backend gets more calls than the other
 	want := map[string]int{

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -81,7 +81,7 @@ func TestEncodingGetHealth(t *testing.T) {
 		encoding Encoding
 		success  bool
 	}{
-		{UnspecifiedEncoding, true},
+		{UnspecifiedEncoding, false},
 		{Thrift, true},
 		{Raw, false},
 		{JSON, false},
@@ -189,17 +189,4 @@ func TestJSONEncodingResponse(t *testing.T) {
 			assert.Nil(t, got, "Failed response should not return result")
 		}
 	}
-}
-
-func TestUnspecifiedHealthSerializer(t *testing.T) {
-	s := unspecifiedHealthSerializer{}
-	assert.Equal(t, UnspecifiedEncoding, s.Encoding())
-	bytes, err := s.Request(nil)
-	assert.Nil(t, bytes)
-	assert.Error(t, err, errUnspecifiedHealthSerializer.Error())
-	obj, err := s.Response(nil)
-	assert.Nil(t, obj)
-	assert.Error(t, err, errUnspecifiedHealthSerializer.Error())
-	err = s.CheckSuccess(nil)
-	assert.Error(t, err, errUnspecifiedHealthSerializer.Error())
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -438,6 +438,7 @@ func TestGRPCReflectionSource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			gotOut, gotErr := runTestWithOpts(tt.opts)
+			fmt.Println("got", gotErr)
 			assert.Contains(t, gotErr, tt.wantErr)
 			assert.Contains(t, gotOut, tt.wantRes)
 		})

--- a/integration_test.go
+++ b/integration_test.go
@@ -438,7 +438,6 @@ func TestGRPCReflectionSource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			gotOut, gotErr := runTestWithOpts(tt.opts)
-			fmt.Println("got", gotErr)
 			assert.Contains(t, gotErr, tt.wantErr)
 			assert.Contains(t, gotOut, tt.wantRes)
 		})

--- a/request_test.go
+++ b/request_test.go
@@ -23,7 +23,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -195,33 +194,39 @@ func TestNewSerializer(t *testing.T) {
 	defer s.Stop()
 
 	tests := []struct {
+		msg      string
 		encoding encoding.Encoding
 		opts     RequestOptions
-		topts    TransportOptions
 		want     encoding.Encoding
+		peers    []string
 		wantErr  string
 	}{
 		{
+			msg:      "json with --health",
 			encoding: encoding.JSON,
 			opts:     RequestOptions{Health: true},
 			wantErr:  `--health not supported with encoding "json"`,
 		},
 		{
+			msg:      "raw with --health",
 			encoding: encoding.Raw,
 			opts:     RequestOptions{Health: true},
 			wantErr:  `--health not supported with encoding "raw"`,
 		},
 		{
+			msg:      "thrift with --health",
 			encoding: encoding.Thrift,
 			opts:     RequestOptions{Health: true},
 			want:     encoding.Thrift,
 		},
 		{
+			msg:      "protobuf with --health",
 			encoding: encoding.Protobuf,
 			opts:     RequestOptions{Health: true},
 			want:     encoding.Protobuf,
 		},
 		{
+			msg:      "thrift with --health and procedure",
 			encoding: encoding.Thrift,
 			opts: RequestOptions{
 				Health:    true,
@@ -230,59 +235,70 @@ func TestNewSerializer(t *testing.T) {
 			wantErr: errHealthAndProcedure.Error(),
 		},
 		{
+			msg:      "unknown encoding",
 			encoding: encoding.Encoding("asd"),
 			opts:     RequestOptions{Procedure: "procedure"},
 			wantErr:  errUnrecognizedEncoding.Error(),
 		},
 		{
+			msg:      "unspecified encoding with --health",
 			encoding: encoding.UnspecifiedEncoding,
 			opts:     RequestOptions{Health: true},
-			want:     encoding.UnspecifiedEncoding,
+			want:     encoding.Thrift,
 		},
 		{
+			msg:      "unspecified encoding with thrift file",
 			encoding: encoding.UnspecifiedEncoding,
 			opts:     RequestOptions{ThriftFile: validThrift, Procedure: "Simple::foo"},
 			want:     encoding.Thrift,
 		},
 		{
+			msg:      "unspecified encoding with simple procedure",
 			encoding: encoding.UnspecifiedEncoding,
 			opts:     RequestOptions{Procedure: "hello"},
-			want:     encoding.JSON,
+			wantErr:  errUnrecognizedEncoding.Error(),
 		},
 		{
+			msg:      "json with thrift procedure",
 			encoding: encoding.JSON,
 			opts:     RequestOptions{Procedure: "Test::foo"},
-			want:     encoding.JSON,
+			want:     encoding.JSON, // explicitly set encoding always takes priority.
 		},
 		{
+			msg:      "json without procedure",
 			encoding: encoding.JSON,
 			wantErr:  errMissingProcedure.Error(),
 		},
 		{
+			msg:      "raw without procedure",
 			encoding: encoding.Raw,
 			wantErr:  errMissingProcedure.Error(),
 		},
 		{
+			msg:      "thrift without file",
 			encoding: encoding.Thrift,
 			wantErr:  encoding.ErrSpecifyThriftFile.Error(),
 		},
 		{
+			msg:      "thrift with file, without procedure lists services",
 			encoding: encoding.Thrift,
 			opts:     RequestOptions{ThriftFile: validThrift},
 			wantErr:  "available services",
 		},
 		{
+			msg:      "json with procedure",
 			encoding: encoding.JSON,
 			opts:     RequestOptions{Procedure: "procedure"},
 			want:     encoding.JSON,
 		},
 		{
+			msg:      "raw with procedure",
 			encoding: encoding.Raw,
 			opts:     RequestOptions{Procedure: "procedure"},
 			want:     encoding.Raw,
 		},
 		{
-			encoding: encoding.Protobuf,
+			msg: "unspecified with invalid descriptor",
 			opts: RequestOptions{
 				Procedure:         "Bar/Baz",
 				FileDescriptorSet: []string{"testdata/protobuf/simple/nonexisting.bin"},
@@ -290,7 +306,7 @@ func TestNewSerializer(t *testing.T) {
 			wantErr: "could not load protoset file",
 		},
 		{
-			encoding: encoding.Protobuf,
+			msg: "unspecified with valid descriptor",
 			opts: RequestOptions{
 				FileDescriptorSet: []string{"testdata/protobuf/simple/simple.proto.bin"},
 				Procedure:         "Bar/Baz",
@@ -298,63 +314,65 @@ func TestNewSerializer(t *testing.T) {
 			want: encoding.Protobuf,
 		},
 		{
-			encoding: encoding.Protobuf,
+			msg: "unspecified with grpc procedure invalid, peer for reflection",
 			opts: RequestOptions{
 				Procedure: "Bar/Baz",
 				Timeout:   timeMillisFlag(time.Millisecond),
 			},
-			topts:   TransportOptions{Peers: []string{"127.0.0.1:0"}},
+			peers:   []string{"127.0.0.1:0"},
 			wantErr: "could not reach reflection server:",
 		},
 		{
-			encoding: encoding.Protobuf,
+			msg: "unspecified encoding with grpc procedure and grpc peer",
 			opts: RequestOptions{
-				Procedure: "Bar/Baz",
+				Procedure: "grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+				Timeout:   timeMillisFlag(time.Second),
 			},
-			wantErr: "specify at least one peer using --peer or using --peer-list",
+			peers: []string{"grpc://" + ln.Addr().String()},
+			want:  encoding.Protobuf,
 		},
 		{
-			encoding: encoding.Protobuf,
+			msg: "unspecified encoding with valid host:port peer",
 			opts: RequestOptions{
 				Procedure: "grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
 				Timeout:   timeMillisFlag(time.Millisecond * 500),
 			},
-			topts: TransportOptions{Peers: []string{"grpc://" + ln.Addr().String()}},
+			peers: []string{ln.Addr().String()},
 			want:  encoding.Protobuf,
 		},
 		{
-			encoding: encoding.Protobuf,
-			opts: RequestOptions{
-				Procedure: "grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
-				Timeout:   timeMillisFlag(time.Millisecond * 500),
-			},
-			topts: TransportOptions{Peers: []string{ln.Addr().String()}},
-			want:  encoding.Protobuf,
-		},
-		{
-			encoding: encoding.Protobuf,
+			msg: "unspecified encoding with valid grpc peer, unknown symbol",
 			opts: RequestOptions{
 				Procedure: "Bar/Baz",
 				Timeout:   timeMillisFlag(time.Millisecond * 500),
 			},
-			topts:   TransportOptions{Peers: []string{"grpc://" + ln.Addr().String()}},
+			peers:   []string{"grpc://" + ln.Addr().String()},
 			wantErr: "Symbol not found: Bar",
 		},
 		{
-			encoding: encoding.Protobuf,
+			msg: "unspecified encoding with valid host:port peer, unknown symbol",
 			opts: RequestOptions{
 				Procedure: "Bar/Baz",
 				Timeout:   timeMillisFlag(time.Millisecond * 500),
 			},
-			topts:   TransportOptions{Peers: []string{ln.Addr().String()}},
+			peers:   []string{ln.Addr().String()},
 			wantErr: "Symbol not found: Bar",
 		},
 	}
 
 	for _, tt := range tests {
 		tt.opts.Encoding = tt.encoding
-		t.Run(fmt.Sprintf("%+v", tt.opts), func(t *testing.T) {
-			got, err := NewSerializer(Options{ROpts: tt.opts, TOpts: tt.topts})
+
+		tOpts := TransportOptions{
+			Peers: tt.peers,
+		}
+		if tt.peers == nil {
+			tOpts.Peers = []string{"127.0.0.1:0"}
+		}
+
+		t.Run(tt.msg, func(t *testing.T) {
+			opts := Options{ROpts: tt.opts, TOpts: tOpts}
+			got, err := NewSerializer(resolveOpts(t, opts))
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr, "unexpected error")
@@ -377,13 +395,13 @@ func TestNewSerializerProtobufReflection(t *testing.T) {
 	reflection.Register(s)
 	go s.Serve(ln)
 
-	serializer, err := NewSerializer(Options{
+	serializer, err := NewSerializer(resolveOpts(t, Options{
 		ROpts: RequestOptions{
 			Procedure: "grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
 			Timeout:   timeMillisFlag(time.Millisecond * 100),
 		},
 		TOpts: TransportOptions{Peers: []string{ln.Addr().String()}},
-	})
+	}))
 	assert.NoError(t, err)
 	require.NotNil(t, serializer)
 	assert.Equal(t, encoding.Protobuf, serializer.Encoding())
@@ -391,30 +409,37 @@ func TestNewSerializerProtobufReflection(t *testing.T) {
 
 func TestDetectEncoding(t *testing.T) {
 	tests := []struct {
+		msg  string
 		opts RequestOptions
 		want encoding.Encoding
 	}{
 		{
+			msg:  "explicit raw",
 			opts: RequestOptions{Encoding: encoding.Raw, Procedure: "procedure"},
 			want: encoding.Raw,
 		},
 		{
+			msg:  "unspecified with simple procedure",
 			opts: RequestOptions{Procedure: "procedure"},
-			want: encoding.JSON,
+			want: encoding.UnspecifiedEncoding,
 		},
 		{
+			msg:  "unspecified with Thrift procedure",
 			opts: RequestOptions{Procedure: "Svc::foo"},
 			want: encoding.Thrift,
 		},
 		{
+			msg:  "unspecified with Thrift file and simple procedure",
 			opts: RequestOptions{ThriftFile: validThrift, Procedure: "procedure"},
 			want: encoding.Thrift,
 		},
 		{
+			msg:  "unspecified with gRPC procedure",
 			opts: RequestOptions{Procedure: "package.Service/Method"},
 			want: encoding.Protobuf,
 		},
 		{
+			msg: "unspecified with gRPC file descriptor and simple procedure",
 			opts: RequestOptions{
 				FileDescriptorSet: []string{"testdata/protobuf/simple/simple.proto.bin"},
 				Procedure:         "procedure",
@@ -424,8 +449,10 @@ func TestDetectEncoding(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := detectEncoding(tt.opts)
-		assert.Equal(t, tt.want, got, "detectEncoding(%+v)", tt.opts)
+		t.Run(tt.msg, func(t *testing.T) {
+			got := tt.opts.detectEncoding()
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }
 
@@ -519,4 +546,14 @@ func TestPrepareRequestErr(t *testing.T) {
 	req, err := prepareRequest(req, nil /* headers */, Options{})
 	assert.Error(t, err)
 	assert.Nil(t, req)
+}
+
+func resolveOpts(t *testing.T, opts Options) (Options, resolvedProtocolEncoding) {
+	scheme, peers, err := loadTransportPeers(opts.TOpts)
+	require.NoError(t, err, "failed to load peers")
+
+	opts.TOpts.Peers = peers
+
+	resolved := resolveProtocolEncoding(scheme, opts.ROpts)
+	return opts, resolved
 }

--- a/transport/interface.go
+++ b/transport/interface.go
@@ -54,7 +54,8 @@ type Protocol int
 
 // The list of protocols supported by YAB.
 const (
-	TChannel Protocol = iota + 1
+	Unknown Protocol = iota
+	TChannel
 	HTTP
 	GRPC
 )

--- a/transport_test.go
+++ b/transport_test.go
@@ -46,13 +46,13 @@ func TestParsePeer(t *testing.T) {
 	}{
 		{"1.1.1.1:1", "", "1.1.1.1:1"},
 		{"some.host:1234", "", "some.host:1234"},
-		{"1.1.1.1", "unknown", ""},
+		{"1.1.1.1", "", "1.1.1.1"},
 		{"ftp://1.1.1.1", "ftp", "1.1.1.1"},
 		{"http://1.1.1.1", "http", "1.1.1.1"},
 		{"https://1.1.1.1", "https", "1.1.1.1"},
 		{"http://1.1.1.1:8080", "http", "1.1.1.1:8080"},
 		{"grpc://1.1.1.1:8080", "grpc", "1.1.1.1:8080"},
-		{"://asd", "unknown", ""},
+		{"://asd", "", "://asd"},
 	}
 
 	for _, tt := range tests {
@@ -79,7 +79,7 @@ func TestEnsureSameProtocol(t *testing.T) {
 		{
 			msg:   "only hosts",
 			peers: []string{"1.1.1.1", "2.2.2.2"},
-			want:  "unknown",
+			want:  "",
 		},
 		{
 			msg:   "http urls",
@@ -97,9 +97,9 @@ func TestEnsureSameProtocol(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			msg:     "mix of host:ports and hosts",
-			peers:   []string{"1.1.1.1:1234", "1.1.1.1"},
-			wantErr: true,
+			msg:   "mix of host:ports and hosts",
+			peers: []string{"1.1.1.1:1234", "1.1.1.1"},
+			want:  "",
 		},
 	}
 
@@ -118,62 +118,212 @@ func TestEnsureSameProtocol(t *testing.T) {
 	}
 }
 
-func TestGetTransport(t *testing.T) {
+func TestGetHosts(t *testing.T) {
+	peers := []string{
+		"1.1.1.1",
+		"1.1.1.2:2222",
+		"http://1.1.1.3/foo/bar",
+		"http://1.1.1.4:8080",
+		"ftp://1.1.1.5/",
+	}
+	want := []string{
+		"1.1.1.1",
+		"1.1.1.2:2222",
+		"1.1.1.3",
+		"1.1.1.4:8080",
+		"1.1.1.5",
+	}
+
+	assert.Equal(t, want, getHosts(peers))
+}
+
+func TestLoadTransportPeers(t *testing.T) {
 	tests := []struct {
-		opts   TransportOptions
-		errMsg string
+		msg        string
+		opts       TransportOptions
+		wantScheme string
+		wantPeers  []string
+		errMsg     string
 	}{
 		{
+			msg:    "no peers specified",
 			opts:   TransportOptions{},
-			errMsg: errServiceRequired.Error(),
-		},
-		{
-			opts:   TransportOptions{ServiceName: "svc"},
 			errMsg: errPeerRequired.Error(),
 		},
 		{
-			opts: TransportOptions{ServiceName: "svc", Peers: []string{"1.1.1.1:1"}},
+			msg:        "inline peers with ip:port",
+			opts:       TransportOptions{Peers: []string{"1.1.1.1:1"}},
+			wantScheme: "",
+			wantPeers:  []string{"1.1.1.1:1"},
 		},
 		{
-			opts: TransportOptions{ServiceName: "svc", Peers: []string{"localhost:1234"}},
+			msg:        "inline peers with localhost:port",
+			opts:       TransportOptions{Peers: []string{"localhost:1234"}},
+			wantScheme: "",
+			wantPeers:  []string{"localhost:1234"},
 		},
 		{
-			opts: TransportOptions{ServiceName: "svc", PeerList: "testdata/valid_peerlist.json"},
+			msg:       "valid peerlist",
+			opts:      TransportOptions{PeerList: "testdata/valid_peerlist.json"},
+			wantPeers: []string{"1.1.1.1:1", "2.2.2.2:2"},
 		},
 		{
-			opts:   TransportOptions{ServiceName: "svc", PeerList: "testdata/invalid.json"},
+			msg:    "unknown peerlist URL",
+			opts:   TransportOptions{PeerList: "unknown://foo"},
+			errMsg: "no peer provider available for scheme",
+		},
+		{
+			msg:    "invalid peerlist URL",
+			opts:   TransportOptions{PeerList: ":://foo.html"},
+			errMsg: "could not parse peer provider URL",
+		},
+		{
+			msg:    "invalid peer list",
+			opts:   TransportOptions{PeerList: "testdata/invalid.json"},
 			errMsg: "peer list should be YAML, JSON, or newline delimited strings",
 		},
 		{
-			opts:   TransportOptions{ServiceName: "svc", PeerList: "testdata/empty.txt"},
+			msg:    "empty peer list",
+			opts:   TransportOptions{PeerList: "testdata/empty.txt"},
 			errMsg: "specified peer list is empty",
 		},
 		{
-			opts:   TransportOptions{ServiceName: "svc", Peers: []string{"1.1.1.1:1"}, PeerList: "testdata/valid_peerlist.json"},
+			msg:    "both peers and peer list specified",
+			opts:   TransportOptions{Peers: []string{"1.1.1.1:1"}, PeerList: "testdata/valid_peerlist.json"},
 			errMsg: errPeerOptions.Error(),
 		},
 		{
-			opts: TransportOptions{ServiceName: "svc", Peers: []string{"http://1.1.1.1"}},
+			msg:        "URL peer list",
+			opts:       TransportOptions{Peers: []string{"http://1.1.1.1"}},
+			wantScheme: "http",
+			wantPeers:  []string{"http://1.1.1.1"},
 		},
 		{
-			opts:   TransportOptions{ServiceName: "svc", Peers: []string{"1.1.1.1:1", "http://1.1.1.1"}},
+			msg:    "URL and host:port in peer list",
+			opts:   TransportOptions{Peers: []string{"1.1.1.1:1", "http://1.1.1.1"}},
 			errMsg: "found mixed protocols",
 		},
 	}
 
 	for _, tt := range tests {
-		tt.opts.CallerName = "svc"
-		transport, err := getTransport(tt.opts, encoding.Thrift, opentracing.NoopTracer{})
-		if tt.errMsg != "" {
-			if assert.Error(t, err, "getTransport(%v) should fail", tt.opts) {
-				assert.Contains(t, err.Error(), tt.errMsg, "Unexpected error for getTransport(%v)", tt.opts)
+		t.Run(tt.msg, func(t *testing.T) {
+			scheme, peers, err := loadTransportPeers(tt.opts)
+			if tt.errMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg, "Unexpected error")
+				return
 			}
-			continue
-		}
 
-		if assert.NoError(t, err, "getTransport(%v) should not fail", tt.opts) {
-			assert.NotNil(t, transport, "getTransport(%v) didn't get transport", tt.opts)
-		}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantScheme, scheme, "unexpected scheme")
+			assert.Equal(t, tt.wantPeers, peers, "unexpected scheme")
+		})
+	}
+
+}
+
+func TestGetTransport(t *testing.T) {
+	tests := []struct {
+		msg      string
+		opts     TransportOptions
+		resolved resolvedProtocolEncoding
+		noTracer bool
+		errMsg   string
+	}{
+		{
+			msg: "TChannel Thrift ip:port without service",
+			opts: TransportOptions{
+				CallerName: "caller",
+				Peers:      []string{"1.1.1.1:1"},
+			},
+			resolved: _resolvedTChannelThrift,
+			errMsg:   errServiceRequired.Error(),
+		},
+		{
+			msg: "TChannel Thrift ip:port without caller",
+			opts: TransportOptions{
+				ServiceName: "svc",
+				Peers:       []string{"1.1.1.1:1"},
+			},
+			resolved: _resolvedTChannelThrift,
+			errMsg:   errCallerRequired.Error(),
+		},
+		{
+			msg: "TChannel Thrift ip:port without tracer",
+			opts: TransportOptions{
+				ServiceName: "svc",
+				CallerName:  "caller",
+				Peers:       []string{"1.1.1.1:1"},
+			},
+			resolved: _resolvedTChannelThrift,
+			noTracer: true,
+			errMsg:   errTracerRequired.Error(),
+		},
+		{
+			msg: "TChannel Thrift ip:port",
+			opts: TransportOptions{
+				ServiceName: "svc",
+				CallerName:  "caller",
+				Peers:       []string{"1.1.1.1:1"},
+			},
+			resolved: _resolvedTChannelThrift,
+		},
+		{
+			msg: "TChannel Thrift localhost:port",
+			opts: TransportOptions{
+				ServiceName: "svc",
+				CallerName:  "caller",
+				Peers:       []string{"localhost:1234"},
+			},
+			resolved: _resolvedTChannelThrift,
+		},
+		{
+			msg: "TChannel Thrift URL",
+			opts: TransportOptions{
+				ServiceName: "svc",
+				CallerName:  "caller",
+				Peers:       []string{"tchannel://localhost:1234"},
+			},
+			resolved: _resolvedTChannelThrift,
+		},
+		{
+			msg: "gRPC URL",
+			opts: TransportOptions{
+				ServiceName: "svc",
+				CallerName:  "caller",
+				Peers:       []string{"grpc://localhost:1234"},
+			},
+			resolved: resolvedProtocolEncoding{protocol: transport.GRPC, enc: encoding.Protobuf},
+		},
+		{
+			msg: "HTTP JSON URL",
+			opts: TransportOptions{
+				ServiceName: "svc",
+				CallerName:  "caller",
+				Peers:       []string{"http://1.1.1.1"},
+			},
+			resolved: resolvedProtocolEncoding{protocol: transport.HTTP, enc: encoding.JSON},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			var tracer opentracing.Tracer
+			if !tt.noTracer {
+				tracer = opentracing.NoopTracer{}
+			}
+
+			transport, err := getTransport(tt.opts, tt.resolved, tracer)
+			if tt.errMsg != "" {
+				require.Error(t, err, "getTransport(%v) should fail", tt.opts)
+				assert.Contains(t, err.Error(), tt.errMsg, "Unexpected error for getTransport(%v)", tt.opts)
+				return
+			}
+
+			require.NoError(t, err, "getTransport(%v) should not fail", tt.opts)
+			require.NotNil(t, transport, "getTransport(%v) didn't get transport", tt.opts)
+			assert.Equal(t, tt.resolved.protocol, transport.Protocol(), "incorrect protocol")
+		})
 	}
 }
 
@@ -213,7 +363,7 @@ func TestGetTransportCallerName(t *testing.T) {
 			Peers:       []string{server.hostPort()},
 			CallerName:  tt.caller,
 		}
-		tchan, err := getTransport(opts, encoding.Raw, opentracing.NoopTracer{})
+		tchan, err := getTransport(opts, resolvedProtocolEncoding{protocol: transport.TChannel, enc: encoding.Raw}, opentracing.NoopTracer{})
 		if tt.wantErr {
 			assert.Error(t, err, fmt.Sprintf("Expect fail: %+v", tt))
 			continue
@@ -264,65 +414,11 @@ func TestGetTransportTraceEnabled(t *testing.T) {
 			ctx = opentracing.ContextWithSpan(ctx, span)
 		}
 
-		tchan, err := getTransport(opts, encoding.Raw, tracer)
+		tchan, err := getTransport(opts, _resolvedTChannelRaw, tracer)
 		require.NoError(t, err, "getTransport failed")
 		res, err := tchan.Call(ctx, &transport.Request{Method: "test"})
 		require.NoError(t, err, "transport.Call failed")
 
 		assert.Equal(t, tt.traceEnabled, res.Body[0], "TraceEnabled mismatch")
-	}
-}
-
-func TestGetTransportInferFromEncoding(t *testing.T) {
-	tests := []struct {
-		desc     string
-		peer     string
-		encoding encoding.Encoding
-		want     transport.Protocol
-	}{
-		{
-			desc:     "infer grpc from proto encoding",
-			peer:     "1.1.1.1:1234",
-			encoding: encoding.Protobuf,
-			want:     transport.GRPC,
-		},
-		{
-			desc:     "don't infer encoding if specified",
-			peer:     "http://1.1.1.1:1234",
-			encoding: encoding.Protobuf,
-			want:     transport.HTTP,
-		},
-		{
-			desc:     "infer tchannel from thrift encoding",
-			peer:     "1.1.1.1:1234",
-			encoding: encoding.Thrift,
-			want:     transport.TChannel,
-		},
-		{
-			desc:     "infer tchannel from raw encoding",
-			peer:     "1.1.1.1:1234",
-			encoding: encoding.Raw,
-			want:     transport.TChannel,
-		},
-		{
-			desc:     "infer tchannel from JSON encoding",
-			peer:     "1.1.1.1:1234",
-			encoding: encoding.JSON,
-			want:     transport.TChannel,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			tOpts := TransportOptions{
-				ServiceName: "service",
-				CallerName:  "caller",
-				Peers:       []string{tt.peer},
-			}
-			transport, err := getTransport(tOpts, tt.encoding, opentracing.NoopTracer{})
-			assert.NoError(t, err, "getTransport(%v) should not fail", tt.desc)
-			require.NotNil(t, transport, "getTransport(%v) didn't get transport", tt.desc)
-			assert.Equal(t, tt.want, transport.Protocol())
-		})
 	}
 }

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-client-go"
+	"github.com/yarpc/yab/encoding"
+	"github.com/yarpc/yab/transport"
 	"go.uber.org/zap"
 )
 
@@ -43,6 +45,11 @@ const (
 )
 
 var _testLogger = zap.NewNop()
+
+var (
+	_resolvedTChannelThrift = resolvedProtocolEncoding{protocol: transport.TChannel, enc: encoding.Thrift}
+	_resolvedTChannelRaw    = resolvedProtocolEncoding{protocol: transport.TChannel, enc: encoding.Raw}
+)
 
 type testOutput struct {
 	*bytes.Buffer


### PR DESCRIPTION
The code to detect encoding/protocol is split up into phases, since we
have to create/detect one before the other.

This has caused issues (e.g., unspecifiedHealthSeriailizer) which then
led to issues like https://github.com/yarpc/yab/issues/281

Rather than fix these as one-offs, refactor the code so we try to
determine the transport protocol & encoding together as one step before
we create the transport or the serializer.

This should make it easier to reason about which encoding/transport
we'll use when the user doesn't specify one.

Fixes #281.