### PR TITLE
Bugfix: gRPC bidirectional stream stuck on invalid input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 
 .PHONY: test
 test:
-	go test -cover -race ./...
+	go test -cover -timeout 30s -race ./...
 
 
 .PHONY: docs
@@ -28,6 +28,6 @@ docs:
 
 .PHONY: test_ci
 test_ci: install build
-	go test -race -coverprofile=cover_temp.out -coverpkg=./... ./...
+	go test -timeout 30s -race -coverprofile=cover_temp.out -coverpkg=./... ./...
 	grep -v "^github.com/yarpc/yab/testdata/*" cover_temp.out > cover.out
 	go tool cover -html=cover.out -o cover.html

--- a/handler.go
+++ b/handler.go
@@ -149,7 +149,7 @@ func makeStreamRequest(t transport.Transport, streamReq *transport.StreamRequest
 
 	switch serializer.MethodType() {
 	case encoding.BidirectionalStream:
-		return makeBidiStream(ctx, stream, streamIO)
+		return makeBidiStream(ctx, cancel, stream, streamIO)
 	case encoding.ClientStream:
 		return makeClientStream(ctx, stream, streamIO)
 	default:
@@ -220,12 +220,9 @@ func makeClientStream(ctx context.Context, stream *yarpctransport.ClientStream, 
 }
 
 // makeBidiStream starts bi-directional streaming rpc
-func makeBidiStream(ctx context.Context, stream *yarpctransport.ClientStream, streamIO StreamIO) error {
+func makeBidiStream(ctx context.Context, cancel context.CancelFunc, stream *yarpctransport.ClientStream, streamIO StreamIO) error {
 	var wg sync.WaitGroup
 	var sendErr error
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	wg.Add(1)
 	// Start go routine to concurrently send stream messages.

--- a/integration_test.go
+++ b/integration_test.go
@@ -970,8 +970,10 @@ test: 1
 				ROpts: RequestOptions{
 					FileDescriptorSet: []string{"testdata/protobuf/simple/simple.proto.bin"},
 					Procedure:         "Bar/BidiStream",
-					Timeout:           timeMillisFlag(time.Minute),
-					RequestJSON:       `{"test_err": 1}`,
+					// Ensure request timeout is longer than go test timeout (30s)
+					// See MakeFile(test_ci,test) for go test timeout.
+					Timeout:     timeMillisFlag(time.Second * 31),
+					RequestJSON: `{"test_err": 1}`,
 				},
 				TOpts: TransportOptions{
 					ServiceName: "foo",

--- a/integration_test.go
+++ b/integration_test.go
@@ -964,6 +964,22 @@ test: 1
 			},
 			wantErr: "Failed while reading stream input: could not parse given request body as message of type \"Foo\": Message type Foo has no known field named test_err\n",
 		},
+		{
+			desc: "bidirectional streaming with input and long timeout",
+			opts: Options{
+				ROpts: RequestOptions{
+					FileDescriptorSet: []string{"testdata/protobuf/simple/simple.proto.bin"},
+					Procedure:         "Bar/BidiStream",
+					Timeout:           timeMillisFlag(time.Minute),
+					RequestJSON:       `{"test_err": 1}`,
+				},
+				TOpts: TransportOptions{
+					ServiceName: "foo",
+				},
+			},
+			expectedInput: []simple.Foo{{Test: 1}},
+			wantErr:       "Failed while reading stream input: could not parse given request body as message of type \"Foo\": Message type Foo has no known field named test_err\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
Bidirectional stream handler has two go-routines, one for sending requests and another one for receiving the response from the server. In case any error occurs in the `send` go-routine, the context is canceled to stop the receiving routine as both send & receive routines share the same context. But turns out context is not respected by [yarpc-go/SendMessage](https://github.com/yarpc/yarpc-go/blob/b7ba06c0dfa8658b705622e338b0ad35d14bfb78/transport/grpc/stream.go#L130) and [yarpc-go/ReceiveMessage](https://github.com/yarpc/yarpc-go/blob/b7ba06c0dfa8658b705622e338b0ad35d14bfb78/transport/grpc/stream.go#L147-L154) methods from YARPC (gRPC stream methods also do not respect context in sendMsg and recvMsg API). Instead the send and receive gRPC calls can be unblocked by canceling the context originally passed while initiating stream requests.

Fix: when an unexpected error occurs in send or receive handling, cancel the original context used during stream initiation. This closes the underlying http/2 stream, causing send and receive routines blocked on stream message APIs to unblock.