### PR TITLE
Fix flaky unit test TestBenchmarkStateGetQuantileSuccess

### DIFF
--- a/bench_state.go
+++ b/bench_state.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"time"
 
@@ -139,7 +140,7 @@ func (s *benchmarkState) getQuantile(q float64) time.Duration {
 	rightBias := exactIdx - float64(leftIdx)
 	leftBias := 1 - rightBias
 
-	return time.Duration(float64(s.latencies[leftIdx])*leftBias + float64(s.latencies[rightIdx])*rightBias)
+	return time.Duration(math.Round(float64(s.latencies[leftIdx])*leftBias + float64(s.latencies[rightIdx])*rightBias))
 }
 
 type byDuration []time.Duration


### PR DESCRIPTION
This fixes a flaky test which is failing on dev. The issue came when wrapping a float64 number as time.Duration (which converts to int64) value, which rounded the number down.

Fix is to first round the float64 value and then return it as a time.Duration value.