### PR TITLE
Bump actions/setup-go from v1 to v6

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v6
       with:
         go-version: 1.23.x
 
@@ -49,7 +49,7 @@ jobs:
     steps:
 
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v6
       with:
         go-version: 1.23.x
 


### PR DESCRIPTION
`actions/setup-go@v1` is pinned to a deprecated Node.js runtime, which now makes the "Setup Go" CI step fail outright before checkout, install, or test even run. See e.g. https://github.com/yarpc/yab/actions/runs/28618582924/job/84874999716 (failing on PR #439).

This bumps it to the current major release, `v6`, which is a drop-in replacement (same `go-version` input, no other config changes needed).