### PR TITLE
Refactor benchmark to accept benchmarker interface 

### DIFF
--- a/bench_method.go
+++ b/bench_method.go
@@ -35,15 +35,15 @@ type peerTransport struct {
 	peerID int
 }
 
-// benchmarker exposes method to dispatch requests for benchmark.
-type benchmarker interface {
+// benchmarkCaller exposes method to dispatch requests for benchmark.
+type benchmarkCaller interface {
 	// Call dispatches a request using the provided transport.
 	Call(transport.Transport) (time.Duration, error)
 }
 
 // warmTransport warms up a transport and returns it. The transport is warmed
 // up by making some number of requests through it.
-func warmTransport(b benchmarker, opts TransportOptions, resolved resolvedProtocolEncoding, warmupRequests int) (transport.Transport, error) {
+func warmTransport(b benchmarkCaller, opts TransportOptions, resolved resolvedProtocolEncoding, warmupRequests int) (transport.Transport, error) {
 	transport, err := getTransport(opts, resolved, opentracing.NoopTracer{})
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func peerBalancer(peers []string) func(i int) (string, int) {
 
 // warmTransports returns n transports that have been warmed up.
 // No requests may fail during the warmup period.
-func warmTransports(b benchmarker, n int, tOpts TransportOptions, resolved resolvedProtocolEncoding, warmupRequests int) ([]peerTransport, error) {
+func warmTransports(b benchmarkCaller, n int, tOpts TransportOptions, resolved resolvedProtocolEncoding, warmupRequests int) ([]peerTransport, error) {
 	peerFor := peerBalancer(tOpts.Peers)
 	transports := make([]peerTransport, n)
 	errs := make([]error, n)

--- a/benchmark.go
+++ b/benchmark.go
@@ -109,7 +109,7 @@ func (o BenchmarkOptions) enabled() bool {
 	return o.MaxDuration != 0 || o.MaxRequests != 0
 }
 
-func runWorker(t transport.Transport, b benchmarker, s *benchmarkState, run *limiter.Run, logger *zap.Logger) {
+func runWorker(t transport.Transport, b benchmarkCaller, s *benchmarkState, run *limiter.Run, logger *zap.Logger) {
 	for cur := run; cur.More(); {
 		latency, err := b.Call(t)
 		if err != nil {
@@ -123,7 +123,7 @@ func runWorker(t transport.Transport, b benchmarker, s *benchmarkState, run *lim
 	}
 }
 
-func runBenchmark(out output, logger *zap.Logger, allOpts Options, resolved resolvedProtocolEncoding, methodName string, b benchmarker) {
+func runBenchmark(out output, logger *zap.Logger, allOpts Options, resolved resolvedProtocolEncoding, methodName string, b benchmarkCaller) {
 	opts := allOpts.BOpts
 
 	if err := opts.validate(); err != nil {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -90,7 +90,7 @@ func TestBenchmark(t *testing.T) {
 				Concurrency: 2,
 			},
 			TOpts: s.transportOpts(),
-		}, _resolvedTChannelThrift, m)
+		}, _resolvedTChannelThrift, fooMethod, m)
 
 		bufStr := buf.String()
 		assert.Contains(t, bufStr, "Max RPS")
@@ -146,7 +146,7 @@ func TestRunBenchmarkErrors(t *testing.T) {
 		// need to run the benchmark in a separate goroutine.
 		go func() {
 			defer wg.Done()
-			runBenchmark(out, _testLogger, opts, _resolvedTChannelThrift, m)
+			runBenchmark(out, _testLogger, opts, _resolvedTChannelThrift, fooMethod, m)
 		}()
 
 		wg.Wait()
@@ -198,7 +198,7 @@ func TestBenchmarkStatsPerPeer(t *testing.T) {
 		ROpts: RequestOptions{
 			Procedure: fooMethod,
 		},
-	}, _resolvedTChannelThrift, m)
+	}, _resolvedTChannelThrift, fooMethod, m)
 
 	// Ensure one backend gets more calls than the other
 	want := map[string]int{
@@ -284,7 +284,7 @@ func TestBenchmarkOutput(t *testing.T) {
 					TOpts: s.transportOpts(),
 				}
 
-				runBenchmark(out, _testLogger, opts, _resolvedTChannelThrift, m)
+				runBenchmark(out, _testLogger, opts, _resolvedTChannelThrift, fooMethod, m)
 				bufStr := buf.String()
 				bufWarnStr := bufWarn.String()
 

--- a/benchmark_unary.go
+++ b/benchmark_unary.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"time"
+
+	"github.com/yarpc/yab/encoding"
+	"github.com/yarpc/yab/transport"
+)
+
+// benchmarkUnaryMethod benchmarks unary requests.
+type benchmarkUnaryMethod struct {
+	serializer encoding.Serializer
+	req        *transport.Request
+}
+
+// Call dispatches unary request on the provided transport.
+func (m benchmarkUnaryMethod) Call(t transport.Transport) (time.Duration, error) {
+	start := time.Now()
+	res, err := makeRequest(t, m.req)
+	duration := time.Since(start)
+
+	if err == nil {
+		err = m.serializer.CheckSuccess(res)
+	}
+	return duration, err
+}

--- a/benchmark_unary_test.go
+++ b/benchmark_unary_test.go
@@ -36,7 +36,7 @@ import (
 	"go.uber.org/atomic"
 )
 
-func benchmarkMethodForTest(t *testing.T, procedure string, p transport.Protocol) benchmarkMethod {
+func benchmarkMethodForTest(t *testing.T, procedure string, p transport.Protocol) benchmarkUnaryMethod {
 	return benchmarkMethodForROpts(t, RequestOptions{
 		Encoding:   encoding.Thrift,
 		ThriftFile: validThrift,
@@ -44,7 +44,7 @@ func benchmarkMethodForTest(t *testing.T, procedure string, p transport.Protocol
 	}, p)
 }
 
-func benchmarkMethodForROpts(t *testing.T, rOpts RequestOptions, p transport.Protocol) benchmarkMethod {
+func benchmarkMethodForROpts(t *testing.T, rOpts RequestOptions, p transport.Protocol) benchmarkUnaryMethod {
 	serializer, err := NewSerializer(Options{ROpts: rOpts}, resolvedProtocolEncoding{
 		protocol: p,
 		enc:      encoding.Thrift,
@@ -55,7 +55,7 @@ func benchmarkMethodForROpts(t *testing.T, rOpts RequestOptions, p transport.Pro
 	require.NoError(t, err, "Failed to serialize Thrift body")
 
 	req.Timeout = time.Second
-	return benchmarkMethod{serializer, req}
+	return benchmarkUnaryMethod{serializer, req}
 }
 
 func TestBenchmarkMethodWarmTransport(t *testing.T) {
@@ -96,7 +96,7 @@ func TestBenchmarkMethodWarmTransport(t *testing.T) {
 			Peers:       []string{tt.peer},
 		}
 
-		transport, err := m.WarmTransport(tOpts, resolvedProtocolEncoding{
+		transport, err := warmTransport(m, tOpts, resolvedProtocolEncoding{
 			protocol: transport.TChannel,
 			enc:      encoding.JSON,
 		}, 1 /* warmupRequests */)
@@ -159,7 +159,7 @@ func TestBenchmarkMethodCall(t *testing.T) {
 			m.req.Method = tt.reqMethod
 		}
 
-		d, err := m.call(tp)
+		d, err := m.Call(tp)
 		if tt.wantErr != "" {
 			if assert.Error(t, err, "call should fail") {
 				assert.Contains(t, err.Error(), tt.wantErr, "call should return 0 duration")
@@ -233,7 +233,7 @@ func TestBenchmarkMethodWarmTransportsSuccess(t *testing.T) {
 		ServiceName: "foo",
 		Peers:       serverHPs,
 	}
-	transports, err := m.WarmTransports(numServers, tOpts, _resolvedTChannelThrift, 1 /* warmupRequests */)
+	transports, err := warmTransports(m, numServers, tOpts, _resolvedTChannelThrift, 1 /* warmupRequests */)
 	assert.NoError(t, err, "WarmTransports should not fail")
 	assert.Equal(t, numServers, len(transports), "Got unexpected number of transports")
 	for i, transport := range transports {
@@ -292,19 +292,11 @@ func TestBenchmarkMethodWarmTransportsError(t *testing.T) {
 			ServiceName: "foo",
 			Peers:       []string{s.hostPort()},
 		}
-		_, err := m.WarmTransports(10, tOpts, _resolvedTChannelThrift, tt.warmup)
+		_, err := warmTransports(m, 10, tOpts, _resolvedTChannelThrift, tt.warmup)
 		if tt.wantErr {
 			assert.Error(t, err, "%v: WarmTransports should fail", msg)
 		} else {
 			assert.NoError(t, err, "%v: WarmTransports should succeed", msg)
 		}
 	}
-}
-
-func TestBenchmarkMethodHealth(t *testing.T) {
-	m := benchmarkMethodForROpts(t, RequestOptions{
-		Encoding: encoding.Thrift,
-		Health:   true,
-	}, transport.TChannel)
-	assert.Equal(t, "Meta::health", m.Method())
 }

--- a/handler.go
+++ b/handler.go
@@ -69,7 +69,7 @@ func (r requestHandler) handleUnaryRequest() {
 		makeInitialRequest(r.out, r.transport, r.serializer, req)
 	}
 
-	runBenchmark(r.out, r.logger, r.opts, r.resolved, benchmarkMethod{
+	runBenchmark(r.out, r.logger, r.opts, r.resolved, req.Method, benchmarkUnaryMethod{
 		serializer: r.serializer,
 		req:        req,
 	})


### PR DESCRIPTION
Add `benchmarker` interface in benchmark and warmup methods. This change sets up clean interface to add streaming benchmarker from #319. Decouples transport warmup methods from unary benchmark which enables them to be used by streaming benchmarks as well. 