### PR TITLE
gRPC: Propogate routing delegate/key to reflection calls

### DIFF
--- a/protobuf/source_reflection.go
+++ b/protobuf/source_reflection.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/grpcreflect"
 	"github.com/yarpc/yab/encoding/encodingerror"
+	yproto "go.uber.org/yarpc/encoding/protobuf"
 	ygrpc "go.uber.org/yarpc/transport/grpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -54,7 +55,7 @@ func NewDescriptorProviderReflection(args ReflectionArgs) (DescriptorProvider, e
 	routingHeaders := metadata.Pairs(
 		ygrpc.CallerHeader, args.Caller,
 		ygrpc.ServiceHeader, args.Service,
-		ygrpc.EncodingHeader, "proto",
+		ygrpc.EncodingHeader, string(yproto.Encoding),
 	)
 	if args.RoutingDelegate != "" {
 		routingHeaders.Append(ygrpc.RoutingDelegateHeader, args.RoutingDelegate)

--- a/protobuf/source_reflection.go
+++ b/protobuf/source_reflection.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/grpcreflect"
 	"github.com/yarpc/yab/encoding/encodingerror"
+	ygrpc "go.uber.org/yarpc/transport/grpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
@@ -18,10 +19,12 @@ import (
 
 // ReflectionArgs are args for constructing a DescriptorProvider that reaches out to a reflection server.
 type ReflectionArgs struct {
-	Caller  string
-	Service string
-	Peers   []string
-	Timeout time.Duration
+	Caller          string
+	Service         string
+	RoutingDelegate string
+	RoutingKey      string
+	Peers           []string
+	Timeout         time.Duration
 }
 
 // NewDescriptorProviderReflection returns a DescriptorProvider that reaches
@@ -47,12 +50,20 @@ func NewDescriptorProviderReflection(args ReflectionArgs) (DescriptorProvider, e
 		return nil, fmt.Errorf("could not reach reflection server: %s", err)
 	}
 	pbClient := rpb.NewServerReflectionClient(conn)
-	metadataContext := metadata.NewOutgoingContext(context.Background(),
-		map[string][]string{
-			"rpc-caller":   []string{args.Caller},
-			"rpc-service":  []string{args.Service},
-			"rpc-encoding": []string{"proto"},
-		})
+
+	routingHeaders := metadata.Pairs(
+		ygrpc.CallerHeader, args.Caller,
+		ygrpc.ServiceHeader, args.Service,
+		ygrpc.EncodingHeader, "proto",
+	)
+	if args.RoutingDelegate != "" {
+		routingHeaders.Append(ygrpc.RoutingDelegateHeader, args.RoutingDelegate)
+	}
+	if args.RoutingKey != "" {
+		routingHeaders.Append(ygrpc.RoutingKeyHeader, args.RoutingKey)
+	}
+
+	metadataContext := metadata.NewOutgoingContext(context.Background(), routingHeaders)
 	return &grpcreflectSource{
 		client: grpcreflect.NewClient(metadataContext, pbClient),
 	}, nil

--- a/protobuf/source_reflection_test.go
+++ b/protobuf/source_reflection_test.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	ygrpc "go.uber.org/yarpc/transport/grpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
+	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 )
 
 func TestReflection(t *testing.T) {
@@ -98,4 +101,98 @@ func TestReflectionNotRegistered(t *testing.T) {
 	_, err = got.FindService("foo")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown service grpc.reflection.v1alpha.ServerReflection", "unexpected error")
+}
+
+func TestReflectionRoutingHeaders(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	s := grpc.NewServer()
+	go s.Serve(ln)
+
+	// Ensure that all streams are closed by the end of the test.
+	defer s.GracefulStop()
+
+	drs := &dummyReflectionServer{}
+	rpb.RegisterServerReflectionServer(s, drs)
+
+	baseMD := metadata.Pairs(
+		ygrpc.CallerHeader, "test-caller",
+		ygrpc.ServiceHeader, "test-service",
+		ygrpc.EncodingHeader, "proto",
+	)
+	tests := []struct {
+		msg  string
+		rd   string
+		rk   string
+		want map[string]string
+	}{
+		{
+			msg:  "no routing delegate or key",
+			want: nil,
+		},
+		{
+			msg:  "only routing delegate",
+			rd:   "test-rd",
+			want: map[string]string{ygrpc.RoutingDelegateHeader: "test-rd"},
+		},
+		{
+			msg:  "only routing key",
+			rk:   "test-rk",
+			want: map[string]string{ygrpc.RoutingKeyHeader: "test-rk"},
+		},
+		{
+			msg: "routing delegate & key",
+			rd:  "test-rd",
+			rk:  "test-rk",
+			want: map[string]string{
+				ygrpc.RoutingDelegateHeader: "test-rd",
+				ygrpc.RoutingKeyHeader:      "test-rk",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			drs.Reset()
+
+			source, err := NewDescriptorProviderReflection(ReflectionArgs{
+				Timeout:         time.Second,
+				Peers:           []string{ln.Addr().String()},
+				Caller:          "test-caller",
+				Service:         "test-service",
+				RoutingDelegate: tt.rd,
+				RoutingKey:      tt.rk,
+			})
+			require.NoError(t, err)
+			defer source.Close()
+
+			_, err = source.FindService("foo")
+			require.Error(t, err, "expected error from stub server")
+			assert.Contains(t, err.Error(), assert.AnError.Error(), "unexpected error")
+
+			for k := range baseMD {
+				assert.Equal(t, baseMD.Get(k), drs.md.Get(k), "unexpected values for header %v", k)
+			}
+			for k := range tt.want {
+				assert.Equal(t, []string{tt.want[k]}, drs.md.Get(k), "unexpected values for header %v", k)
+			}
+		})
+	}
+}
+
+type dummyReflectionServer struct {
+	md metadata.MD
+}
+
+func (s *dummyReflectionServer) Reset() {
+	s.md = nil
+}
+
+func (s *dummyReflectionServer) ServerReflectionInfo(r rpb.ServerReflection_ServerReflectionInfoServer) error {
+	if md, ok := metadata.FromIncomingContext(r.Context()); ok {
+		s.md = md
+	}
+	return assert.AnError
 }

--- a/protobuf/source_reflection_test.go
+++ b/protobuf/source_reflection_test.go
@@ -109,13 +109,12 @@ func TestReflectionRoutingHeaders(t *testing.T) {
 	defer ln.Close()
 
 	s := grpc.NewServer()
+	drs := &dummyReflectionServer{}
+	rpb.RegisterServerReflectionServer(s, drs)
 	go s.Serve(ln)
 
 	// Ensure that all streams are closed by the end of the test.
 	defer s.GracefulStop()
-
-	drs := &dummyReflectionServer{}
-	rpb.RegisterServerReflectionServer(s, drs)
 
 	baseMD := metadata.Pairs(
 		ygrpc.CallerHeader, "test-caller",

--- a/request.go
+++ b/request.go
@@ -133,10 +133,12 @@ func newProtoDescriptorProvider(ropts RequestOptions, topts TransportOptions, re
 	}
 
 	return protobuf.NewDescriptorProviderReflection(protobuf.ReflectionArgs{
-		Caller:  topts.CallerName,
-		Service: topts.ServiceName,
-		Peers:   getHosts(topts.Peers),
-		Timeout: ropts.Timeout.Duration(),
+		Caller:          topts.CallerName,
+		Service:         topts.ServiceName,
+		RoutingDelegate: topts.RoutingDelegate,
+		RoutingKey:      topts.RoutingKey,
+		Peers:           getHosts(topts.Peers),
+		Timeout:         ropts.Timeout.Duration(),
 	})
 }
 


### PR DESCRIPTION
The gRPC reflection logic creates a custom gRPC connection (using native
gRPC) compared to the call (which uses YARPC), with inconsistent
handling of routing headers.

The reflection code was not using the routing delegate/key previously,
so fix the logic to propogate these headers.

Fixes #292