### PR TITLE
Add --rpc-encoding flag to override RPC-Encoding header

### DIFF
--- a/options.go
+++ b/options.go
@@ -90,6 +90,7 @@ type TransportOptions struct {
 	RoutingKey          string            `long:"rk" description:"The routing key overrides the service name traffic group for proxies."`
 	RoutingDelegate     string            `long:"rd" description:"The routing delegate overrides the routing key traffic group for proxies."`
 	ShardKey            string            `long:"sk" description:"The shard key is a transport header that clues where to send a request within a clustered traffic group."`
+	RPCEncoding         string            `long:"rpc-encoding" description:"Override the RPC-Encoding header value for gRPC and HTTP transports. This does not affect the actual encoding, only the header value, and it's intended to be used for development."`
 	Jaeger              bool              `long:"jaeger" description:"Use the Jaeger tracing client to send Uber style traces and baggage headers"`
 	TransportHeaders    map[string]string `short:"T" long:"topt" description:"Transport options for TChannel, protocol headers for HTTP"`
 	HTTPMethod          string            `long:"http-method" description:"The HTTP method to use"`

--- a/transport.go
+++ b/transport.go
@@ -179,10 +179,6 @@ func getTransport(opts TransportOptions, resolved resolvedProtocolEncoding, trac
 		})
 	}
 
-	httpEncoding := resolved.enc.String()
-	if opts.RPCEncoding != "" {
-		httpEncoding = opts.RPCEncoding
-	}
 	hopts := transport.HTTPOptions{
 		Method:          opts.HTTPMethod,
 		SourceService:   opts.CallerName,
@@ -190,7 +186,7 @@ func getTransport(opts TransportOptions, resolved resolvedProtocolEncoding, trac
 		RoutingDelegate: opts.RoutingDelegate,
 		RoutingKey:      opts.RoutingKey,
 		ShardKey:        opts.ShardKey,
-		Encoding:        httpEncoding,
+		Encoding:        resolved.enc.String(),
 		URLs:            opts.Peers,
 		Tracer:          tracer,
 		UseHTTP2:        opts.UseHTTP2,

--- a/transport.go
+++ b/transport.go
@@ -164,17 +164,25 @@ func getTransport(opts TransportOptions, resolved resolvedProtocolEncoding, trac
 	}
 
 	if resolved.protocol == transport.GRPC {
+		grpcEncoding := resolved.enc.String()
+		if opts.RPCEncoding != "" {
+			grpcEncoding = opts.RPCEncoding
+		}
 		return transport.NewGRPC(transport.GRPCOptions{
 			Addresses:       getHosts(opts.Peers),
 			Tracer:          tracer,
 			Caller:          opts.CallerName,
-			Encoding:        resolved.enc.String(),
+			Encoding:        grpcEncoding,
 			RoutingKey:      opts.RoutingKey,
 			RoutingDelegate: opts.RoutingDelegate,
 			MaxResponseSize: opts.GRPCMaxResponseSize,
 		})
 	}
 
+	httpEncoding := resolved.enc.String()
+	if opts.RPCEncoding != "" {
+		httpEncoding = opts.RPCEncoding
+	}
 	hopts := transport.HTTPOptions{
 		Method:          opts.HTTPMethod,
 		SourceService:   opts.CallerName,
@@ -182,7 +190,7 @@ func getTransport(opts TransportOptions, resolved resolvedProtocolEncoding, trac
 		RoutingDelegate: opts.RoutingDelegate,
 		RoutingKey:      opts.RoutingKey,
 		ShardKey:        opts.ShardKey,
-		Encoding:        resolved.enc.String(),
+		Encoding:        httpEncoding,
 		URLs:            opts.Peers,
 		Tracer:          tracer,
 		UseHTTP2:        opts.UseHTTP2,


### PR DESCRIPTION
## Summary
This PR adds a new `--rpc-encoding` flag that allows users to override the value of the `RPC-Encoding` header for gRPC and HTTP transports.

## Motivation
Developers need the ability to specify different values for the `rpc-encoding` header without affecting the actual serialization.

## Changes
- Added `--rpc-encoding` flag to `TransportOptions` in `options.go`
- Updated `transport.go` to use the custom value when specified, falling back to the default behavior otherwise

## Usage
```bash
yab --rpc-encoding=custom-value -p localhost:8080 -s myservice ...
```
