### PR TITLE
Print response headers on error responses too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Changelog
 =========
 
 # Unreleased (0.21.0)
-* Nothing yet
+* New: Print response headers on error responses too.
 
 # 0.20.0 (2021-05-18)
 * Add `stream-delay-close-send` option which delays client send stream closure.

--- a/integration_test.go
+++ b/integration_test.go
@@ -54,9 +54,9 @@ import (
 	yhttp "go.uber.org/yarpc/transport/http"
 	ytchan "go.uber.org/yarpc/transport/tchannel"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
 	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -1190,6 +1190,13 @@ func TestGRPCReflectionSource(t *testing.T) {
 					Peers:       []string{addr.String()},
 				},
 			},
+			wantRes: `{
+  "headers": {
+    "content-type": "application/grpc"
+  }
+}
+
+`,
 			wantErr: "Failed while making call: code:unknown message:negative input\n",
 		},
 		{
@@ -1205,6 +1212,13 @@ func TestGRPCReflectionSource(t *testing.T) {
 					Peers:       []string{addr.String()},
 				},
 			},
+			wantRes: `{
+  "headers": {
+    "content-type": "application/grpc"
+  }
+}
+
+`,
 			wantErr: `Failed while making call: code:invalid-argument message:invalid username
 {
   "details": [
@@ -1222,8 +1236,8 @@ func TestGRPCReflectionSource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			gotOut, gotErr := runTestWithOpts(tt.opts)
-			assert.Equal(t, gotErr, tt.wantErr)
-			assert.Equal(t, gotOut, tt.wantRes)
+			assert.Equal(t, tt.wantErr, gotErr, "bad error")
+			assert.Equal(t, tt.wantRes, gotOut, "bad response")
 		})
 	}
 }

--- a/transport/grpc.go
+++ b/transport/grpc.go
@@ -128,11 +128,16 @@ func (t *grpcTransport) Call(ctx context.Context, request *Request) (*Response, 
 
 	ctx, cancel := requestContextWithTimeout(ctx, request)
 	defer cancel()
+
+	var errs error
+
 	transportResponse, err := t.Outbound.Call(ctx, t.requestToYARPCRequest(request))
-	if err != nil {
-		return nil, err
-	}
-	return yarpcResponseToResponse(transportResponse)
+	errs = multierr.Append(errs, err)
+
+	r, err := yarpcResponseToResponse(transportResponse)
+	errs = multierr.Append(errs, err)
+
+	return r, errs
 }
 
 func (t *grpcTransport) CallStream(ctx context.Context, request *StreamRequest) (*transport.ClientStream, error) {


### PR DESCRIPTION
This would be super helpfull during debugging.

It is slightly unclear whether this should be printed on stdout or
stderr .. so I'm opting for the easiest option and printing it as is.