### PR TITLE
gRPC: Add max-response-size option to support large responses

### DIFF
--- a/options.go
+++ b/options.go
@@ -74,17 +74,17 @@ type RequestOptions struct {
 
 // TransportOptions are transport related options.
 type TransportOptions struct {
-	ServiceName      string            `short:"s" long:"service" description:"The TChannel/Hyperbahn service name"`
-	Peers            []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
-	PeerList         string            `short:"P" long:"peer-list" description:"Path or URL of a JSON, YAML, or flat file containing a list of host:ports. -P? for supported protocols."`
-	CallerName       string            `long:"caller" description:"Caller will override the default caller name (which is yab-$USER)."`
-	RoutingKey       string            `long:"rk" description:"The routing key overrides the service name traffic group for proxies."`
-	RoutingDelegate  string            `long:"rd" description:"The routing delegate overrides the routing key traffic group for proxies."`
-	ShardKey         string            `long:"sk" description:"The shard key is a transport header that clues where to send a request within a clustered traffic group."`
-	Jaeger           bool              `long:"jaeger" description:"Use the Jaeger tracing client to send Uber style traces and baggage headers"`
-	TransportHeaders map[string]string `short:"T" long:"topt" description:"Transport options for TChannel, protocol headers for HTTP"`
-	HTTPMethod       string            `long:"http-method" description:"The HTTP method to use"`
-	MaxResponseSize  int               `long:"max-response-size" description:"Maximum response size, applicable for gRPC requests only. Default value is 4MB"`
+	ServiceName         string            `short:"s" long:"service" description:"The TChannel/Hyperbahn service name"`
+	Peers               []string          `short:"p" long:"peer" description:"The host:port of the service to call"`
+	PeerList            string            `short:"P" long:"peer-list" description:"Path or URL of a JSON, YAML, or flat file containing a list of host:ports. -P? for supported protocols."`
+	CallerName          string            `long:"caller" description:"Caller will override the default caller name (which is yab-$USER)."`
+	RoutingKey          string            `long:"rk" description:"The routing key overrides the service name traffic group for proxies."`
+	RoutingDelegate     string            `long:"rd" description:"The routing delegate overrides the routing key traffic group for proxies."`
+	ShardKey            string            `long:"sk" description:"The shard key is a transport header that clues where to send a request within a clustered traffic group."`
+	Jaeger              bool              `long:"jaeger" description:"Use the Jaeger tracing client to send Uber style traces and baggage headers"`
+	TransportHeaders    map[string]string `short:"T" long:"topt" description:"Transport options for TChannel, protocol headers for HTTP"`
+	HTTPMethod          string            `long:"http-method" description:"The HTTP method to use"`
+	GRPCMaxResponseSize int               `long:"grpc-max-response-size" description:"Maximum response size for gRPC requests. Default value is 4MB"`
 
 	// This is a hack to work around go-flags not allowing disabling flags:
 	// https://github.com/jessevdk/go-flags/issues/191

--- a/options.go
+++ b/options.go
@@ -84,6 +84,7 @@ type TransportOptions struct {
 	Jaeger           bool              `long:"jaeger" description:"Use the Jaeger tracing client to send Uber style traces and baggage headers"`
 	TransportHeaders map[string]string `short:"T" long:"topt" description:"Transport options for TChannel, protocol headers for HTTP"`
 	HTTPMethod       string            `long:"http-method" description:"The HTTP method to use"`
+	MaxResponseSize  int               `long:"max-response-size" description:"Maximum response size, applicable for gRPC requests only. Default value is 4MB"`
 
 	// This is a hack to work around go-flags not allowing disabling flags:
 	// https://github.com/jessevdk/go-flags/issues/191

--- a/transport.go
+++ b/transport.go
@@ -171,6 +171,7 @@ func getTransport(opts TransportOptions, resolved resolvedProtocolEncoding, trac
 			Encoding:        resolved.enc.String(),
 			RoutingKey:      opts.RoutingKey,
 			RoutingDelegate: opts.RoutingDelegate,
+			MaxResponseSize: opts.MaxResponseSize,
 		})
 	}
 

--- a/transport.go
+++ b/transport.go
@@ -171,7 +171,7 @@ func getTransport(opts TransportOptions, resolved resolvedProtocolEncoding, trac
 			Encoding:        resolved.enc.String(),
 			RoutingKey:      opts.RoutingKey,
 			RoutingDelegate: opts.RoutingDelegate,
-			MaxResponseSize: opts.MaxResponseSize,
+			MaxResponseSize: opts.GRPCMaxResponseSize,
 		})
 	}
 

--- a/transport/grpc.go
+++ b/transport/grpc.go
@@ -53,6 +53,7 @@ type GRPCOptions struct {
 	Encoding        string
 	RoutingKey      string
 	RoutingDelegate string
+	MaxResponseSize int
 }
 
 // NewGRPC returns a transport that calls a GRPC service.
@@ -81,7 +82,12 @@ func newGRPC(options GRPCOptions) (*grpcTransport, error) {
 		return nil, errGRPCNoCaller
 	}
 
-	transport := grpc.NewTransport(grpc.Tracer(options.Tracer))
+	transportOptions := []grpc.TransportOption{grpc.Tracer(options.Tracer)}
+	if options.MaxResponseSize != 0 {
+		transportOptions = append(transportOptions, grpc.ClientMaxRecvMsgSize(options.MaxResponseSize))
+	}
+
+	transport := grpc.NewTransport(transportOptions...)
 	outbound := transport.NewOutbound(peer.Bind(roundrobin.New(transport), peer.BindPeers(peersToIdentifiers(options.Addresses))))
 	if err := transport.Start(); err != nil {
 		return nil, err

--- a/transport/grpc.go
+++ b/transport/grpc.go
@@ -83,7 +83,7 @@ func newGRPC(options GRPCOptions) (*grpcTransport, error) {
 	}
 
 	transportOptions := []grpc.TransportOption{grpc.Tracer(options.Tracer)}
-	if options.MaxResponseSize != 0 {
+	if options.MaxResponseSize > 0 {
 		transportOptions = append(transportOptions, grpc.ClientMaxRecvMsgSize(options.MaxResponseSize))
 	}
 

--- a/transport/grpc_test.go
+++ b/transport/grpc_test.go
@@ -104,7 +104,7 @@ func TestGRPCSuccess(t *testing.T) {
 		testBarResponse := &testBarResponse{}
 		require.NoError(t, json.Unmarshal(response.Body, testBarResponse))
 		require.Equal(t, "hello", testBarResponse.One)
-	})
+	}, 0)
 }
 
 func TestGRPCError(t *testing.T) {
@@ -115,12 +115,37 @@ func TestGRPCError(t *testing.T) {
 		require.NoError(t, err)
 		_, err = grpcTestEnv.Transport.Call(context.Background(), request)
 		require.Equal(t, yarpcerrors.UnknownErrorf("hello"), err)
+	}, 0)
+}
+
+func TestGRPCMaxResponseSize(t *testing.T) {
+	t.Run("With default max response size", func(t *testing.T) {
+		doWithGRPCTestEnv(t, "example-caller", 1, []transport.Procedure{
+			newTestJSONProcedure("example", "Foo::Bar", testLargeResponse),
+		}, func(t *testing.T, grpcTestEnv *grpcTestEnv) {
+			request, err := newTestJSONRequest("example", "Foo::Bar", &testBarRequest{One: "hello", Size: 1024 * 1024 * 4})
+			require.NoError(t, err)
+			_, err = grpcTestEnv.Transport.Call(context.Background(), request)
+			require.Error(t, err)
+			require.Equal(t, yarpcerrors.CodeResourceExhausted, yarpcerrors.FromError(err).Code())
+		}, 0)
+	})
+	t.Run("With custom max response size", func(t *testing.T) {
+		doWithGRPCTestEnv(t, "example-caller", 1, []transport.Procedure{
+			newTestJSONProcedure("example", "Foo::Bar", testLargeResponse),
+		}, func(t *testing.T, grpcTestEnv *grpcTestEnv) {
+			request, err := newTestJSONRequest("example", "Foo::Bar", &testBarRequest{One: "hello", Size: 1024 * 1024 * 4})
+			require.NoError(t, err)
+			_, err = grpcTestEnv.Transport.Call(context.Background(), request)
+			require.NoError(t, err)
+		}, 1024*1025*4)
 	})
 }
 
 type testBarRequest struct {
 	One   string
 	Error string
+	Size  int
 }
 
 type testBarResponse struct {
@@ -136,6 +161,17 @@ func testBar(ctx context.Context, request *testBarRequest) (*testBarResponse, er
 	}
 	return &testBarResponse{
 		One: request.One,
+	}, nil
+}
+
+func testLargeResponse(ctx context.Context, request *testBarRequest) (*testBarResponse, error) {
+	body := make([]byte, request.Size)
+	// filling body with non-zero to avoid html-escape in json encoder
+	for i := range body {
+		body[i] = 'a'
+	}
+	return &testBarResponse{
+		One: string(body),
 	}, nil
 }
 
@@ -163,8 +199,9 @@ func doWithGRPCTestEnv(
 	numInbounds int,
 	procedures []transport.Procedure,
 	f func(*testing.T, *grpcTestEnv),
+	maxResponseSize int,
 ) {
-	grpcTestEnv, err := newGRPCTestEnv(caller, numInbounds, procedures)
+	grpcTestEnv, err := newGRPCTestEnv(caller, numInbounds, procedures, maxResponseSize)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, grpcTestEnv.Close())
@@ -183,8 +220,13 @@ func newGRPCTestEnv(
 	caller string,
 	numInbounds int,
 	procedures []transport.Procedure,
+	maxResponseSize int,
 ) (_ *grpcTestEnv, err error) {
-	yarpcTransport := grpc.NewTransport()
+	var options []grpc.TransportOption
+	if maxResponseSize > 0 {
+		options = append(options, grpc.ServerMaxSendMsgSize(maxResponseSize))
+	}
+	yarpcTransport := grpc.NewTransport(options...)
 	if err := yarpcTransport.Start(); err != nil {
 		return nil, err
 	}
@@ -216,10 +258,11 @@ func newGRPCTestEnv(
 	}
 
 	transport, err := NewGRPC(GRPCOptions{
-		Addresses: addresses,
-		Tracer:    opentracing.NoopTracer{},
-		Caller:    caller,
-		Encoding:  "json",
+		Addresses:       addresses,
+		Tracer:          opentracing.NoopTracer{},
+		Caller:          caller,
+		Encoding:        "json",
+		MaxResponseSize: maxResponseSize,
 	})
 	if err != nil {
 		return nil, err

--- a/transport/grpc_test.go
+++ b/transport/grpc_test.go
@@ -21,12 +21,12 @@
 package transport
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
@@ -165,10 +165,9 @@ func testBar(ctx context.Context, request *testBarRequest) (*testBarResponse, er
 }
 
 func testLargeResponse(ctx context.Context, request *testBarRequest) (*testBarResponse, error) {
-	// filling body with non-zero to avoid html-escape in json encoder
-	body := string(bytes.Repeat([]byte("a"), request.Size))
 	return &testBarResponse{
-		One: body,
+		// filling One with non-zero value to avoid html-escape in json encoder
+		One: strings.Repeat("a", request.Size),
 	}, nil
 }
 
@@ -219,10 +218,7 @@ func newGRPCTestEnv(
 	procedures []transport.Procedure,
 	maxResponseSize int,
 ) (_ *grpcTestEnv, err error) {
-	var options []grpc.TransportOption
-	if maxResponseSize > 0 {
-		options = append(options, grpc.ServerMaxSendMsgSize(maxResponseSize))
-	}
+	options := []grpc.TransportOption{grpc.ServerMaxSendMsgSize(1024 * 1024 * 10)}
 	yarpcTransport := grpc.NewTransport(options...)
 	if err := yarpcTransport.Start(); err != nil {
 		return nil, err


### PR DESCRIPTION
This change addresses #311, adds new option `max-response-size` (applicable only for gRPC requests)