### PR TITLE
Include previously missed changes, and bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 Changelog
 =========
 
-# 0.16.2 (2020-03-24)
+# 0.17.0 (2020-03-24)
 * Fix gRPC reflection requests not propogating routing key and routing delegate.
+* When Thrift method is not found, list all available methdods in service::method
+  to match the passed-in method format.
+* Improved errors when Proto service is not found by including
+  list of all available services.
 
 # 0.16.1 (2019-10-02)
 * Fix bug that prevented nested JSON to be marshalled into Proto encoded


### PR DESCRIPTION
There were a couple of other commits in 2019 that haven't been released,
so include them in the CHANGELOG and bump minor version instead of patch
version.