### PR TITLE
Enable race detection in CI tests and ignore testdata in coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,3 +13,5 @@ coverage:
         if_not_found: success  # if parent is not found report status as success, error, or failure
         if_ci_failed: error    # if ci fails report status as success, error, or failure
 
+ignore:
+ - /testdata/

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,4 +14,4 @@ coverage:
         if_ci_failed: error    # if ci fails report status as success, error, or failure
 
 ignore:
- - /testdata/
+ - /testdata/**/*

--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,6 @@ docs:
 
 .PHONY: test_ci
 test_ci: install build
-	go test -race -coverprofile=cover.out -coverpkg=./... ./...
+	go test -race -coverprofile=cover_temp.out -coverpkg=./... ./...
+	grep -v "^github.com/yarpc/yab/testdata/*" cover_temp.out > cover.out
 	go tool cover -html=cover.out -o cover.html

--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,6 @@ docs:
 
 .PHONY: test_ci
 test_ci: install build
-	go test -coverprofile=cover.out -coverpkg=./... ./...
+	go test -race -coverprofile=cover_temp.out -coverpkg=./... ./...
+	grep -v "^github.com/yarpc/yab/testdata/*" cover_temp.out > cover.out
 	go tool cover -html=cover.out -o cover.html

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,5 @@ docs:
 
 .PHONY: test_ci
 test_ci: install build
-	go test -race -coverprofile=cover_temp.out -coverpkg=./... ./...
-	grep -v "^github.com/yarpc/yab/testdata/*" cover_temp.out > cover.out
+	go test -race -coverprofile=cover.out -coverpkg=./... ./...
 	go tool cover -html=cover.out -o cover.html


### PR DESCRIPTION
* Enable race detection in CI tests
* Ignore `testdata` directory in coverage output 