### PR TITLE
Add `stream-interval` stream request option

### DIFF
--- a/benchmark_stream.go
+++ b/benchmark_stream.go
@@ -33,6 +33,7 @@ type benchmarkStreamMethod struct {
 	serializer            encoding.Serializer
 	streamRequest         *transport.StreamRequest
 	streamRequestMessages [][]byte
+	opts                  StreamRequestOptions
 }
 
 // Call dispatches stream request on the provided transport.
@@ -40,7 +41,7 @@ func (m benchmarkStreamMethod) Call(t transport.Transport) (benchmarkCallReporte
 	streamIO := newStreamIOBenchmark(m.streamRequestMessages)
 
 	start := time.Now()
-	err := makeStreamRequest(t, m.streamRequest, m.serializer, streamIO)
+	err := makeStreamRequest(t, m.streamRequest, m.serializer, streamIO, m.opts)
 	callReport := newBenchmarkStreamCallReport(time.Since(start), streamIO.streamMessagesReceived(), streamIO.streamMessagesSent())
 
 	if err != nil {

--- a/handler.go
+++ b/handler.go
@@ -436,5 +436,4 @@ func (s *intervalWaiter) wait(ctx context.Context) {
 	}
 
 	s.lastAllowed = time.Now()
-	return
 }

--- a/handler.go
+++ b/handler.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"sync"
+	"time"
 
 	"github.com/uber/tchannel-go"
 	"github.com/yarpc/yab/encoding"
@@ -95,7 +96,7 @@ func (r requestHandler) handleStreamRequest() {
 	streamIO := newStreamIOInitializer(r.out, r.serializer, streamMsgReader)
 
 	if r.shouldMakeInitialRequest() {
-		if err = makeStreamRequest(r.transport, streamReq, r.serializer, streamIO); err != nil {
+		if err = makeStreamRequest(r.transport, streamReq, r.serializer, streamIO, r.opts.ROpts.StreamRequestOptions); err != nil {
 			r.out.Fatalf("%v\n", err)
 		}
 	}
@@ -113,6 +114,7 @@ func (r requestHandler) handleStreamRequest() {
 		serializer:            r.serializer,
 		streamRequest:         streamReq,
 		streamRequestMessages: streamRequests,
+		opts:                  r.opts.ROpts.StreamRequestOptions,
 	})
 }
 
@@ -130,7 +132,7 @@ func (r requestHandler) isStreamingMethod() bool {
 // it then delegates to handler based on rpc type to handle request and response of the stream
 // nextBodyFn is called to get the next stream message body
 // responseHandlerFn is called with the response of the stream
-func makeStreamRequest(t transport.Transport, streamReq *transport.StreamRequest, serializer encoding.Serializer, streamIO StreamIO) error {
+func makeStreamRequest(t transport.Transport, streamReq *transport.StreamRequest, serializer encoding.Serializer, streamIO StreamIO, opts StreamRequestOptions) error {
 	streamTransport, ok := t.(transport.StreamTransport)
 	if !ok {
 		return fmt.Errorf("Transport does not support stream calls: %q", t.Protocol())
@@ -149,9 +151,9 @@ func makeStreamRequest(t transport.Transport, streamReq *transport.StreamRequest
 
 	switch serializer.MethodType() {
 	case encoding.BidirectionalStream:
-		return makeBidiStream(ctx, stream, streamIO)
+		return makeBidiStream(ctx, stream, streamIO, opts)
 	case encoding.ClientStream:
-		return makeClientStream(ctx, stream, streamIO)
+		return makeClientStream(ctx, stream, streamIO, opts)
 	default:
 		return makeServerStream(ctx, stream, streamIO)
 	}
@@ -194,14 +196,18 @@ func makeServerStream(ctx context.Context, stream *yarpctransport.ClientStream, 
 }
 
 // makeClientStream starts client-side streaming rpc
-func makeClientStream(ctx context.Context, stream *yarpctransport.ClientStream, streamIO StreamIO) error {
+func makeClientStream(ctx context.Context, stream *yarpctransport.ClientStream, streamIO StreamIO, opts StreamRequestOptions) error {
 	var err error
+	reqWaiter := newIntervalWaiter(opts.Interval.Duration())
+
 	for err == nil {
 		var reqBody []byte
 		reqBody, err = streamIO.NextRequest()
 		if err != nil {
 			break
 		}
+
+		reqWaiter.wait(ctx)
 		err = sendStreamMessage(ctx, stream, reqBody)
 	}
 
@@ -220,12 +226,13 @@ func makeClientStream(ctx context.Context, stream *yarpctransport.ClientStream, 
 }
 
 // makeBidiStream starts bi-directional streaming rpc
-func makeBidiStream(ctx context.Context, stream *yarpctransport.ClientStream, streamIO StreamIO) error {
+func makeBidiStream(ctx context.Context, stream *yarpctransport.ClientStream, streamIO StreamIO, opts StreamRequestOptions) error {
 	var wg sync.WaitGroup
 	var sendErr error
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	reqWaiter := newIntervalWaiter(opts.Interval.Duration())
 
 	wg.Add(1)
 	// Start go routine to concurrently send stream messages.
@@ -247,6 +254,7 @@ func makeBidiStream(ctx context.Context, stream *yarpctransport.ClientStream, st
 				break
 			}
 
+			reqWaiter.wait(ctx)
 			err = sendStreamMessage(ctx, stream, reqBody)
 		}
 
@@ -394,4 +402,39 @@ func newStreamIOInitializer(out output, serializer encoding.Serializer, streamMs
 		serializer:      serializer,
 		streamMsgReader: streamMsgReader,
 	}
+}
+
+// intervalWaiter provides `wait` method to maintain time gap of `interval` between
+// consecutive `wait` calls.
+type intervalWaiter struct {
+	interval    time.Duration // required time gap between calls.
+	lastAllowed time.Time
+}
+
+func newIntervalWaiter(interval time.Duration) *intervalWaiter {
+	return &intervalWaiter{
+		interval: interval,
+	}
+}
+
+// wait method waits until the time gap between previous call and current call is
+// more than interval provided. It returns early if the provided context is done.
+func (s *intervalWaiter) wait(ctx context.Context) {
+	now := time.Now()
+	diff := now.Sub(s.lastAllowed)
+
+	// gap between this and previous call is more than required interval.
+	if diff >= s.interval {
+		s.lastAllowed = now
+		return
+	}
+
+	// wait for the remaining duration or context completion.
+	select {
+	case <-ctx.Done():
+	case <-time.After(s.interval - diff):
+	}
+
+	s.lastAllowed = time.Now()
+	return
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -131,29 +131,24 @@ func TestStreamRequestRecorder(t *testing.T) {
 }
 
 func TestIntervalWaiter(t *testing.T) {
-	duration := time.Millisecond * 100
-
 	t.Run("initial call must not wait", func(t *testing.T) {
-		waiter := newIntervalWaiter(duration)
+		waiter := newIntervalWaiter(time.Millisecond * 100)
 		now := time.Now()
 		waiter.wait(context.Background())
-		assert.True(t, time.Now().Sub(now) < time.Millisecond)
+		timeTaken := time.Now().Sub(now)
+		assert.True(t, timeTaken < time.Millisecond, "Unexpected time taken on wait: %v", timeTaken)
 	})
 
 	t.Run("interval gap must be 100ms between consecutive calls", func(t *testing.T) {
-		waiter := newIntervalWaiter(duration)
+		waiter := newIntervalWaiter(time.Millisecond * 100)
 		waiter.wait(context.Background())
 
-		now := time.Now()
-		waiter.wait(context.Background())
-		duration := time.Now().Sub(now)
-		assert.True(t, duration > (duration), "Unexpected time taken on wait: %v", duration)
-		assert.True(t, duration < (duration), "Unexpected time taken on wait: %v", duration)
-
-		now = time.Now()
-		waiter.wait(context.Background())
-		duration = time.Now().Sub(now)
-		assert.True(t, duration > (duration), "Unexpected time taken on wait: %v", duration)
-		assert.True(t, duration < (duration), "Unexpected time taken on wait: %v", duration)
+		for i := 0; i < 2; i++ {
+			now := time.Now()
+			waiter.wait(context.Background())
+			timeTaken := time.Now().Sub(now)
+			assert.True(t, timeTaken > (time.Millisecond*100), "Unexpected time taken on wait: %v", timeTaken)
+			assert.True(t, timeTaken < (time.Millisecond*200), "Unexpected time taken on wait: %v", timeTaken)
+		}
 	})
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -131,27 +131,29 @@ func TestStreamRequestRecorder(t *testing.T) {
 }
 
 func TestIntervalWaiter(t *testing.T) {
+	duration := time.Millisecond * 100
+
 	t.Run("initial call must not wait", func(t *testing.T) {
-		waiter := newIntervalWaiter(time.Millisecond * 100)
+		waiter := newIntervalWaiter(duration)
 		now := time.Now()
 		waiter.wait(context.Background())
 		assert.True(t, time.Now().Sub(now) < time.Millisecond)
 	})
 
 	t.Run("interval gap must be 100ms between consecutive calls", func(t *testing.T) {
-		waiter := newIntervalWaiter(time.Millisecond * 100)
+		waiter := newIntervalWaiter(duration)
 		waiter.wait(context.Background())
 
 		now := time.Now()
 		waiter.wait(context.Background())
 		duration := time.Now().Sub(now)
-		assert.True(t, duration > (time.Millisecond*100), "Unexpected time taken on wait: %v", duration)
-		assert.True(t, duration < (time.Millisecond*200), "Unexpected time taken on wait: %v", duration)
+		assert.True(t, duration > (duration), "Unexpected time taken on wait: %v", duration)
+		assert.True(t, duration < (duration), "Unexpected time taken on wait: %v", duration)
 
 		now = time.Now()
 		waiter.wait(context.Background())
 		duration = time.Now().Sub(now)
-		assert.True(t, duration > (time.Millisecond*100), "Unexpected time taken on wait: %v", duration)
-		assert.True(t, duration < (time.Millisecond*200), "Unexpected time taken on wait: %v", duration)
+		assert.True(t, duration > (duration), "Unexpected time taken on wait: %v", duration)
+		assert.True(t, duration < (duration), "Unexpected time taken on wait: %v", duration)
 	})
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -22,9 +22,11 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -125,5 +127,31 @@ func TestStreamRequestRecorder(t *testing.T) {
 		gotRequests, err := streamIO.allRequests()
 		require.NoError(t, err)
 		assert.Equal(t, requests, gotRequests)
+	})
+}
+
+func TestIntervalWaiter(t *testing.T) {
+	t.Run("initial call must not wait", func(t *testing.T) {
+		waiter := newIntervalWaiter(time.Millisecond * 100)
+		now := time.Now()
+		waiter.wait(context.Background())
+		assert.True(t, time.Now().Sub(now) < time.Millisecond)
+	})
+
+	t.Run("interval gap must be 100ms between consecutive calls", func(t *testing.T) {
+		waiter := newIntervalWaiter(time.Millisecond * 100)
+		waiter.wait(context.Background())
+
+		now := time.Now()
+		waiter.wait(context.Background())
+		duration := time.Now().Sub(now)
+		assert.True(t, duration > (time.Millisecond*100), "Unexpected time taken on wait: %v", duration)
+		assert.True(t, duration < (time.Millisecond*200), "Unexpected time taken on wait: %v", duration)
+
+		now = time.Now()
+		waiter.wait(context.Background())
+		duration = time.Now().Sub(now)
+		assert.True(t, duration > (time.Millisecond*100), "Unexpected time taken on wait: %v", duration)
+		assert.True(t, duration < (time.Millisecond*200), "Unexpected time taken on wait: %v", duration)
 	})
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -136,7 +136,7 @@ func TestIntervalWaiter(t *testing.T) {
 		now := time.Now()
 		waiter.wait(context.Background())
 		timeTaken := time.Now().Sub(now)
-		assert.True(t, timeTaken < time.Millisecond, "Unexpected time taken on wait: %v", timeTaken)
+		assert.LessOrEqual(t, int64(timeTaken), int64(time.Millisecond), "Unexpected time taken on wait: %v", timeTaken)
 	})
 
 	t.Run("interval gap must be 100ms between consecutive calls", func(t *testing.T) {
@@ -147,8 +147,8 @@ func TestIntervalWaiter(t *testing.T) {
 			now := time.Now()
 			waiter.wait(context.Background())
 			timeTaken := time.Now().Sub(now)
-			assert.True(t, timeTaken > (time.Millisecond*100), "Unexpected time taken on wait: %v", timeTaken)
-			assert.True(t, timeTaken < (time.Millisecond*200), "Unexpected time taken on wait: %v", timeTaken)
+			assert.GreaterOrEqual(t, int64(timeTaken), int64(time.Millisecond*100), "Unexpected time taken on wait: %v", timeTaken)
+			assert.LessOrEqual(t, int64(timeTaken), int64(time.Millisecond*200), "Unexpected time taken on wait: %v", timeTaken)
 		}
 	})
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -983,6 +983,74 @@ test: 1
 	}
 }
 
+func TestGRPCStreamWithStreamIntervalOption(t *testing.T) {
+	t.Run("client stream", func(t *testing.T) {
+		addr, server := setupGRPCServer(t, &simpleService{
+			returnOutput:  []simple.Foo{{Test: 4}},
+			expectedInput: []simple.Foo{{Test: 1}, {Test: 2}, {Test: -1}},
+		})
+		defer server.Stop()
+
+		opts := Options{
+			ROpts: RequestOptions{
+				FileDescriptorSet: []string{"testdata/protobuf/simple/simple.proto.bin"},
+				Procedure:         "Bar/ClientStream",
+				Timeout:           timeMillisFlag(time.Second * 5),
+				RequestJSON:       `{"test":1}{"test":2}{"test":-1}`,
+				StreamRequestOptions: StreamRequestOptions{
+					Interval: timeMillisFlag(time.Millisecond * 1000),
+				},
+			},
+			TOpts: TransportOptions{
+				ServiceName: "foo",
+				Peers:       []string{"grpc://" + addr.String()},
+			},
+		}
+
+		now := time.Now()
+		_, gotErr := runTestWithOpts(opts)
+		duration := time.Now().Sub(now)
+
+		assert.Empty(t, gotErr)
+		// test must run for more than 2 seconds as there are three requests and
+		// it must take 2 seconds totally between consecutive messages
+		assert.True(t, duration > (time.Second*2), "Unexpected time taken on wait: %v", duration)
+	})
+
+	t.Run("bidirectional stream", func(t *testing.T) {
+		addr, server := setupGRPCServer(t, &simpleService{
+			returnOutput:  []simple.Foo{{Test: 4}, {Test: 9}},
+			expectedInput: []simple.Foo{{Test: 1}, {Test: 2}, {Test: -1}},
+		})
+		defer server.Stop()
+
+		opts := Options{
+			ROpts: RequestOptions{
+				FileDescriptorSet: []string{"testdata/protobuf/simple/simple.proto.bin"},
+				Procedure:         "Bar/BidiStream",
+				Timeout:           timeMillisFlag(time.Second * 5),
+				RequestJSON:       `{"test":1}{"test":2}{"test":-1}`,
+				StreamRequestOptions: StreamRequestOptions{
+					Interval: timeMillisFlag(time.Millisecond * 1000),
+				},
+			},
+			TOpts: TransportOptions{
+				ServiceName: "foo",
+				Peers:       []string{"grpc://" + addr.String()},
+			},
+		}
+
+		now := time.Now()
+		_, gotErr := runTestWithOpts(opts)
+		duration := time.Now().Sub(now)
+
+		assert.Empty(t, gotErr)
+		// test must run for more than 2 seconds as there are three requests and
+		// it must take 2 seconds totally between consecutive messages
+		assert.True(t, duration > (time.Second*2), "Unexpected time taken on wait: %v", duration)
+	})
+}
+
 func TestGRPCReflectionSource(t *testing.T) {
 	addr, server := setupGRPCServer(t, &simpleService{})
 	defer server.GracefulStop()

--- a/options.go
+++ b/options.go
@@ -70,6 +70,13 @@ type RequestOptions struct {
 		JSON     bool        `long:"json" hidden:"true"`
 		Raw      bool        `long:"raw" hidden:"true"`
 	}
+
+	StreamRequestOptions StreamRequestOptions
+}
+
+// StreamRequestOptions are stream request related options
+type StreamRequestOptions struct {
+	Interval timeMillisFlag `long:"stream-interval" description:"Interval between consecutive stream request message sends."`
 }
 
 // TransportOptions are transport related options.

--- a/options.go
+++ b/options.go
@@ -76,7 +76,7 @@ type RequestOptions struct {
 
 // StreamRequestOptions are stream request related options
 type StreamRequestOptions struct {
-	Interval timeMillisFlag `long:"stream-interval" description:"Interval between consecutive stream request message sends."`
+	Interval timeMillisFlag `long:"stream-interval" description:"Interval between consecutive stream message sends, applicable separately to every stream request opened on a connection."`
 }
 
 // TransportOptions are transport related options.


### PR DESCRIPTION
Stream interval option ensures consecutive stream message sends always have a gap of at-least `stream-interval` specified time duration, basically stream requests are dispatched slowly. This is useful in stream benchmarking/testing where users want to observe stream behaviour under real world conditions where each message send would have some gap between them. This works with ad-hoc and benchmark streaming requests.

```
yab --timeout=1m --service "test-server" --method uber.yarpc.encoding.protobuf.Test/Stream -p grpc://localhost:55555 -r '{"value":"req-1"}{"value":"req-2"}' --stream-interval=500ms

{
  "value": "req-1"
}

// Wait for `stream-interval`=500ms

{
  "value": "req-1req-2"
}
```