### PR TITLE
Envoy proxy requires the authority header

### DIFF
--- a/protobuf/source_reflection.go
+++ b/protobuf/source_reflection.go
@@ -44,6 +44,7 @@ func NewDescriptorProviderReflection(args ReflectionArgs) (DescriptorProvider, e
 
 	conn, err := grpc.DialContext(context.Background(),
 		r.Scheme()+":///", // minimal target to dial registered host:port pairs
+		grpc.WithAuthority(strings.Join(args.Peers, ",")),
 		grpc.WithTimeout(args.Timeout),
 		grpc.WithBlock(),
 		grpc.WithInsecure())


### PR DESCRIPTION
If envoy receives a header frame without the authority header it drops
the frame.

The errors is the following:
[2020-09-29 22:34:48.118][1962226][debug][http2]
[external/envoy/source/common/http/http2/codec_impl_legacy.cc:786] [C3]
invalid http2: Invalid HTTP header field was received: frame type: 1,
stream: 1, name: [:authority], value: []
[2020-09-29 22:34:48.118][1962226][debug][http2]
[external/envoy/source/common/http/http2/codec_impl_legacy.cc:792] [C3]
invalid frame: Invalid HTTP header field was received on stream 1