### PR TITLE
New: print proto error details if any in the returned error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+# Unreleased
+* New: gRPC details are now printed along the error if there are any.
 # 0.19.1 (2021-04-02)
 * Fix byte parsing to allow 8-bit signed integers to match the Thrift spec & other language implementations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 # Unreleased
 * New: gRPC details are now printed along the error if there are any.
+
 # 0.19.1 (2021-04-02)
 * Fix byte parsing to allow 8-bit signed integers to match the Thrift spec & other language implementations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Changelog
 =========
 
 # Unreleased
-* New: gRPC details are now printed along the error if there are any.
+* New: gRPC details are now printed along with the error if there are any.
 
 # 0.19.1 (2021-04-02)
 * Fix byte parsing to allow 8-bit signed integers to match the Thrift spec & other language implementations.

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -69,6 +69,13 @@ type Serializer interface {
 	MethodType() MethodType
 }
 
+// ProtoErrorSerializer deserializes errors.
+// Error details are very specific to proto.
+type ProtoErrorSerializer interface {
+	// Error converts an error into something that can be displayed to a user.
+	ErrorDetails(err error) ([]interface{}, error)
+}
+
 // StreamRequestReader interface exposes method to read multiple request body
 type StreamRequestReader interface {
 	// NextBody returns the encoded request body if available, and if not, returns an

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -69,9 +69,9 @@ type Serializer interface {
 	MethodType() MethodType
 }
 
-// ProtoErrorSerializer deserializes errors.
+// ProtoErrorDeserializer deserializes errors.
 // Error details are very specific to proto.
-type ProtoErrorSerializer interface {
+type ProtoErrorDeserializer interface {
 	// Error converts an error into something that can be displayed to a user.
 	ErrorDetails(err error) ([]interface{}, error)
 }

--- a/encoding/protobuf.go
+++ b/encoding/protobuf.go
@@ -128,13 +128,15 @@ func (p protoSerializer) ErrorDetails(err error) ([]interface{}, error) {
 	for _, detail := range errStatus.Details {
 		rdetail, rerr := p.anyResolver.Resolve(detail.TypeUrl)
 		if rerr != nil {
-			// If we reach this point it means we are not able to resolve the type of the detai
+			// If we reach this point it means we are not able to resolve the type of the detail
 			// This can happen when an error is being bubbled up in a chaine of services.
 			// For instance, let's say we have A -> B -> C.
 			// If A does not have registered detail messages from C and B blindly bubbled up
 			// errors from C, YAB will not be able to resolve the type of the details based
 			// on the descriptors given by A (through the reflection server).
-			details = append(details, map[string]interface{}{detail.TypeUrl: detail.Value})
+			details = append(details, map[string]interface{}{
+				detail.TypeUrl: detail.Value,
+			})
 			continue
 		}
 
@@ -142,7 +144,9 @@ func (p protoSerializer) ErrorDetails(err error) ([]interface{}, error) {
 			return nil, fmt.Errorf("could not unmarshal error detail message %s", err.Error())
 		}
 
-		details = append(details, map[string]interface{}{detail.TypeUrl: rdetail})
+		details = append(details, map[string]interface{}{
+			detail.TypeUrl: rdetail,
+		})
 	}
 
 	return details, nil

--- a/encoding/protobuf.go
+++ b/encoding/protobuf.go
@@ -126,7 +126,6 @@ func (p protoSerializer) ErrorDetails(err error) ([]interface{}, error) {
 
 	details := []interface{}{}
 	for _, detail := range errStatus.Details {
-
 		// By default we set to the value of the proto detail message to its byte values.
 		// It is possible that YAB will not be able to resolve the type message.
 		// This can happen when an error is being bubbled up in a chain of services.

--- a/encoding/protobuf_test.go
+++ b/encoding/protobuf_test.go
@@ -275,7 +275,7 @@ func TestProtobufErrorDetails(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			serializer, err := NewProtobuf(tt.method, tt.source)
 			require.NoError(t, err, "Failed to create serializer")
-			errorSerializer, ok := serializer.(ProtoErrorSerializer)
+			errorSerializer, ok := serializer.(ProtoErrorDeserializer)
 			require.True(t, ok)
 
 			result, err := errorSerializer.ErrorDetails(tt.err)

--- a/encoding/protobuf_test.go
+++ b/encoding/protobuf_test.go
@@ -213,7 +213,7 @@ func TestProtobufErrorDetails(t *testing.T) {
 			method:        "Bar/Baz",
 			err:           nil,
 			wantErr:       nil,
-			wantOutAsJSON: `null`,
+			wantOutAsJSON: "null",
 		},
 		{
 			desc:          "std error",
@@ -221,7 +221,7 @@ func TestProtobufErrorDetails(t *testing.T) {
 			method:        "Bar/Baz",
 			err:           fmt.Errorf("this is a test error"),
 			wantErr:       nil,
-			wantOutAsJSON: `null`,
+			wantOutAsJSON: "null",
 		},
 		{
 			desc:          "yarpc error with no details",
@@ -229,7 +229,7 @@ func TestProtobufErrorDetails(t *testing.T) {
 			method:        "Bar/Baz",
 			err:           yarpcerrors.FromError(fmt.Errorf("this is a test error")),
 			wantErr:       nil,
-			wantOutAsJSON: `null`,
+			wantOutAsJSON: "null",
 		},
 		{
 			desc:          "yarpc error bad details bytes",
@@ -237,7 +237,7 @@ func TestProtobufErrorDetails(t *testing.T) {
 			method:        "Bar/Baz",
 			err:           yarpcerrors.FromError(fmt.Errorf("this is a test error")).WithDetails([]byte{0x8, 0x1, 0x12}),
 			wantErr:       fmt.Errorf("could not unmarshal error details unexpected EOF"),
-			wantOutAsJSON: `null`,
+			wantOutAsJSON: "null",
 		},
 		{
 			desc:   "yarpc error with  1 detail",
@@ -281,7 +281,7 @@ func TestProtobufErrorDetails(t *testing.T) {
 			result, err := errorSerializer.ErrorDetails(tt.err)
 
 			if tt.wantErr != nil {
-				require.Error(t, err, "%v", tt.desc)
+				require.Error(t, err, tt.desc)
 				assert.Contains(t, err.Error(), tt.wantErr.Error(), "%v: invalid error", tt.desc)
 			} else {
 				require.NoError(t, err, tt.desc)

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.uber.org/zap v1.10.0
 	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17
 	golang.org/x/text v0.3.1-0.20180511172408-5c1cf69b5978 // indirect
+	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 // indirect
 	google.golang.org/grpc v1.24.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/integration_test.go
+++ b/integration_test.go
@@ -55,8 +55,6 @@ import (
 	ytchan "go.uber.org/yarpc/transport/tchannel"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
-	//"go.uber.org/yarpc/encoding/protobuf"
-	//"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/main.go
+++ b/main.go
@@ -475,7 +475,7 @@ func makeInitialRequest(out output, transport transport.Transport, serializer en
 	if err != nil {
 		buffer := bytes.NewBufferString(err.Error())
 
-		if errorSerializer, ok := serializer.(encoding.ProtoErrorSerializer); ok {
+		if errorSerializer, ok := serializer.(encoding.ProtoErrorDeserializer); ok {
 			details, derr := errorSerializer.ErrorDetails(err)
 			if derr != nil {
 				out.Fatalf("Failed to get protobuf error details %s", derr.Error())

--- a/main.go
+++ b/main.go
@@ -473,8 +473,7 @@ func makeContextWithTrace(ctx context.Context, t transport.Transport, request *t
 func makeInitialRequest(out output, transport transport.Transport, serializer encoding.Serializer, req *transport.Request) {
 	response, err := makeRequestWithTracePriority(transport, req, 1)
 	if err != nil {
-		buffer := bytes.NewBuffer(nil)
-		buffer.WriteString(err.Error())
+		buffer := bytes.NewBufferString(err.Error())
 
 		if errorSerializer, ok := serializer.(encoding.ProtoErrorSerializer); ok {
 			details, derr := errorSerializer.ErrorDetails(err)
@@ -488,7 +487,7 @@ func makeInitialRequest(out output, transport transport.Transport, serializer en
 					out.Fatalf("Failed to convert protobuf error details to JSON: %v\nMap: %+v\n", merr, details)
 				}
 				buffer.WriteString("\n")
-				buffer.WriteString(string(bs))
+				buffer.Write(bs)
 				buffer.WriteString("\n")
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -474,7 +474,7 @@ func makeInitialRequest(out output, transport transport.Transport, serializer en
 	response, err := makeRequestWithTracePriority(transport, req, 1)
 	if err != nil {
 		buffer := bytes.NewBuffer(nil)
-		_, _ = buffer.WriteString(err.Error())
+		buffer.WriteString(err.Error())
 
 		if errorSerializer, ok := serializer.(encoding.ProtoErrorSerializer); ok {
 			details, derr := errorSerializer.ErrorDetails(err)
@@ -487,9 +487,9 @@ func makeInitialRequest(out output, transport transport.Transport, serializer en
 				if merr != nil {
 					out.Fatalf("Failed to convert protobuf error details to JSON: %v\nMap: %+v\n", merr, details)
 				}
-				_, _ = buffer.WriteString("\n")
-				_, _ = buffer.WriteString(string(bs))
-				_, _ = buffer.WriteString("\n")
+				buffer.WriteString("\n")
+				buffer.WriteString(string(bs))
+				buffer.WriteString("\n")
 			}
 		}
 


### PR DESCRIPTION
Error details are now printed along the protobuf error if there are any.

For example you will get the following:
```
Failed while making call: code:internal message:this is an expected error
{
  "details": [
    {
      "type.googleapis.com/uber.infra.net.rpc.probe.EchoErrorDetail": {
        "payload": {
          "pongInt32": 1
        }
      }
    }
  ]
}
```

If no error details are returned, the output will remain the same as before, for instance:
```
Failed while making call: code:internal message:this is an expected error
```