### PR TITLE
Fix protobuf reflection hung calls

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -55,6 +55,7 @@ import (
 	ytchan "go.uber.org/yarpc/transport/tchannel"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
+	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 )
 
 //go:generate thriftrw --plugin=yarpc --out ./testdata/yarpc ./testdata/integration.thrift
@@ -1132,4 +1133,47 @@ func TestGRPCReflectionSource(t *testing.T) {
 			assert.Contains(t, gotOut, tt.wantRes)
 		})
 	}
+}
+
+type protoReflectService struct {
+	sleepDuration time.Duration // If non-zero, handler sleeps for the given duration.
+}
+
+func (p protoReflectService) ServerReflectionInfo(s rpb.ServerReflection_ServerReflectionInfoServer) error {
+	if p.sleepDuration != 0 {
+		// Sleep until the given duration or until stream context completes.
+		select {
+		case <-s.Context().Done():
+		case <-time.After(p.sleepDuration):
+		}
+	}
+	return nil
+}
+
+func TestGPCReflectionTimeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	// Sleep duration must be longer than go test timeout (30s) to
+	// catch client which does not respect timeouts in reflection calls.
+	// See MakeFile(test_ci,test) for go test timeout.
+	reflectSvc := protoReflectService{sleepDuration: time.Second * 31}
+	s := grpc.NewServer()
+	rpb.RegisterServerReflectionServer(s, reflectSvc)
+	go s.Serve(ln)
+	defer s.Stop()
+
+	gotOut, gotErr := runTestWithOpts(Options{
+		ROpts: RequestOptions{
+			Procedure:   "Bar/Baz",
+			Timeout:     timeMillisFlag(time.Second * 1),
+			RequestJSON: `{"test":0}`,
+		},
+		TOpts: TransportOptions{
+			ServiceName: "foo",
+			Peers:       []string{ln.Addr().String()},
+		},
+	})
+	assert.Empty(t, gotOut, "Expected empty stdout")
+	assert.Contains(t, gotErr, "error in protobuf reflection: rpc error: code = DeadlineExceeded desc = context deadline exceeded", "Expected deadline exceeded error")
 }

--- a/protobuf/source_reflection.go
+++ b/protobuf/source_reflection.go
@@ -67,14 +67,14 @@ func NewDescriptorProviderReflection(args ReflectionArgs) (DescriptorProvider, e
 	ctx, cancel := context.WithTimeout(context.Background(), args.Timeout)
 	metadataContext := metadata.NewOutgoingContext(ctx, routingHeaders)
 	return &grpcreflectSource{
-		client:    grpcreflect.NewClient(metadataContext, pbClient),
-		ctxCancel: cancel,
+		client:     grpcreflect.NewClient(metadataContext, pbClient),
+		cancelFunc: cancel,
 	}, nil
 }
 
 type grpcreflectSource struct {
-	client    *grpcreflect.Client
-	ctxCancel context.CancelFunc
+	client     *grpcreflect.Client
+	cancelFunc context.CancelFunc
 }
 
 func (s *grpcreflectSource) FindMessage(messageType string) (*desc.MessageDescriptor, error) {
@@ -118,7 +118,7 @@ func (s *grpcreflectSource) FindService(fullyQualifiedName string) (*desc.Servic
 }
 
 func (s *grpcreflectSource) Close() {
-	s.ctxCancel()
+	s.cancelFunc()
 	s.client.Reset()
 }
 

--- a/protobuf/source_reflection.go
+++ b/protobuf/source_reflection.go
@@ -101,7 +101,7 @@ func (s *grpcreflectSource) FindService(fullyQualifiedName string) (*desc.Servic
 		}
 
 		available, availableErr := s.client.ListServices()
-		if availableErr != nil {
+		if availableErr != nil && !grpcreflect.IsElementNotFoundError(availableErr) {
 			return nil, wrapReflectionError(availableErr)
 		}
 


### PR DESCRIPTION
I have added a test to confirm the issue of the hung call in protobuf reflection methods. This change fixes it by adding a context deadline around the Protobuf reflection gRPC stream call. 

Fixes: #335 