### PR TITLE
Fixed: Maintain protobuf reflection connection until end of request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Changelog
 =========
 
 # Unreleased (0.21.0)
-* Nothing yet
+* Fix parsing of protobuf responses/error-details containing Any type fields, by maintaining
+  reflection server connection until end of the request.
 
 # 0.20.0 (2021-05-18)
 * Add `stream-delay-close-send` option which delays client send stream closure.

--- a/encoding/protobuf.go
+++ b/encoding/protobuf.go
@@ -25,7 +25,7 @@ type protoSerializer struct {
 	serviceName string
 	methodName  string
 	method      *desc.MethodDescriptor
-	anyResolver jsonpb.AnyResolver
+	anyResolver anyResolver
 }
 
 // bytesMsg wraps a raw byte slice for serialization purposes. Especially
@@ -262,6 +262,12 @@ func (p protoStreamRequestReader) NextBody() ([]byte, error) {
 	}
 
 	return p.proto.encode(body)
+}
+
+// Close stops the protobuf reflection/file based descriptor provider.
+func (p protoSerializer) Close() error {
+	p.anyResolver.source.Close()
+	return nil
 }
 
 func splitMethod(fullMethod string) (svc, method string, err error) {

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	go.uber.org/zap v1.10.0
 	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17
 	golang.org/x/text v0.3.1-0.20180511172408-5c1cf69b5978 // indirect
-	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 // indirect
+	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
 	google.golang.org/grpc v1.24.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/integration_test.go
+++ b/integration_test.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/yarpc/yab/testdata/gen-go/integration"
+	testdataany "github.com/yarpc/yab/testdata/protobuf/any"
 	"github.com/yarpc/yab/testdata/protobuf/simple"
 	yintegration "github.com/yarpc/yab/testdata/yarpc/integration"
 	"github.com/yarpc/yab/testdata/yarpc/integration/fooserver"
@@ -54,9 +55,9 @@ import (
 	yhttp "go.uber.org/yarpc/transport/http"
 	ytchan "go.uber.org/yarpc/transport/tchannel"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
 	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -383,7 +384,7 @@ func (s *simpleService) Baz(c context.Context, in *simple.Foo) (*simple.Foo, err
 
 	if in.Test == -1 {
 		st := status.New(codes.InvalidArgument, "invalid username")
-		st, err := st.WithDetails(in)
+		st, err := st.WithDetails(in, &testdataany.FooAny{Value: 123})
 		if err != nil {
 			// If this errored, it will always error
 			// here, so better panic so we can figure
@@ -1211,6 +1212,11 @@ func TestGRPCReflectionSource(t *testing.T) {
     {
       "type.googleapis.com/Foo": {
         "test": -1
+      }
+    },
+    {
+      "type.googleapis.com/FooAny": {
+        "value": 123
       }
     }
   ]

--- a/main.go
+++ b/main.go
@@ -329,6 +329,9 @@ func runWithOptions(opts Options, out output, logger *zap.Logger) {
 	if err != nil {
 		out.Fatalf("Failed while parsing input: %v\n", err)
 	}
+	if serializerWithClose, ok := serializer.(io.Closer); ok {
+		defer serializerWithClose.Close()
+	}
 
 	tracer, closer := getTracer(opts, out)
 	if closer != nil {

--- a/request.go
+++ b/request.go
@@ -122,9 +122,6 @@ func NewSerializer(opts Options, resolved resolvedProtocolEncoding) (encoding.Se
 			return nil, err
 		}
 
-		// The descriptor is only used in the New function, so it's safe to defer Close.
-		defer descSource.Close()
-
 		return encoding.NewProtobuf(opts.ROpts.Procedure, descSource)
 	}
 


### PR DESCRIPTION
This change avoids early closure of protobuf reflection connection, allowing correct parsing of protobuf messages containing `Anytype` fields in the response or error details.

Before:
```
> yab test-service test_service.Test/Unary -r '{}'
Failed while parsing response: unknown message type "test_service.Test.FooAny"
```

After:
```
> yab test-service test_service.Test/Unary -r '{}'
{
  "body": {
    "any" : {
      "value": 123
    }
  }
}
```