### PR TITLE
Add benchmark caller result to hold call latency 

### DIFF
--- a/bench_method.go
+++ b/bench_method.go
@@ -38,7 +38,19 @@ type peerTransport struct {
 // benchmarkCaller exposes method to dispatch requests for benchmark.
 type benchmarkCaller interface {
 	// Call dispatches a request using the provided transport.
-	Call(transport.Transport) (time.Duration, error)
+	Call(transport.Transport) (benchmarkCallLatencyResult, error)
+}
+
+type benchmarkCallLatencyResult struct {
+	latency time.Duration
+}
+
+func newBenchmarkCallLatencyResult(latency time.Duration) benchmarkCallLatencyResult {
+	return benchmarkCallLatencyResult{latency}
+}
+
+func (r benchmarkCallLatencyResult) Latency() time.Duration {
+	return r.latency
 }
 
 // warmTransport warms up a transport and returns it. The transport is warmed

--- a/benchmark.go
+++ b/benchmark.go
@@ -111,7 +111,7 @@ func (o BenchmarkOptions) enabled() bool {
 
 func runWorker(t transport.Transport, b benchmarkCaller, s *benchmarkState, run *limiter.Run, logger *zap.Logger) {
 	for cur := run; cur.More(); {
-		latency, err := b.Call(t)
+		callResult, err := b.Call(t)
 		if err != nil {
 			s.recordError(err)
 			// TODO: Add information about which peer specifically failed.
@@ -119,7 +119,7 @@ func runWorker(t transport.Transport, b benchmarkCaller, s *benchmarkState, run 
 			continue
 		}
 
-		s.recordLatency(latency)
+		s.recordLatency(callResult.Latency())
 	}
 }
 

--- a/benchmark_unary.go
+++ b/benchmark_unary.go
@@ -34,7 +34,7 @@ type benchmarkUnaryMethod struct {
 }
 
 // Call dispatches unary request on the provided transport.
-func (m benchmarkUnaryMethod) Call(t transport.Transport) (time.Duration, error) {
+func (m benchmarkUnaryMethod) Call(t transport.Transport) (benchmarkCallLatencyResult, error) {
 	start := time.Now()
 	res, err := makeRequest(t, m.req)
 	duration := time.Since(start)
@@ -42,5 +42,5 @@ func (m benchmarkUnaryMethod) Call(t transport.Transport) (time.Duration, error)
 	if err == nil {
 		err = m.serializer.CheckSuccess(res)
 	}
-	return duration, err
+	return newBenchmarkCallLatencyResult(duration), err
 }

--- a/benchmark_unary_test.go
+++ b/benchmark_unary_test.go
@@ -159,7 +159,7 @@ func TestBenchmarkMethodCall(t *testing.T) {
 			m.req.Method = tt.reqMethod
 		}
 
-		d, err := m.Call(tp)
+		callResult, err := m.Call(tp)
 		if tt.wantErr != "" {
 			if assert.Error(t, err, "call should fail") {
 				assert.Contains(t, err.Error(), tt.wantErr, "call should return 0 duration")
@@ -168,7 +168,7 @@ func TestBenchmarkMethodCall(t *testing.T) {
 		}
 
 		assert.NoError(t, err, "call should not fail")
-		assert.True(t, d > time.Microsecond, "duration was too short, got %v", d)
+		assert.True(t, callResult.Latency() > time.Microsecond, "duration was too short, got %v", callResult.Latency())
 	}
 }
 


### PR DESCRIPTION
This pull request is a duplicate of #324, which merged into the #319's branch, and it is currently in the review phase. This pull request aims to land those same changes into dev and then rebase #319 with `dev` to scrap out the #324 changes from its diff.