### PR TITLE
Output errors in JSON format

### DIFF
--- a/bench_state.go
+++ b/bench_state.go
@@ -25,7 +25,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/yarpc/yab/sorted"
 	"github.com/yarpc/yab/statsd"
 )
 
@@ -99,17 +98,20 @@ func (s *benchmarkState) getLatencies() map[float64]time.Duration {
 	return latencyValues
 }
 
-func (s *benchmarkState) printErrors(out output) {
+func (s *benchmarkState) getErrorSummary() *ErrorSummary {
 	if len(s.errors) == 0 {
-		return
+		return nil
 	}
-	out.Printf("Errors:\n")
-	for _, k := range sorted.MapKeys(s.errors) {
-		v := s.errors[k]
-		out.Printf("  %4d: %v\n", v, k)
+	sum := &ErrorSummary{
+		TotalErrors: s.totalErrors,
+		ErrorRate:   100 * float64(s.totalErrors) / float64(s.totalRequests),
+		ErrorsCount: map[string]int{},
 	}
-	out.Printf("Total errors: %v\n", s.totalErrors)
-	out.Printf("Error rate: %.4f%%\n", 100*float32(s.totalErrors)/float32(s.totalRequests))
+
+	for k, v := range s.errors {
+		sum.ErrorsCount[k] = v
+	}
+	return sum
 }
 
 func (s *benchmarkState) getQuantile(q float64) time.Duration {

--- a/bench_state_test.go
+++ b/bench_state_test.go
@@ -62,7 +62,7 @@ func TestBenchmarkStateErrors(t *testing.T) {
 	assert.Equal(t, state1.totalSuccess, 0, "Success count mismatch")
 	assert.Equal(t, state1.totalRequests, 7, "Request count mismatch")
 
-	state1.printErrors(out)
+	printErrors(out, state1.getErrorSummary())
 
 	expected := map[string]int{
 		"failed after Xms": 7,
@@ -81,7 +81,7 @@ func TestBenchmarkStateErrors(t *testing.T) {
 func TestBenchmarkStateNoError(t *testing.T) {
 	state := newBenchmarkState(statsd.Noop)
 	buf, _, out := getOutput(t)
-	state.printErrors(out)
+	printErrors(out, state.getErrorSummary())
 	assert.Equal(t, 0, buf.Len(), "Expected no output with no errors, got: %s", buf.String())
 }
 

--- a/benchmark.go
+++ b/benchmark.go
@@ -69,9 +69,9 @@ type Summary struct {
 
 // ErrorSummary stores the summary of the errors encountered
 type ErrorSummary struct {
-	TotalErrors int     `json:"totalErrors"`
-	ErrorRate   float64 `json:"errorRate"`
-	ErrorsCount map[string]int
+	TotalErrors int            `json:"totalErrors"`
+	ErrorRate   float64        `json:"errorRate"`
+	ErrorsCount map[string]int `json:"errorsCount"`
 }
 
 // StreamSummary stores summary of stream messages sent and received

--- a/benchmark.go
+++ b/benchmark.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/yarpc/yab/encoding"
 	"github.com/yarpc/yab/limiter"
+	"github.com/yarpc/yab/sorted"
 	"github.com/yarpc/yab/statsd"
 	"github.com/yarpc/yab/transport"
 
@@ -66,6 +67,13 @@ type Summary struct {
 	RPS                float64 `json:"rps"`
 }
 
+// ErrorSummary stores the summary of the errors encountered
+type ErrorSummary struct {
+	TotalErrors int     `json:"totalErrors"`
+	ErrorRate   float64 `json:"errorRate"`
+	ErrorsCount map[string]int
+}
+
 // StreamSummary stores summary of stream messages sent and received
 type StreamSummary struct {
 	TotalStreamMessagesSent     int `json:"totalStreamMessagesSent"`
@@ -77,6 +85,9 @@ type BenchmarkOutput struct {
 	Parameters Parameters        `json:"benchmarkParameters"`
 	Latencies  map[string]string `json:"latencies"`
 	Summary    Summary           `json:"summary"`
+
+	// ErrorSummary sums up the errors encountered (if any). Is nil if no errors have been encountered
+	ErrorSummary *ErrorSummary `json:"errorSummary,omitempty"`
 
 	// StreamSummary is available only for streaming benchmark. It is nil and
 	// omitted in unary benchmark.
@@ -245,9 +256,7 @@ func runBenchmark(out output, logger *zap.Logger, allOpts Options, resolved reso
 		zap.Time("startTime", start),
 	)
 
-	// Print out errors
-	// TODO: allow errors to be printed in JSON format for output consistency
-	overall.printErrors(out)
+	errors := overall.getErrorSummary()
 
 	latencyValues := overall.getLatencies()
 
@@ -272,13 +281,13 @@ func runBenchmark(out output, logger *zap.Logger, allOpts Options, resolved reso
 	}
 
 	if formatAsJSON {
-		outputJSON(out, parameters, latencyValues, summary, streamSummary)
+		outputJSON(out, parameters, latencyValues, summary, streamSummary, errors)
 	} else {
-		outputPlaintext(out, latencyValues, summary, streamSummary)
+		outputPlaintext(out, latencyValues, summary, streamSummary, errors)
 	}
 }
 
-func outputJSON(out output, parameters Parameters, latencyValues map[float64]time.Duration, summary Summary, streamSummary *StreamSummary) {
+func outputJSON(out output, parameters Parameters, latencyValues map[float64]time.Duration, summary Summary, streamSummary *StreamSummary, errorSummary *ErrorSummary) {
 	latencies := make(map[string]string, len(_quantiles))
 	for _, quantile := range _quantiles {
 		latencies[fmt.Sprintf("%.4f", quantile)] = latencyValues[quantile].String()
@@ -288,6 +297,7 @@ func outputJSON(out output, parameters Parameters, latencyValues map[float64]tim
 		Parameters:    parameters,
 		Latencies:     latencies,
 		Summary:       summary,
+		ErrorSummary:  errorSummary,
 		StreamSummary: streamSummary,
 	}
 
@@ -298,7 +308,10 @@ func outputJSON(out output, parameters Parameters, latencyValues map[float64]tim
 	out.Printf("%s\n", jsonOutput)
 }
 
-func outputPlaintext(out output, latencyValues map[float64]time.Duration, summary Summary, streamSummary *StreamSummary) {
+func outputPlaintext(out output, latencyValues map[float64]time.Duration, summary Summary, streamSummary *StreamSummary, errorSummary *ErrorSummary) {
+	// Print errors
+	printErrors(out, errorSummary)
+
 	// Print out latencies
 	printLatencies(out, latencyValues)
 
@@ -328,6 +341,19 @@ func printLatencies(out output, latencyValues map[float64]time.Duration) {
 	for _, quantile := range _quantiles {
 		out.Printf("  %.4f: %v\n", quantile, latencyValues[quantile])
 	}
+}
+
+func printErrors(out output, errorSum *ErrorSummary) {
+	if errorSum == nil {
+		return
+	}
+	out.Printf("Errors:\n")
+	for _, k := range sorted.MapKeys(errorSum.ErrorsCount) {
+		v := errorSum.ErrorsCount[k]
+		out.Printf("  %4d: %v\n", v, k)
+	}
+	out.Printf("Total errors: %v\n", errorSum.TotalErrors)
+	out.Printf("Error rate: %.4f%%\n", errorSum.ErrorRate)
 }
 
 // stopOnInterrupt sets up a signal that will trigger the run to stop.

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -380,9 +380,8 @@ func TestBenchmarkErrorsOutput(t *testing.T) {
 				b := []byte(bufStr)
 				err := json.Unmarshal(b, &benchmarkOutput)
 				require.NoError(t, err)
-				assert.Equal(t, benchmarkOutput.Parameters.MaxRPS, opts.BOpts.RPS)
-				assert.GreaterOrEqual(t, opts.BOpts.MaxRequests, benchmarkOutput.Summary.TotalRequests)
-				assert.Equal(t, len(_quantiles), len(benchmarkOutput.Latencies))
+				// EXPECT: All requests were errors
+				assert.GreaterOrEqual(t, opts.BOpts.MaxRequests, benchmarkOutput.ErrorSummary.TotalErrors)
 			}
 		})
 	}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -325,16 +325,17 @@ func TestBenchmarkErrorsOutput(t *testing.T) {
 		notWantOutput []string
 	}{
 		{
-			format:        "json",
-			wantJSON:      true,
-			wantOutput:    []string{"summary", "benchmarkParameters", "maxRPS", "latencies", "errorSummary"},
+			format:   "json",
+			wantJSON: true,
+			wantOutput: []string{"summary", "benchmarkParameters", "maxRPS", "latencies", "errorSummary",
+				"errorRate", "totalErrors", "errorsCount"},
 			notWantOutput: []string{"Errors:", "Benchmark parameters", "Max RPS", "Unrecognized format option"},
 		},
 		{
 			format:        "text",
 			wantJSON:      false,
 			wantOutput:    []string{"Benchmark parameters", "Max RPS", "Errors:"},
-			notWantOutput: []string{"summary", "maxRPS", "Unrecognized format option"},
+			notWantOutput: []string{"summary", "maxRPS", "Unrecognized format option", "errorRate", "totalErrors", "errorsCount"},
 		},
 	}
 


### PR DESCRIPTION
So far, the errors encountered during a YAB benchmark run would be printed as text and not json, when format is json. This PR fixes that.

I'm rearranging the error printing a bit to align it with the other info printed. Lastly, I've added a test that verifies the output when errors are encountered (something that was not tested before).
