### PR TITLE
Fixed: patch gRPC server handler to close send stream post request dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@ Changelog
 =========
 
 # Unreleased (0.21.0)
-* Fix gRPC server stream handling to be compatible with Java gRPC server by closing
-  the send stream post dispatching the client request.
+* Fix gRPC server stream handling to be compatible with Java gRPC server.
 
 # 0.20.0 (2021-05-18)
 * Add `stream-delay-close-send` option which delays client send stream closure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Changelog
 =========
 
 # Unreleased (0.21.0)
-* Nothing yet
+* Fix gRPC server stream handling to be compatible with Java gRPC server by closing
+  the send stream post dispatching the client request.
 
 # 0.20.0 (2021-05-18)
 * Add `stream-delay-close-send` option which delays client send stream closure.

--- a/handler.go
+++ b/handler.go
@@ -155,12 +155,12 @@ func makeStreamRequest(t transport.Transport, streamReq *transport.StreamRequest
 	case encoding.ClientStream:
 		return makeClientStream(ctx, stream, streamIO, opts)
 	default:
-		return makeServerStream(ctx, stream, streamIO, opts)
+		return makeServerStream(ctx, stream, streamIO)
 	}
 }
 
 // makeServerStream starts server-side streaming rpc
-func makeServerStream(ctx context.Context, stream *yarpctransport.ClientStream, streamIO StreamIO, opts StreamRequestOptions) error {
+func makeServerStream(ctx context.Context, stream *yarpctransport.ClientStream, streamIO StreamIO) error {
 	req, err := streamIO.NextRequest()
 	// Use nil body if no initial request input is empty, since request
 	// is mandatory in server streaming rpc.
@@ -180,7 +180,7 @@ func makeServerStream(ctx context.Context, stream *yarpctransport.ClientStream, 
 		return err
 	}
 
-	if err = closeSendStream(ctx, stream, opts.DelayCloseSendStream.Duration()); err != nil {
+	if err := closeSendStream(ctx, stream, 0); err != nil {
 		return err
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -155,12 +155,12 @@ func makeStreamRequest(t transport.Transport, streamReq *transport.StreamRequest
 	case encoding.ClientStream:
 		return makeClientStream(ctx, stream, streamIO, opts)
 	default:
-		return makeServerStream(ctx, stream, streamIO)
+		return makeServerStream(ctx, stream, streamIO, opts)
 	}
 }
 
 // makeServerStream starts server-side streaming rpc
-func makeServerStream(ctx context.Context, stream *yarpctransport.ClientStream, streamIO StreamIO) error {
+func makeServerStream(ctx context.Context, stream *yarpctransport.ClientStream, streamIO StreamIO, opts StreamRequestOptions) error {
 	req, err := streamIO.NextRequest()
 	// Use nil body if no initial request input is empty, since request
 	// is mandatory in server streaming rpc.
@@ -177,6 +177,10 @@ func makeServerStream(ctx context.Context, stream *yarpctransport.ClientStream, 
 	}
 
 	if err = sendStreamMessage(ctx, stream, req); err != nil {
+		return err
+	}
+
+	if err = closeSendStream(ctx, stream, opts.DelayCloseSendStream.Duration()); err != nil {
 		return err
 	}
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -54,9 +54,9 @@ import (
 	yhttp "go.uber.org/yarpc/transport/http"
 	ytchan "go.uber.org/yarpc/transport/tchannel"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
 	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 


### PR DESCRIPTION
This change is a compatibility fix with the Java gRPC server specifically for server-side streaming methods.

In server-side streaming requests, Java servers wait until the client sends the first request and closes the send stream before forwarding the request to the service handler. This behavior is different in Go gRPC servers, where it receives the request and immediately invokes the handler without waiting for the client's send stream to close.

With this change for a server-side streaming method, we dispatch the request and immediately close the send stream. (does not have any side-effect on the Go side).

Earlier:
```
> yab --peer grpc://localhost:8087 --timeout 10s --service stream-java-server -H  --procedure example.java.service/GetMulti -r '{"topic_name": "test"}'
Failed while receiving stream response: code:deadline-exceeded message:context deadline exceeded
```

After:
```
> yab --peer grpc://localhost:8087 --timeout 10s --service stream-java-server -H  --procedure example.java.service/GetMulti -r '{"topic_name": "test"}'

{
  "topic_name": "test_1"
}
{
  "topic_name": "test_2",
  "status": true
}
```

Go server stream with this change works as expected:
```
yab -F hellostream --procedure routeguide.RouteGuide/ListFeatures --service helloworld -p grpc://localhost:10000 -r '{"lo":{"latitude": 400000000, "longitude": -750000000},"hi":{"latitude": 410000000, "longitude": -749800000}}'
{
  "name": "100-122 Locktown Road, Frenchtown, NJ 08825, USA",
  "location": {
    "latitude": 405047245,
    "longitude": -749800722
  }
}

{
  "location": {
    "latitude": 405314270,
    "longitude": -749836354
  }
}
```