### PR TITLE
encoding: Improve error message for unsupported encoding with --health

### DIFF
--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -94,7 +94,7 @@ func (e Encoding) GetHealth(serviceName string) (Serializer, error) {
 	case Protobuf:
 		return protoHealthSerializer{serviceName: serviceName}, nil
 	default:
-		return nil, fmt.Errorf("--health not supported with encoding %q", e.String())
+		return nil, fmt.Errorf("--health not supported with encoding %q, please specify -e (thrift|proto)", e.String())
 	}
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -205,13 +205,13 @@ func TestNewSerializer(t *testing.T) {
 			msg:      "json with --health",
 			encoding: encoding.JSON,
 			opts:     RequestOptions{Health: true},
-			wantErr:  `--health not supported with encoding "json"`,
+			wantErr:  `--health not supported with encoding "json", please specify -e`,
 		},
 		{
 			msg:      "raw with --health",
 			encoding: encoding.Raw,
 			opts:     RequestOptions{Health: true},
-			wantErr:  `--health not supported with encoding "raw"`,
+			wantErr:  `--health not supported with encoding "raw", please specify -e`,
 		},
 		{
 			msg:      "thrift with --health",


### PR DESCRIPTION
In previous versions of yab, `--health` only supported Thrift. Now that
we support Protobuf, we default to the right encoding based on
transport, see #282.

For TChannel, we assume thrift
For gRPC, we assume proto
For HTTP, we assume JSON

The latter used to presume Thrift, but now will just fail. In future, we
may want to use `/health` for HTTP --health, so rather than going back
to Thrift, give a clearer error message which tells users how to specify
the encoding explicitly.