### PR TITLE
CI: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Use dependabot to upgrade dependencies for yab.

We don't want to use dependabot for our libraries because it forces
consumers of those libraries to always upgrade all transitive
dependencies, even if not yet necessary for us.

However, since yab is intended to be a binary, not a library,
it's okay to do this in yab.
