### PR TITLE
Accept multiple requests from yaml templates

### DIFF
--- a/template.go
+++ b/template.go
@@ -47,11 +47,12 @@ type template struct {
 	RoutingKey      string `yaml:"routingKey" yaml-aliases:"routingkey,routing-key,rk"`
 	RoutingDelegate string `yaml:"routingDelegate" yaml-aliases:"routingdelegate,routing-delegate,rd"`
 
-	Headers map[string]string           `yaml:"headers"`
-	Baggage map[string]string           `yaml:"baggage"`
-	Jaeger  bool                        `yaml:"jaeger"`
-	Request map[interface{}]interface{} `yaml:"request"`
-	Timeout time.Duration               `yaml:"timeout"`
+	Headers  map[string]string             `yaml:"headers"`
+	Baggage  map[string]string             `yaml:"baggage"`
+	Jaeger   bool                          `yaml:"jaeger"`
+	Request  map[interface{}]interface{}   `yaml:"request"`
+	Requests []map[interface{}]interface{} `yaml:"requests"`
+	Timeout  time.Duration                 `yaml:"timeout"`
 }
 
 func readYAMLFile(yamlTemplate string, templateArgs map[string]string, opts *Options) error {
@@ -79,19 +80,42 @@ func readYAMLFile(yamlTemplate string, templateArgs map[string]string, opts *Opt
 	return readYAMLRequest(base, contents, templateArgs, opts)
 }
 
+func getYAMLRequestBody(t template, templateArgs map[string]string) ([]byte, error) {
+	if t.Request != nil {
+		req, err := templateargs.ProcessMap(t.Request, templateArgs)
+		if err != nil {
+			return nil, err
+		}
+
+		return yaml.Marshal(req)
+	}
+
+	var body string
+	for _, req := range t.Requests {
+		processedReq, err := templateargs.ProcessMap(req, templateArgs)
+		if err != nil {
+			return nil, err
+		}
+
+		bytes, err := yaml.Marshal(processedReq)
+		if err != nil {
+			return nil, err
+		}
+
+		// append yaml object delimiter and request body
+		body += "---\n" + string(bytes)
+	}
+
+	return []byte(body), nil
+}
+
 func readYAMLRequest(base string, contents []byte, templateArgs map[string]string, opts *Options) error {
 	var t template
 	if err := yamlalias.UnmarshalStrict(contents, &t); err != nil {
 		return err
 	}
 
-	var err error
-	t.Request, err = templateargs.ProcessMap(t.Request, templateArgs)
-	if err != nil {
-		return err
-	}
-
-	body, err := yaml.Marshal(t.Request)
+	body, err := getYAMLRequestBody(t, templateArgs)
 	if err != nil {
 		return err
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -82,10 +82,22 @@ func TestTemplate(t *testing.T) {
 }
 
 func TestTemplateRequestsField(t *testing.T) {
-	opts := newOptions()
-	mustReadYAMLFile(t, "testdata/templates/stream.yab", opts)
+	t.Run("only requests field set", func(t *testing.T) {
+		opts := newOptions()
+		mustReadYAMLFile(t, "testdata/templates/stream.yab", opts)
+		want := `---
+test: 1
+---
+test: 2
+`
+		assert.Equal(t, want, opts.ROpts.RequestJSON)
+	})
 
-	assert.Equal(t, "---\ntest: 1\n---\ntest: 2\n", opts.ROpts.RequestJSON)
+	t.Run("error when request and requests fields are set", func(t *testing.T) {
+		opts := newOptions()
+		err := readYAMLFile("testdata/templates/invalid-fields.yab", map[string]string{}, opts)
+		assert.EqualError(t, err, errIncorrectRequestFields.Error())
+	})
 }
 
 func TestTemplateArgs(t *testing.T) {

--- a/template_test.go
+++ b/template_test.go
@@ -81,6 +81,13 @@ func TestTemplate(t *testing.T) {
 	assert.True(t, opts.ROpts.ThriftDisableEnvelopes)
 }
 
+func TestTemplateRequestsField(t *testing.T) {
+	opts := newOptions()
+	mustReadYAMLFile(t, "testdata/templates/stream.yab", opts)
+
+	assert.Equal(t, "---\ntest: 1\n---\ntest: 2\n", opts.ROpts.RequestJSON)
+}
+
 func TestTemplateArgs(t *testing.T) {
 	opts := newOptions()
 	args := map[string]string{"user": "bar", "uuids": "[1,2,3,4,5]"}

--- a/testdata/templates/invalid-fields.yab
+++ b/testdata/templates/invalid-fields.yab
@@ -1,0 +1,9 @@
+service: foo
+procedure: Bar/BidiStream
+caller: bar
+timeout: 4.5s
+request:
+    description: request and requests fields must not be set together
+requests:
+    - test: 1
+    - test: 2

--- a/testdata/templates/stream.yab
+++ b/testdata/templates/stream.yab
@@ -1,0 +1,7 @@
+service: foo
+procedure: Bar/BidiStream
+caller: bar
+timeout: 4.5s
+requests:
+    - test: 1
+    - test: 2


### PR DESCRIPTION
Yaml template can be used to send gRPC stream requests now, `requests` field accepts multiple requests.

Example template: 
```
service: foo
procedure: Bar/BidiStream
caller: bar
timeout: 4.5s
requests:
    - test: 1
    - test: 2
```

Template command:
```
yab -y test/stream.yab -p grpc://localhost:55555
{
  "value": "1"
}

{
  "value": "12"
}
```
