### PR TITLE
Increase benchmark test duration to avoid intermittent failures

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -467,7 +467,7 @@ func TestBenchmarkLowRPSDuration(t *testing.T) {
 	start := time.Now()
 	main()
 	duration := time.Since(start)
-	assert.True(t, duration < 200*time.Millisecond, "Expected 100ms benchmark to complete within 200ms, took %v", duration)
+	assert.True(t, duration < 300*time.Millisecond, "Expected 100ms benchmark to complete within 300ms, took %v", duration)
 }
 
 func TestHelpOutput(t *testing.T) {


### PR DESCRIPTION
Test runs a benchmark for 100ms and expects test to finish under 200ms, but many times on slower CI machines the test takes +10ms causing intermittent failures.

```
--- FAIL: TestBenchmarkLowRPSDuration (0.21s)
    main_test.go:470: 
        	Error Trace:	main_test.go:470
        	Error:      	Should be true
        	Test:       	TestBenchmarkLowRPSDuration
        	Messages:   	Expected 100ms benchmark to complete within 200ms, took 203.495352ms
```