### PR TITLE
Delay client send stream closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+# Unreleased
+* Add `delay-close-send-stream` option which delays client send stream closure.
+
 # 0.19.1 (2021-04-02)
 * Fix byte parsing to allow 8-bit signed integers to match the Thrift spec & other language implementations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Changelog
 =========
 
 # Unreleased
-* Add `delay-close-send-stream` option which delays client send stream closure.
+* Add `stream-delay-close-send` option which delays client send stream closure.
 
 # 0.19.1 (2021-04-02)
 * Fix byte parsing to allow 8-bit signed integers to match the Thrift spec & other language implementations.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Request Options:
       --stream-interval=         Interval between consecutive stream message sends,
                                  applicable separately to every stream request
                                  opened on a connection.
-      --delay-close-send-stream= Delay the closure of send stream once all the
+      --stream-delay-close-send= Delay the closure of send stream once all the
                                  request messages have been sent.
 
 Transport Options:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ Request Options:
       --multiplexed-thrift       Enables the Thrift TMultiplexedProtocol used
                                  by services that host multiple Thrift services
                                  on a single endpoint.
-      --stream-interval=         Interval between consecutive stream message sends, applicable separately to every stream request opened on a connection.
+      --stream-interval=         Interval between consecutive stream message sends,
+                                 applicable separately to every stream request
+                                 opened on a connection.
+      --delay-close-send-stream= Delay the closure of send stream once all the
+                                 request messages have been sent.
 
 Transport Options:
   -s, --service=                 The TChannel/Hyperbahn service name

--- a/integration_test.go
+++ b/integration_test.go
@@ -1019,7 +1019,7 @@ func TestGRPCStreamWithBoundedExecutionTime(t *testing.T) {
 					Timeout:           timeMillisFlag(time.Second * 5),
 					RequestJSON:       `{"test":1}{"test":2}{"test":-1}`,
 					StreamRequestOptions: StreamRequestOptions{
-						Interval: timeMillisFlag(time.Millisecond * 1000),
+						Interval: timeMillisFlag(time.Millisecond * 100),
 					},
 				},
 			},
@@ -1027,7 +1027,7 @@ func TestGRPCStreamWithBoundedExecutionTime(t *testing.T) {
 			expectedInput: []simple.Foo{{Test: 1}, {Test: 2}, {Test: -1}},
 			// Test must run for more than 2 seconds as there are three requests and
 			// it must take 2 seconds totally between consecutive messages.
-			wantExecTime: time.Second * 2,
+			wantExecTime: time.Millisecond * 200,
 		},
 		{
 			desc: "bidirectional streaming with stream interval option",
@@ -1038,15 +1038,15 @@ func TestGRPCStreamWithBoundedExecutionTime(t *testing.T) {
 					Timeout:           timeMillisFlag(time.Second * 5),
 					RequestJSON:       `{"test":1}{"test":2}{"test":-1}`,
 					StreamRequestOptions: StreamRequestOptions{
-						Interval: timeMillisFlag(time.Millisecond * 1000),
+						Interval: timeMillisFlag(time.Millisecond * 100),
 					},
 				},
 			},
 			returnOutput:  []simple.Foo{{Test: 4}, {Test: 9}},
 			expectedInput: []simple.Foo{{Test: 1}, {Test: 2}, {Test: -1}},
-			// Test must run for more than 2 seconds as there are three requests and
-			// it must take 2 seconds totally between consecutive messages.
-			wantExecTime: time.Second * 2,
+			// Test must run for more than 200ms as there are three requests and
+			// it must take 200ms totally between consecutive messages.
+			wantExecTime: time.Millisecond * 200,
 		},
 		{
 			desc: "client side streaming with close send stream delay",
@@ -1057,15 +1057,15 @@ func TestGRPCStreamWithBoundedExecutionTime(t *testing.T) {
 					Timeout:           timeMillisFlag(time.Second * 5),
 					RequestJSON:       `{"test":1}{"test":2}{"test":-1}`,
 					StreamRequestOptions: StreamRequestOptions{
-						DelayCloseSendStream: timeMillisFlag(time.Millisecond * 1000),
+						DelayCloseSendStream: timeMillisFlag(time.Millisecond * 100),
 					},
 				},
 			},
 			returnOutput:  []simple.Foo{{Test: 4}},
 			expectedInput: []simple.Foo{{Test: 1}, {Test: 2}, {Test: -1}},
-			// Test must run for more than 1 seconds as send stream closure has a delay
-			// of 1 second.
-			wantExecTime: time.Second * 1,
+			// Test must run for more than 100ms as send stream closure has a delay
+			// of 100ms.
+			wantExecTime: time.Millisecond * 100,
 		},
 		{
 			desc: "bidirectional streaming with close send stream delay",
@@ -1076,15 +1076,15 @@ func TestGRPCStreamWithBoundedExecutionTime(t *testing.T) {
 					Timeout:           timeMillisFlag(time.Second * 5),
 					RequestJSON:       `{"test":1}{"test":2}`,
 					StreamRequestOptions: StreamRequestOptions{
-						DelayCloseSendStream: timeMillisFlag(time.Millisecond * 1000),
+						DelayCloseSendStream: timeMillisFlag(time.Millisecond * 100),
 					},
 				},
 			},
 			returnOutput:  []simple.Foo{{Test: 4}, {Test: 9}},
 			expectedInput: []simple.Foo{{Test: 1}, {Test: 2}, {Test: -1}},
-			// Test must run for more than 1 seconds as send stream closure has a delay
-			// of 1 second.
-			wantExecTime: time.Second * 1,
+			// Test must run for more than 100ms as send stream closure has a delay
+			// of 100ms.
+			wantExecTime: time.Millisecond * 100,
 		},
 	}
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -1039,8 +1039,8 @@ func TestGRPCStreamWithBoundedExecutionTime(t *testing.T) {
 			},
 			returnOutput:  []simple.Foo{{Test: 4}},
 			expectedInput: []simple.Foo{{Test: 1}, {Test: 2}, {Test: -1}},
-			// Test must run for more than 2 seconds as there are three requests and
-			// it must take 2 seconds totally between consecutive messages.
+			// Test must run for more than 200ms as there are three requests and
+			// it must take 200ms totally between consecutive messages.
 			wantExecTime: time.Millisecond * 200,
 		},
 		{

--- a/options.go
+++ b/options.go
@@ -77,7 +77,7 @@ type RequestOptions struct {
 // StreamRequestOptions are stream request related options
 type StreamRequestOptions struct {
 	Interval             timeMillisFlag `long:"stream-interval" description:"Interval between consecutive stream message sends, applicable separately to every stream request opened on a connection."`
-	DelayCloseSendStream timeMillisFlag `long:"delay-close-send-stream" description:"Delay the closure of send stream once all the request messages have been sent."`
+	DelayCloseSendStream timeMillisFlag `long:"stream-delay-close-send" description:"Delay the closure of send stream once all the request messages have been sent."`
 }
 
 // TransportOptions are transport related options.

--- a/options.go
+++ b/options.go
@@ -76,7 +76,8 @@ type RequestOptions struct {
 
 // StreamRequestOptions are stream request related options
 type StreamRequestOptions struct {
-	Interval timeMillisFlag `long:"stream-interval" description:"Interval between consecutive stream message sends, applicable separately to every stream request opened on a connection."`
+	Interval             timeMillisFlag `long:"stream-interval" description:"Interval between consecutive stream message sends, applicable separately to every stream request opened on a connection."`
+	DelayCloseSendStream timeMillisFlag `long:"delay-close-send-stream" description:"Delay the closure of send stream once all the request messages have been sent."`
 }
 
 // TransportOptions are transport related options.


### PR DESCRIPTION
Adds option `delay-close-send-stream` which accepts time duration to delay the closure of the send stream in the client streaming, and bidirectional streaming methods. 

Currently, Yab closes the send stream once all the client requests have been dispatched which causes certain bidirectional streaming servers to stop the stream entirely. With this option, once all the client requests have been dispatched we can delay the closure of send stream. 

This is particularly useful for Adhoc requests where servers stop sending the messages once send stream is closed. 

For example, the client opens a bidirectional stream to watch the user activity of two users. But the server closes the stream if the client-side send stream is stopped.

Earlier:
```zsh
yab --timeout=1m  --service "test-service" --method uber.yarpc.encoding.protobuf.Test/Stream -p grpc://localhost:5555   -r '{"watch": "user-1"} {"watch": "user-2"}'

// server doesn't send any message as the client has ended the send stream after sending the above two messages.
```

Now:
```zsh
yab --timeout=1m  --service "test-service" --method uber.yarpc.encoding.protobuf.Test/Stream -p grpc://localhost:5555   -r '{"watch": "user-1"} {"watch": "user-2"}' --delay-close-send-stream=1m

{"user": "user-1", "activity": "LOGIN"}
.
.
.
// server continues to stream responses until send stream is open
```

