### PR TITLE
[yab] handle byte correctly based on thrift spec

### DIFF
--- a/thrift/types.go
+++ b/thrift/types.go
@@ -118,8 +118,11 @@ func parseBinaryList(vl []interface{}) ([]byte, error) {
 		case int:
 			// YAML uses int for all small values. For large values, it may use int64 or uint64
 			// but those are not valid bool values anyway, so we don't need to check them.
-			if v < 0 || v >= (1<<8) {
-				return nil, fmt.Errorf("failed to parse list of bytes: %v is not a byte", v)
+			// from https://thrift.apache.org/docs/types:
+			// byte: An 8-bit signed integer
+			// 8-bit signed ranges from -128 to 127
+			if boundary := 1 << 7; v < -boundary || v >= boundary {
+				return nil, fmt.Errorf("failed to parse list of bytes: %v is not a valid thrift byte(8-bit signed integer) between -128 and 127 inclusive", v)
 			}
 			bs = append(bs, byte(v))
 		case string:

--- a/thrift/types.go
+++ b/thrift/types.go
@@ -120,8 +120,8 @@ func parseBinaryList(vl []interface{}) ([]byte, error) {
 		// but those are not valid bool values anyway, so we don't need to check them.
 		case int:
 			// from https://thrift.apache.org/docs/types, byte is an 8-bit signed integer
-			// For Go, thriftrw uses a Go byte, which is an uint8 so it is possible to have 0 to 255 over the wire.
-			// Apache Java clients respect the signed int8 and send [-128,127].
+			// In Go, byte is an unsigned int8 (uint8) which has a range [0, 255].
+			// In Java, byte is a signed int8 which has a range of [-128,127].
 			// To make both sides happy, check between [-128,255]
 			if v < math.MinInt8 || v > math.MaxUint8 {
 				return nil, fmt.Errorf("failed to parse list of bytes: %v is not a valid thrift byte", v)

--- a/thrift/types.go
+++ b/thrift/types.go
@@ -119,9 +119,9 @@ func parseBinaryList(vl []interface{}) ([]byte, error) {
 		// but those are not valid bool values anyway, so we don't need to check them.
 		case int:
 			// from https://thrift.apache.org/docs/types, byte is an 8-bit signed integer
-			// For Go, thriftrw uses a Go byte, which is an uint8 so it is possible to have 0 to 225 over the wire.
-			// Apache Java clients respects the signed int8 and send -128 to 127.
-			// To make both sides happy, check between -128 and 225
+			// For Go, thriftrw uses a Go byte, which is an uint8 so it is possible to have 0 to 255 over the wire.
+			// Apache Java clients respect the signed int8 and send -128 to 127.
+			// To make both sides happy, check between -128 and 255
 			if v < -(1<<7) || v >= (1<<8) {
 				return nil, fmt.Errorf("failed to parse list of bytes: %v is not a valid thrift byte", v)
 			}

--- a/thrift/types.go
+++ b/thrift/types.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -120,9 +121,9 @@ func parseBinaryList(vl []interface{}) ([]byte, error) {
 		case int:
 			// from https://thrift.apache.org/docs/types, byte is an 8-bit signed integer
 			// For Go, thriftrw uses a Go byte, which is an uint8 so it is possible to have 0 to 255 over the wire.
-			// Apache Java clients respect the signed int8 and send -128 to 127.
-			// To make both sides happy, check between -128 and 255
-			if v < -(1<<7) || v >= (1<<8) {
+			// Apache Java clients respect the signed int8 and send [-128,127].
+			// To make both sides happy, check between [-128,255]
+			if v < math.MinInt8 || v > math.MaxUint8 {
 				return nil, fmt.Errorf("failed to parse list of bytes: %v is not a valid thrift byte", v)
 			}
 			bs = append(bs, byte(v))

--- a/thrift/types_test.go
+++ b/thrift/types_test.go
@@ -289,7 +289,7 @@ func TestParseBinary(t *testing.T) {
 			want:  []byte(`{"k1": "v1", "k2": 5}` + "\n"),
 		},
 		{
-			value:  []interface{}{128},
+			value:  []interface{}{256},
 			errMsg: "failed to parse list of bytes",
 		},
 		{

--- a/thrift/types_test.go
+++ b/thrift/types_test.go
@@ -273,6 +273,18 @@ func TestParseBinary(t *testing.T) {
 			want:  []byte("AB"),
 		},
 		{
+			value: []interface{}{1, -1},
+			want:  []byte{0x1, 0xff},
+		},
+		{
+			value: []interface{}{-128, 127}, // boundary
+			want:  []byte{0x80, 0x7f},
+		},
+		{
+			value: []interface{}{-1, 255}, // overflow causes the same results
+			want:  []byte{0xff, 0xff},
+		},
+		{
 			value: []interface{}{104, "ello", "", " ", "world"},
 			want:  []byte("hello world"),
 		},

--- a/thrift/types_test.go
+++ b/thrift/types_test.go
@@ -277,8 +277,8 @@ func TestParseBinary(t *testing.T) {
 			want:  []byte{0x1, 0xff},
 		},
 		{
-			value: []interface{}{-128, 127}, // boundary
-			want:  []byte{0x80, 0x7f},
+			value: []interface{}{-128, 127, 255}, // boundary for diff int types
+			want:  []byte{0x80, 0x7f, 0xff},
 		},
 		{
 			value: []interface{}{-1, 255}, // overflow causes the same results

--- a/thrift/types_test.go
+++ b/thrift/types_test.go
@@ -289,7 +289,11 @@ func TestParseBinary(t *testing.T) {
 			want:  []byte(`{"k1": "v1", "k2": 5}` + "\n"),
 		},
 		{
-			value:  []interface{}{256},
+			value:  []interface{}{128},
+			errMsg: "failed to parse list of bytes",
+		},
+		{
+			value:  []interface{}{-129},
 			errMsg: "failed to parse list of bytes",
 		},
 		{


### PR DESCRIPTION
Currently the check range for the byte is 0-256 and it is based on a Golang's byte. 
But [thrift spec](https://thrift.apache.org/docs/types) says it is a signed 8-bit integer between -128 and 127. 

Update the logic to reflect this.
```go
func main() {
	v := -8
	fmt.Printf("casted is %+v\n", byte(v))
}
// Output
casted is 248
```
Verified with a Java server that they will handle the overflown 248 correctly in Java (credits to @abhishekparwal)
```java
public class Main
{
	public static void main(String[] args) {
	    byte x = (byte)248;
		System.out.println(x);
	}
}
// Output
-8
```


  