### PR TITLE
Fix flaky limiter test

### DIFF
--- a/limiter/limiter_test.go
+++ b/limiter/limiter_test.go
@@ -52,10 +52,10 @@ func TestParallel(t *testing.T) {
 }
 
 func TestStop(t *testing.T) {
-	run := New(1000 /* maxRequests */, 1000000 /* rps */, time.Millisecond)
+	run := New(0 /* maxRequests */, 0 /* rps */, 0 /* maxDuration */)
 
 	for i := 0; i < 100; i++ {
-		assert.True(t, run.More(), "Before Stop() should succeed", i)
+		assert.True(t, run.More(), "Before Stop() should succeed, iteration %v", i)
 	}
 	run.Stop()
 	for i := 0; i < 1000; i++ {

--- a/limiter/limiter_test.go
+++ b/limiter/limiter_test.go
@@ -61,6 +61,11 @@ func TestStop(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		assert.False(t, run.More(), "After Stop() should fail")
 	}
+
+	// Make sure we can stop multiple times
+	run.Stop()
+	run.Stop()
+	assert.False(t, run.More(), "After Stop() should fail")
 }
 
 func TestTimeout(t *testing.T) {


### PR DESCRIPTION
TestStop sets a max duration of a millisecond after which it stops the
limiter. If that happens before we've called `.More()` 100 times, then
it causes the test to fail.

Make the limiter have no max limit or duration to avoid flakiness.
Tested with `-count 1000` to verify.